### PR TITLE
Set fullname to start with the overridden name

### DIFF
--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -11,6 +11,6 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Release.Name .Values.nameOverride -}}
+{{- printf "%s-%s" $name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -151,3 +151,11 @@ updateStrategy:
     assert r['deployment'][name]['spec']['strategy']['type'] == 'RollingUpdate'
     assert r['deployment'][name]['spec']['strategy']['rollingUpdate']['maxUnavailable'] == 1
     assert r['deployment'][name]['spec']['strategy']['rollingUpdate']['maxSurge'] == 1
+
+def test_using_a_name_override():
+    config = '''
+nameOverride: overrider
+'''
+
+    r = helm_template(config)
+    assert 'overrider-kibana' in r['deployment']


### PR DESCRIPTION
Before this setting nameOverride would result in resource names like
"kibana-overrider" which meant that Kibana instances would not be sorted
nicely with their Elasticsearch cluster. This changes it around so that
the name will become "overrider-kibana"

Closes #10