### PR TITLE
Set types of empty Elasticsearch values.yaml properties

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -20,7 +20,7 @@ esMajorVersion: 6
 
 # Allows you to add any config files in /usr/share/elasticsearch/config/
 # such as elasticsearch.yml and log4j2.properties
-esConfig:
+esConfig: {}
 #  elasticsearch.yml: |
 #    key:
 #      nestedkey: value
@@ -30,14 +30,14 @@ esConfig:
 # Extra environment variables to append to this nodeGroup
 # This will be appended to the current 'env:' key. You can use any of the kubernetes env
 # syntax here
-extraEnvs:
+extraEnvs: []
 #  - name: MY_ENVIRONMENT_VAR
 #    value: the_value_goes_here
 
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security and for mounting
 # the X-Pack license
-secretMounts:
+secretMounts: []
 #  - name: elastic-certificates
 #    secretName: elastic-certificates
 #    path: /usr/share/elasticsearch/config/certs


### PR DESCRIPTION
When adding files to the `esConfig` property helm lint would throw warnings saying that it was not a table. It turns out that Helm assumed that the property was an array, resulting in Helm throwing the warning.

```
2019/02/11 11:55:55 warning: skipped value for esConfig: Not a table.
```

While the Kubernetes definitions turned out fine, the warning caused our CI solution to think that the deployments were failing.

By setting the default value for `esConfig` to an empty map the linter stopped complaining. To stay consistent I have also added default empty values for other properties.