### PR TITLE
Remove kubernetes 1.10 from ci testing

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -13,5 +13,4 @@ KIBANA_SUITE:
   - 7-alpha
   - 5.x
 KUBERNETES_VERSION:
-  - '1.10'
   - '1.11'


### PR DESCRIPTION
Version `1.10.x` is no longer available as of February 18th 2019 [1].

This is causing failures in ci [2].

[1]:
https://cloud.google.com/kubernetes-engine/docs/release-notes#february-18-2019
[2]:
https://devops-ci.elastic.co/job/elastic+helm-charts+master+cluster-creation/KUBERNETES_VERSION=1.10,label=docker&&virtual/109/console