### PR TITLE
Switch to goss for integration testing of the Elasticsearch examples

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -173,7 +173,7 @@ This chart uses [pytest](https://docs.pytest.org/en/latest/) to test the templat
 
 ```
 pip install -r ../requirements.txt
-make test
+make pytest
 ```
 
 You can also use `helm template` to look at the YAML being generated
@@ -186,5 +186,15 @@ It is possible to run all of the tests and linting inside of a docker container
 
 ```
 make test
+```
+
+## Integration Testing
+
+Integration tests are run using [goss](https://github.com/aelsabbahy/goss/blob/master/docs/manual.md) which is a serverspec like tool written in golang. See [goss.yaml](examples/default/test/goss.yaml) for an example of what the tests look like.
+
+To run the goss tests against the default example:
+```
+cd examples/default
+make goss
 ```
 

--- a/elasticsearch/examples/5.x/Makefile
+++ b/elasticsearch/examples/5.x/Makefile
@@ -1,7 +1,9 @@
-
 default: test
 
+include ../../../helpers/examples.mk
+
 RELEASE := helm-es-fivex
+GOSS_CONTAINER := fivex-master-0
 
 install:
 	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
@@ -16,7 +18,4 @@ secrets:
 	kubectl delete secrets elastic-fivex-credentials || true
 	kubectl create secret generic elastic-fivex-credentials --from-literal=password=changeme --from-literal=username=elastic
 
-health:
-	kubectl exec -ti $$(kubectl get pods -l release=$(RELEASE) -o name | awk -F'/' '{ print $$NF }' | shuf -n 1) -- curl --fail -u elastic:changeme -k 'http://localhost:9200/'
-
-test: secrets install health
+test: secrets install goss

--- a/elasticsearch/examples/5.x/test/goss.yaml
+++ b/elasticsearch/examples/5.x/test/goss.yaml
@@ -2,8 +2,8 @@ http:
   http://localhost:9200/_cluster/health:
     status: 200
     timeout: 2000
-    username: 'elastic'
-    password: 'changeme'
+    username: '{{ .Env.ELASTIC_USERNAME }}'
+    password: '{{ .Env.ELASTIC_PASSWORD }}'
     body:
       - 'green'
       - '"number_of_nodes":3'
@@ -12,8 +12,8 @@ http:
   http://localhost:9200/:
     status: 200
     timeout: 2000
-    username: 'elastic'
-    password: 'changeme'
+    username: '{{ .Env.ELASTIC_USERNAME }}'
+    password: '{{ .Env.ELASTIC_PASSWORD }}'
     body:
       - '"number" : "5.6.14"'
       - '"cluster_name" : "fivex"'

--- a/elasticsearch/examples/5.x/test/goss.yaml
+++ b/elasticsearch/examples/5.x/test/goss.yaml
@@ -1,0 +1,21 @@
+http:
+  http://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    username: 'elastic'
+    password: 'changeme'
+    body:
+      - 'green'
+      - '"number_of_nodes":3'
+      - '"number_of_data_nodes":3'
+
+  http://localhost:9200/:
+    status: 200
+    timeout: 2000
+    username: 'elastic'
+    password: 'changeme'
+    body:
+      - '"number" : "5.6.14"'
+      - '"cluster_name" : "fivex"'
+      - '"name" : "fivex-master-0"'
+      - 'You Know, for Search'

--- a/elasticsearch/examples/5.x/values.yaml
+++ b/elasticsearch/examples/5.x/values.yaml
@@ -2,16 +2,16 @@
 
 clusterName: "fivex"
 masterService: "fivex-master"
-imageTag: "5.6.12"
+imageTag: "5.6.14"
 
 extraEnvs:
   - name: ELASTIC_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: elastic-credentials
+        name: elastic-fivex-credentials
         key: password
   - name: ELASTIC_USERNAME
     valueFrom:
       secretKeyRef:
-        name: elastic-credentials
+        name: elastic-fivex-credentials
         key: username

--- a/elasticsearch/examples/default/Makefile
+++ b/elasticsearch/examples/default/Makefile
@@ -11,7 +11,7 @@ install:
 restart:
 	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../ ; \
 
-test: install goss
+test: goss install
 
 purge:
 	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/default/Makefile
+++ b/elasticsearch/examples/default/Makefile
@@ -1,7 +1,9 @@
+include ../../../helpers/examples.mk
 
 default: test
 
 RELEASE := helm-es-default
+GOSS_CONTAINER := elasticsearch-master-0
 
 install:
 	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../ ; \
@@ -9,8 +11,7 @@ install:
 restart:
 	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../ ; \
 
-test: install
-	helm test $(RELEASE)
+test: install goss
 
 purge:
 	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/default/Makefile
+++ b/elasticsearch/examples/default/Makefile
@@ -1,6 +1,6 @@
-include ../../../helpers/examples.mk
-
 default: test
+
+include ../../../helpers/examples.mk
 
 RELEASE := helm-es-default
 GOSS_CONTAINER := elasticsearch-master-0
@@ -11,7 +11,7 @@ install:
 restart:
 	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../ ; \
 
-test: goss install
+test: install goss
 
 purge:
 	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/default/test/goss.yaml
+++ b/elasticsearch/examples/default/test/goss.yaml
@@ -1,0 +1,45 @@
+port:
+  tcp6:9200:
+    listening: true
+    ip:
+    - '::'
+
+kernel-param:
+  vm.max_map_count:
+    value: '262144'
+
+http:
+  http://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    body:
+      - 'green'
+      - '"number_of_nodes":3'
+      - '"number_of_data_nodes":3'
+
+  http://localhost:9200:
+    status: 200
+    timeout: 2000
+    body:
+      - '"number" : "6.5.4"'
+      - '"cluster_name" : "elasticsearch"'
+      - '"name" : "elasticsearch-master-0"'
+      - 'You Know, for Search'
+
+file:
+  /usr/share/elasticsearch/data:
+    exists: true
+    mode: "2775"
+    owner: root
+    group: elasticsearch
+    filetype: directory
+
+mount: 
+  /usr/share/elasticsearch/data:
+    exists: true
+
+user:
+  elasticsearch:
+    exists: true
+    uid: 1000
+    gid: 1000

--- a/elasticsearch/examples/multi/Makefile
+++ b/elasticsearch/examples/multi/Makefile
@@ -1,15 +1,16 @@
-
 default: test
 
+include ../../../helpers/examples.mk
+
 RELEASE := helm-es-multi
+
+GOSS_CONTAINER := multi-master-0
 
 install:
 	helm upgrade --wait --timeout=600 --install --values ./master.yml $(RELEASE)-master ../../
 	helm upgrade --wait --timeout=600 --install --values ./data.yml $(RELEASE)-data ../../
 
-test: install
-	helm test $(RELEASE)-master
-	helm test $(RELEASE)-data
+test: install goss
 
 purge:
 	helm del --purge $(RELEASE)-master

--- a/elasticsearch/examples/multi/test/goss.yaml
+++ b/elasticsearch/examples/multi/test/goss.yaml
@@ -1,0 +1,9 @@
+http:
+  http://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    body:
+      - 'green'
+      - '"cluster_name":"multi"'
+      - '"number_of_nodes":6'
+      - '"number_of_data_nodes":3'

--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -1,7 +1,10 @@
-
 default: test
 
+include ../../../helpers/examples.mk
+
 RELEASE := helm-es-security
+
+GOSS_CONTAINER := security-master-0
 
 install:
 	# This starts a command in the background to install the license once the cluster has formed
@@ -13,12 +16,8 @@ purge:
 
 license:
 	kubectl exec -ti $$(kubectl get pods -l release=$(RELEASE) -o name | awk -F'/' '{ print $$NF }' | shuf -n 1) -- curl --fail -k -XPUT 'https://localhost:9200/_xpack/license' -H "Content-Type: application/json" -d @/usr/share/elasticsearch/config/license/license.json
-
-health:
-	kubectl exec -ti $$(kubectl get pods -l release=$(RELEASE) -o name | awk -F'/' '{ print $$NF }' | shuf -n 1) -- curl --fail -u elastic:changeme -k 'https://localhost:9200/'
-	kubectl exec -ti $$(kubectl get pods -l release=$(RELEASE) -o name | awk -F'/' '{ print $$NF }' | shuf -n 1) -- curl --fail -u elastic:changeme -k 'https://localhost:9200/_xpack/license' | grep platinum
 	
-test: secrets install health
+test: secrets install goss
 
 secrets:
 	kubectl delete secrets elastic-credentials elastic-license elastic-certificates elastic-certificate-pem || true && \

--- a/elasticsearch/examples/security/test/goss.yaml
+++ b/elasticsearch/examples/security/test/goss.yaml
@@ -1,0 +1,33 @@
+http:
+  https://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    allow-insecure: true
+    username: 'elastic'
+    password: 'changeme'
+    body:
+      - 'green'
+      - '"number_of_nodes":3'
+      - '"number_of_data_nodes":3'
+
+  https://localhost:9200/:
+    status: 200
+    timeout: 2000
+    allow-insecure: true
+    username: 'elastic'
+    password: 'changeme'
+    body:
+      - '"number" : "6.5.4"'
+      - '"cluster_name" : "security"'
+      - '"name" : "security-master-0"'
+      - 'You Know, for Search'
+
+  https://localhost:9200/_xpack/license:
+    status: 200
+    timeout: 2000
+    allow-insecure: true
+    username: 'elastic'
+    password: 'changeme'
+    body:
+      - 'active'
+      - 'platinum'

--- a/elasticsearch/examples/security/test/goss.yaml
+++ b/elasticsearch/examples/security/test/goss.yaml
@@ -3,8 +3,8 @@ http:
     status: 200
     timeout: 2000
     allow-insecure: true
-    username: 'elastic'
-    password: 'changeme'
+    username: '{{ .Env.ELASTIC_USERNAME }}'
+    password: '{{ .Env.ELASTIC_PASSWORD }}'
     body:
       - 'green'
       - '"number_of_nodes":3'
@@ -14,8 +14,8 @@ http:
     status: 200
     timeout: 2000
     allow-insecure: true
-    username: 'elastic'
-    password: 'changeme'
+    username: '{{ .Env.ELASTIC_USERNAME }}'
+    password: '{{ .Env.ELASTIC_PASSWORD }}'
     body:
       - '"number" : "6.5.4"'
       - '"cluster_name" : "security"'
@@ -26,8 +26,8 @@ http:
     status: 200
     timeout: 2000
     allow-insecure: true
-    username: 'elastic'
-    password: 'changeme'
+    username: '{{ .Env.ELASTIC_USERNAME }}'
+    password: '{{ .Env.ELASTIC_PASSWORD }}'
     body:
       - 'active'
       - 'platinum'

--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -1,0 +1,6 @@
+GOSS_VERSION := v0.3.6
+
+goss:
+	kubectl cp test/*.yaml $(GOSS_CONTAINER):/tmp/goss.yaml
+	kubectl exec $(GOSS_CONTAINER) -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o /usr/local/bin/goss && chmod +rx /usr/local/bin/goss && goss validate --color --format documentation"
+

--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -2,5 +2,5 @@ GOSS_VERSION := v0.3.6
 
 goss:
 	kubectl cp test/*.yaml $(GOSS_CONTAINER):/tmp/goss.yaml
-	kubectl exec $(GOSS_CONTAINER) -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o /usr/local/bin/goss && chmod +rx /usr/local/bin/goss && goss validate --color --format documentation"
+	kubectl exec $(GOSS_CONTAINER) -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o goss && chmod +rx ./goss && ./goss validate --color --format documentation"
 


### PR DESCRIPTION
Closes #11 

Only thing I'm not sure about is whether or not to remove the current `helm test` pod. For the integration testing it doesn't add any value. But for cluster operators it does give them a very generic easy way to run `/_cluster/health`. Thoughts? 