### PR TITLE
Example: Inherited settings, child charts, and configuration jobs.

### DIFF
--- a/elasticsearch/examples/inheritance/Chart.yaml
+++ b/elasticsearch/examples/inheritance/Chart.yaml
@@ -1,0 +1,10 @@
+description: Example elasticsearch cluster with inherited settings from a child chart.
+home: https://github.com/elastic/helm-charts
+maintainers:
+- email: helm-charts@elastic.co
+  name: Elastic
+name: inheritance
+version: 6.6.0-alpha1
+appVersion: 6.6.0
+sources:
+  - https://github.com/elastic/elasticsearch

--- a/elasticsearch/examples/inheritance/Makefile
+++ b/elasticsearch/examples/inheritance/Makefile
@@ -1,0 +1,134 @@
+# The name of the thing you are deploying. This setting affects the name of
+# the k8s resources.
+project := secure
+
+# The kubernetes namespace to use.
+namespace := default
+
+# The kubectl config to use.
+k8s := $(shell kubectl config current-context)
+
+# Where to write temporary files.
+workdir := $(shell mktemp -d)
+
+.PHONY: prepare
+prepare:
+	-rm ../secure-elasticsearch/charts/*.tgz
+	helm dep build ../secure-elasticsearch/
+	helm dep update
+
+# Initial deployment and ugprading
+.PHONY: deploy
+deploy:
+	@$(MAKE) confirm warning='This will create or updgrade an Elasticsearch cluster and deploy the helm release'
+	helm upgrade --namespace $(namespace) --install $(project) .
+
+# Pop reference: http://hyperboleandahalf.blogspot.com/2010/06/this-is-why-ill-never-be-adult.html
+# This task removes all non-secret kubernetes/helm resources for this chart.
+.PHONY: clean-all-the-things
+clean-all-the-things:
+	@$(MAKE) confirm warning='This will destroy the Elasticsearch cluster and delete the helm release.'
+	-helm delete --purge $(project)
+	@# Sometimes pvc and pdb resources stick around.
+	-kubectl delete pvc --namespace $(namespace) -l app=$(project)-data
+	-kubectl delete pvc --namespace $(namespace) -l app=$(project)-master
+	-kubectl delete pdb --namespace $(namespace) secure-{data,master}-pdb
+
+# Pop reference: Setec Astronomy - https://en.wikipedia.org/wiki/Sneakers_(1992_film)
+# Remove all the secrets.
+.PHONY: too-many-secrets
+too-many-secrets:
+	@$(MAKE) confirm warning='This will delete all secrets associated with this helm chart.'
+	-kubectl delete secret --namespace $(namespace) elastic-{credentials,certificates,certificate-pem} kibana-{certificate,encryption-key} nginx-certificate elastic-license
+
+# Generate all required secrets.
+.PHONY: secrets
+secrets:
+	@$(MAKE) confirm warning='This will generate secrets for the Elasticsearch cluster.'
+	@$(MAKE) create-secrets
+
+.PHONY: create-secrets
+create-secrets: secret.elasticsearch.credentials secret.elasticsearch.ssl 
+create-secrets: secret.kibana.encryptionKey secret.kibana.ssl
+create-secrets: secret.nginx.ssl
+	@echo "Don't forget to create the x-pack license secret:"
+	@echo "kubectl create secret --namespace $(namespace) generic elastic-license --from-literal=license='the-license-json-content'"
+
+.PHONY: secret.elasticsearch.credentials
+secret.elasticsearch.credentials: password := $(shell pwgen -s 15 1)
+secret.elasticsearch.credentials:
+	@kubectl create secret --namespace $(namespace) generic elastic-credentials --from-literal=username=elastic --from-literal=password="$(password)"
+
+	@echo =[ Cluster Credentials ]=
+	@echo   User: elastic
+	@echo   Password: $(password)
+	@echo ==========================
+
+.PHONY: secret.elasticsearch.ssl
+secret.elasticsearch.ssl: $(workdir)/elastic-certificates.p12 $(workdir)/elastic-certificate.pem
+	@kubectl create secret --namespace $(namespace) generic elastic-certificates --from-file="$(workdir)/elastic-certificates.p12"
+	@kubectl create secret --namespace $(namespace) generic elastic-certificate-pem --from-file="$(workdir)/elastic-certificate.pem"
+
+.PHONY: secret.kibana.ssl
+secret.kibana.ssl: $(workdir)/kibana/kibana.crt $(workdir)/kibana/kibana.key
+	@kubectl create secret --namespace $(namespace) generic kibana-certificate --from-file="$(workdir)/kibana/"
+
+$(workdir)/kibana:
+	@mkdir $@
+
+.INTERMEDIATE: $(workdir)/kibana/kibana.crt
+$(workdir)/kibana/kibana.crt: $(workdir)/kibana/kibana.key
+
+.INTERMEDIATE: $(workdir)/kibana/kibana.key
+$(workdir)/kibana/kibana.key: $(workdir)/kibana
+	# TODO(sissel): Build a better self-signed certificate which includes SANs
+	@openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout $@ -out $(dir $@)/kibana.crt -subj /CN=$(project)-kibana
+
+.PHONY: secret.nginx.ssl
+secret.nginx.ssl: $(workdir)/nginx/tls.crt $(workdir)/nginx/tls.key
+	@kubectl create secret --namespace $(namespace) generic nginx-certificate --from-file="$(workdir)/nginx/"
+
+$(workdir)/nginx:
+	@mkdir $@
+
+.INTERMEDIATE: $(workdir)/nginx/tls.crt
+$(workdir)/nginx/tls.crt: $(workdir)/nginx/tls.key
+
+.INTERMEDIATE: $(workdir)/nginx/tls.key
+$(workdir)/nginx/tls.key: san := "DNS:es.$(project).dev.inf.elasticnet.co,DNS:kibana.$(project).dev.inf.elasticnet.co"
+$(workdir)/nginx/tls.key: $(workdir)/nginx
+	@# Newer openssl verisons have a `-addext` for the `req` command, but it's pretty new (2018)
+	@# To enable older openssl versions, build our openssl config from the system default plus subjectAltName
+	@(cat "$$(openssl version -a |awk '/^OPENSSLDIR: / { print $$2 }' | tr -d '"')/openssl.cnf"; printf "[san]\nsubjectAltName=$(san)") | openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout $@ -out $(dir $@)/tls.crt -config - -extensions san
+
+.INTERMEDIATE: $(workdir)/elastic-certificate.pem
+$(workdir)/elastic-certificate.pem: $(workdir)/elastic-certificates.p12
+	@openssl pkcs12 -cacerts -nokeys -nodes -passin pass: -in $< | sed -ne '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > $@
+
+# Generate certificates for the cluster using Elasticsearch's elasticsearch-certutil.
+.INTERMEDIATE: $(workdir)/elastic-certificates.p12
+$(workdir)/elastic-certificates.p12: owner=$(shell id -u)
+$(workdir)/elastic-certificates.p12:
+	@echo "Generating Elastic Stack Certificates for TLS"
+	@# Running elasticsearch-certutil via docker is a simple way to achieve this.
+	@docker run -it -v $(@D):/certs:Z docker.elastic.co/elasticsearch/elasticsearch:6.5.3 elasticsearch-certutil cert \
+		--pass "" --out /certs/elastic-certificates.p12 -s --dns $(project)-data,$(project)-data-headless,$(project)-master,$(project)-master-headless,localhost,$(project)-data.default,$(project)-master.default
+	@docker run -it -v $(@D):/certs:Z docker.elastic.co/elasticsearch/elasticsearch:6.5.3 chown $(owner) /certs/$(@F)
+
+# Generate a 32-character secrets key for Kibana (xpack.security.encryptionKey)
+.PHONY: secret.kibana.encryptionKey
+secret.kibana.encryptionKey: key := $(shell dd if=/dev/urandom count=32 bs=1 2> /dev/null | base64 | cut -c 1-32)
+secret.kibana.encryptionKey: 
+	@kubectl create secret --namespace $(namespace) generic kibana-encryption-key "--from-literal=key=$(key)"
+
+.PHONY: confirm
+confirm:
+ifndef warning
+	$(error 'confirm' invoked without a $$warning message.)
+endif
+	@echo "!! !! !! !! !! !! !!"
+	@echo "$(warning). Are you sure?"
+	@echo "Current Kubernetes Cluster: $(k8s)"
+	@echo
+	@echo -n "Type the full cluster name to confirm> "
+	@read c; if [ "$(k8s)" != "$$c" ] ; then echo "Incorrect cluster name given. Cancelling..."; exit 1; fi

--- a/elasticsearch/examples/inheritance/requirements.lock
+++ b/elasticsearch/examples/inheritance/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: secure-elasticsearch
+  repository: file://../secure-elasticsearch/
+  version: 6.6.0-alpha1
+- name: secure-elasticsearch
+  repository: file://../secure-elasticsearch/
+  version: 6.6.0-alpha1
+digest: sha256:d5f1aab92b2b9bc5632c99cef5f3611399c5237a343d2f3ddf1f1e0fa0c6c232
+generated: 2019-02-07T21:53:59.040204192-08:00

--- a/elasticsearch/examples/inheritance/requirements.yaml
+++ b/elasticsearch/examples/inheritance/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - name: secure-elasticsearch
+    repository: file://../secure-elasticsearch/
+    version: 6.6.0-alpha1
+    alias: es-data
+  - name: secure-elasticsearch
+    repository: file://../secure-elasticsearch/
+    version: 6.6.0-alpha1
+    alias: es-master

--- a/elasticsearch/examples/inheritance/values.yaml
+++ b/elasticsearch/examples/inheritance/values.yaml
@@ -1,0 +1,25 @@
+# The data nodes
+es-data:
+  elasticsearch: # TODO(sissel): maybe there's a way to import-values to avoid this level?
+    nodeGroup: "data"
+
+    roles:
+      master: "false"
+      ingest: "true"
+      data: "true"
+
+    # Give data nodes 100GB of persistent storage
+    volumeClaimTemplate:
+      resources:
+        requests:
+          storage: 100Gi
+
+# The master nodes
+es-master:
+  elasticsearch:
+    nodeGroup: "master"
+
+    roles:
+      master: "true"
+      ingest: "false"
+      data: "false"

--- a/elasticsearch/examples/secure-elasticsearch/Chart.yaml
+++ b/elasticsearch/examples/secure-elasticsearch/Chart.yaml
@@ -1,0 +1,10 @@
+description: Elasticsearch with Security enabled.
+home: https://github.com/elastic/helm-charts
+maintainers:
+- email: helm-charts@elastic.co
+  name: Elastic
+name: secure-elasticsearch
+version: 6.6.0-alpha1
+appVersion: 6.6.0
+sources:
+  - https://github.com/elastic/elasticsearch

--- a/elasticsearch/examples/secure-elasticsearch/requirements.lock
+++ b/elasticsearch/examples/secure-elasticsearch/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: elasticsearch
+  repository: file://../../
+  version: 6.6.0-alpha1
+digest: sha256:bbc2cadba968089f7b6e613084eba77337bdf0e8379ef74c54ef39ab404fb6ed
+generated: 2019-02-07T21:59:13.922332946-08:00

--- a/elasticsearch/examples/secure-elasticsearch/requirements.yaml
+++ b/elasticsearch/examples/secure-elasticsearch/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: elasticsearch
+    repository: file://../../
+    version: 6.6.0-alpha1

--- a/elasticsearch/examples/secure-elasticsearch/templates/jobs.yaml
+++ b/elasticsearch/examples/secure-elasticsearch/templates/jobs.yaml
@@ -1,0 +1,130 @@
+{{- /* Try to only deploy maintenance/setup jobs when the role is master.
+     * This keeps us from trying to deploy the same job twice if we have
+     * separate master and data nodes defined */ -}}
+{{- if (eq .Values.elasticsearch.roles.master "true") }}
+---
+# This job deploys the Elastic license payload to the cluster once it has formed.
+# Job: {{ .Values.elasticsearch.roles.master }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-deploy-license
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: deploy-license 
+        image: centos:7
+        command: 
+        - sh
+        - -c
+        - |
+          # Apologies for parsing JSON with shell ;)
+          # This code finds the string after the `"uid":` name.
+          # { ... "uid": "the value we want" ... }
+          license_id() {
+            tr -d '\n' | grep -Eo '"uid"\s*:\s*"[^"]+"' | awk -F'"' '{print $4}'
+          }
+
+          uid="$(echo "$license" | license_id)"
+
+          # Load curl's args into "$@"
+          set -- --max-time 10 --fail -D- --cacert /certs/elastic-certificate.pem -u "$username:$password"
+          baseurl="https://{{ .Values.elasticsearch.masterService }}:9200"
+          while true; do
+            current="$(curl "$@" -XGET "$baseurl/_xpack/license" | license_id)"
+            if [ "$?" -ne 0 ] ; then
+              echo "Failure trying to query Elasticsearch's current license."
+              sleep 10
+              continue
+            fi
+            if [ "$current" != "$uid" ] ; then
+              echo "Activating Elastic License (uid = $uid)."
+              echo "$license" | \
+
+              curl "$@" -XPUT --data-binary @- -H "Content-Type: application/json" "$baseurl/_xpack/license"
+              if [ "$?" -ne 0 ]; then
+                echo "Installing license failed. Will retry."
+                sleep 10
+              else
+                echo
+                echo "👍 License install successful."
+                break
+              fi
+            else
+              echo
+              echo "👍 License already active on this cluster."
+              break
+            fi
+          done
+        env:
+        - name: 'username'
+          valueFrom: { secretKeyRef: { name: elastic-credentials, key: username } }
+        - name: 'password'
+          valueFrom: { secretKeyRef: { name: elastic-credentials, key: password } }
+        - name: 'license'
+          valueFrom: { secretKeyRef: { name: elastic-license, key: license } }
+        volumeMounts:
+        - name: elastic-certificate-pem
+          mountPath: /certs
+      volumes:
+      - name: elastic-certificate-pem
+        secret:
+          secretName: elastic-certificate-pem
+---
+# This job pushes cluster and index settings
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cluster-settings
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: cluster-settings
+        image: centos:7
+        command:
+        - sh
+        - -c
+        - |
+
+          # Load curl's args into "$@"
+          set -- --max-time 10 --fail -D- --cacert /certs/elastic-certificate.pem -u "$username:$password"
+
+          set -- "$@" -XPUT -H "Content-Type: application/json"
+          baseurl="https://{{ .Values.elasticsearch.masterService }}:9200"
+
+          try() {
+            while ! "$@" ; do sleep 10; done
+          }
+
+          {{- if .Values.elasticsearch.settings.cluster }}
+          # Deploy cluster settings
+          settings='{ "persistent": {{ .Values.elasticsearch.settings.cluster | toJson }} }'
+          echo "Cluster settings: " "$settings"
+          try curl "$@" "$baseurl/_cluster/settings" --data-binary "$settings"
+          {{- end }}
+
+          {{- if .Values.elasticsearch.settings.index }}
+          # Deploy _all indices settings
+          settings='{ "settings": {{ .Values.elasticsearch.settings.index | toJson }} }'
+          echo "Index (_all) settings:" "$settings"
+          try curl "$@" "$baseurl/_all/_settings" --data-binary "$settings"
+          {{- end }}
+        env:
+        - name: 'username'
+          valueFrom: { secretKeyRef: { name: elastic-credentials, key: username } }
+        - name: 'password'
+          valueFrom: { secretKeyRef: { name: elastic-credentials, key: password } }
+        - name: 'license'
+          valueFrom: { secretKeyRef: { name: elastic-license, key: license } }
+        volumeMounts:
+        - name: elastic-certificate-pem
+          mountPath: /certs
+      volumes:
+      - name: elastic-certificate-pem
+        secret:
+          secretName: elastic-certificate-pem
+{{- end }}

--- a/elasticsearch/examples/secure-elasticsearch/values.yaml
+++ b/elasticsearch/examples/secure-elasticsearch/values.yaml
@@ -1,0 +1,27 @@
+elasticsearch:
+  clusterName: "secure"
+  masterService: "secure-master"
+
+  protocol: https
+
+  settings:
+    node:
+      xpack.security.enabled: true
+      xpack.security.transport.ssl.enabled: 'true'
+      xpack.security.transport.ssl.verification_mode: 'certificate'
+      xpack.security.transport.ssl.keystore.path: '/usr/share/elasticsearch/config/certs/elastic-certificates.p12'
+      xpack.security.transport.ssl.truststore.path: '/usr/share/elasticsearch/config/certs/elastic-certificates.p12'
+      xpack.security.http.ssl.enabled: 'true'
+      xpack.security.http.ssl.truststore.path: '/usr/share/elasticsearch/config/certs/elastic-certificates.p12'
+      xpack.security.http.ssl.keystore.path: '/usr/share/elasticsearch/config/certs/elastic-certificates.p12'
+
+  extraEnvs:
+    - name: ELASTIC_PASSWORD
+      valueFrom: { secretKeyRef: { name: elastic-credentials, key: password } }
+    - name: ELASTIC_USERNAME
+      valueFrom: { secretKeyRef: { name: elastic-credentials, key: username } }
+
+  secretMounts:
+    - name: elastic-certificates
+      secretName: elastic-certificates
+      path: /usr/share/elasticsearch/config/certs

--- a/elasticsearch/templates/configmap.yaml
+++ b/elasticsearch/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.esConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ template "uname" . }}"
 data:
+{{- if .Values.settings.node }}
+  elasticsearch.yml: |
+{{ toYaml .Values.settings.node | indent 4 }}
+{{- end }}
+{{- if .Values.esConfig }}
 {{- range $path, $config := .Values.esConfig }}
   {{ $path }}: |
 {{ $config | indent 4 -}}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{/* This forces a restart if the configmap has changed */}}
-        {{- if .Values.esConfig }}
+        {{- if (or .Values.esConfig .Values.settings.node) }}
         configchecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
     spec:
@@ -86,11 +86,9 @@ spec:
           secret:
             secretName: {{ .name }}
         {{- end }}
-        {{- if .Values.esConfig }}
         - name: esconfig
           configMap:
             name: {{ template "uname" . }}-config
-        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -188,6 +186,11 @@ spec:
             {{- if .subPath }}
             subPath: {{ .subPath }}
             {{- end }}
+          {{- end }}
+          {{- if .Values.settings.node }}
+          - name: esconfig
+            mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+            subPath: elasticsearch.yml
           {{- end }}
           {{- range $path, $config := .Values.esConfig }}
           - name: esconfig

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -18,6 +18,24 @@ minimumMasterNodes: 2
 
 esMajorVersion: 6
 
+# Settings for your nodes, clusters, and indices.
+settings:
+  # These settings become part of elasticsearch.yml on the node.
+  # It should be structured, not a text block.
+  node: {}
+    # Example, to enable Elasticsearch Security
+    #xpack.security.enabled: true
+
+  # These settings are published using the /_cluster/settings endpoint
+  # TODO(sissel): Not implemented yet.
+  cluster: {}
+
+  # These settings are published using the /_settings endpoint
+  # This can be useful to set cluster-wide index settings
+  # such as node_left delayed allocation
+  # TODO(sissel): Not implemented yet.
+  index: {}
+
 # Allows you to add any config files in /usr/share/elasticsearch/config/
 # such as elasticsearch.yml and log4j2.properties
 esConfig:


### PR DESCRIPTION
Example usage:

```
% cd elasticsearch/examples/inheritance
% make prepare # this works around a weird bug in helm#2887
...
% make secrets
...
% kubectl create secret generic elastic-license --from-literal=license="$(cat path/to/license.json")
...
% make deploy
...
```

:clock1: :clock10: :clock4: 

```
% kubectl get pods
NAME                            READY   STATUS      RESTARTS   AGE
secure-cluster-settings-4pwdj   0/1     Completed   0          14m
secure-data-0                   1/1     Running     0          14m
secure-data-1                   1/1     Running     0          14m
secure-data-2                   1/1     Running     0          13m
secure-deploy-license-sl9g6     0/1     Completed   0          14m
secure-master-0                 1/1     Running     0          14m
secure-master-1                 1/1     Running     0          14m
secure-master-2                 1/1     Running     0          14m
```

And for the big flourish:

```
% kubectl port-forward secure-master-0 9200
...

# curl w/ the generated credentials + ca cert
% curl -u elastic:$(kubectl get secret -o json elastic-credentials | jq -r '.data["password"]' | base64 --decode) --cacert <(kubectl get secret -o json elastic-certificate-pem | jq -r '.data["elastic-certificate.pem"]' | base64 -d) https://localhost:9200/
{
  "name" : "secure-master-0",
  "cluster_name" : "secure",
  "cluster_uuid" : "eHyk_-JlQNi_Voxs8hF73w",
  "version" : {
    "number" : "6.6.0",
    "build_flavor" : "default",
    "build_type" : "tar",
    "build_hash" : "a9861f4",
    "build_date" : "2019-01-24T11:27:09.439740Z",
    "build_snapshot" : false,
    "lucene_version" : "7.6.0",
    "minimum_wire_compatibility_version" : "5.6.0",
    "minimum_index_compatibility_version" : "5.0.0"
  },
  "tagline" : "You Know, for Search"
}
```