### PR TITLE
Add Kibana 7 example and update Elasticsearch 7 to also use goss

### DIFF
--- a/elasticsearch/examples/7-alpha/Makefile
+++ b/elasticsearch/examples/7-alpha/Makefile
@@ -1,5 +1,7 @@
-
 default: test
+include ../../../helpers/examples.mk
+
+GOSS_CONTAINER := seven-master-0
 
 RELEASE := helm-es-seven
 
@@ -9,8 +11,7 @@ install:
 restart:
 	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
 
-test: install
-	helm test $(RELEASE)
+test: install goss
 
 purge:
 	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/7-alpha/test/goss.yaml
+++ b/elasticsearch/examples/7-alpha/test/goss.yaml
@@ -1,0 +1,17 @@
+http:
+  http://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    body:
+      - 'green'
+      - '"number_of_nodes":3'
+      - '"number_of_data_nodes":3'
+
+  http://localhost:9200:
+    status: 200
+    timeout: 2000
+    body:
+      - '"number" : "7.0.0-alpha2"'
+      - '"cluster_name" : "seven"'
+      - '"name" : "seven-master-0"'
+      - 'You Know, for Search'

--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -10,6 +10,7 @@ ES_SUITE:
 KIBANA_SUITE:
   - default
   - security
+  - 7-alpha
   - 5.x
 KUBERNETES_VERSION:
   - '1.10'

--- a/kibana/examples/7-alpha/Makefile
+++ b/kibana/examples/7-alpha/Makefile
@@ -1,0 +1,15 @@
+
+default: test
+
+RELEASE := helm-kibana-seven
+
+install:
+	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../ ; \
+	
+purge:
+	helm del --purge $(RELEASE)
+
+health:
+	kubectl exec -ti $$(kubectl get pods -l release=$(RELEASE) -o name | awk -F'/' '{ print $$NF }' | shuf -n 1) -- curl --fail -I 'http://localhost:5601/app/kibana'
+
+test: install health

--- a/kibana/examples/7-alpha/values.yml
+++ b/kibana/examples/7-alpha/values.yml
@@ -1,0 +1,4 @@
+---
+
+imageTag: 7.0.0-alpha2
+elasticsearchURL: "http://seven-master:9200"


### PR DESCRIPTION
I will switch all of the Kibana examples over to goss testing in a
single separate PR.