### PR TITLE
Add https support to readinessProbe

### DIFF
--- a/kibana/README.md
+++ b/kibana/README.md
@@ -42,6 +42,7 @@ This helm chart is a lightweight way to configure and run our official [Kibana d
 | `nodeSelector`            | Configurable [nodeSelector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) so that you can target specific nodes for your Kibana instances                                                                       | `{}`                                                                                                                      |
 | `tolerations`             | Configurable [tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                                                                                                                                                | `[]`                                                                                                                      |
 | `ingress`                 | Configurable [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) to expose the Kibana service. See [`values.yaml`](./values.yaml) for an example                                                                           | `enabled: false`                                                                                                          |
+| `kibanaSSLHostname`       | A hostname matched by the SSL certificate used in Kibana. Note: This only matters if you have enabled SSL in Kibana by setting `SERVER_SSL_ENABLED=true` in `extraEnvs`.  | `localhost`
 
 
 ## Examples

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -62,12 +62,19 @@ spec:
                 #!/usr/bin/env bash -e
                 http () {
                     local path="${1}"
+                    set -- -XGET -s --fail
+
                     if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
-                      BASIC_AUTH="-u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
-                    else
-                      BASIC_AUTH=''
+                      set -- "$@" -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
                     fi
-                    curl -XGET -s --fail ${BASIC_AUTH} 127.0.0.1:{{ .Values.httpPort }}${path}
+
+                    if [ "${SERVER_SSL_ENABLED}" = "true" ] ; then
+                      set -- "$@" --cacert "${SERVER_SSL_CERTIFICATE}" --resolve "{{ .Values.kibanaSSLHostname }}:{{ .Values.httpPort }}:127.0.0.1"
+                      URL="https://{{ .Values.kibanaSSLHostname }}:{{ .Values.httpPort }}${path}"
+                    else
+                      URL="http://localhost:{{ .Values.httpPort }}${path}"
+                    fi
+                    curl "$@" "${URL}"
                 }
   
                 http "/app/kibana"

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -53,6 +53,10 @@ service:
   type: ClusterIP
   port: 5601
 
+# Set this if you are setting server.ssl.enabled in Kibana.
+# This value is a hostname accepted by the SSL certificate provided to kibana.
+kibanaSSLHostname: localhost
+
 ingress:
   enabled: false
   annotations: {}

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -55,6 +55,7 @@ service:
 
 # Set this if you are setting server.ssl.enabled in Kibana.
 # This value is a hostname accepted by the SSL certificate provided to kibana.
+# Configuring this allows the readinessProbe to successfully check Kibana over HTTPS.
 kibanaSSLHostname: localhost
 
 ingress:


### PR DESCRIPTION
If server.ssl.enabled is set in Kibana (vi SERVER_SSL_ENABLED env var),
then the readinessProbe will use https to test for readiness.

Fixes #16