### PR TITLE
Add all currently supported GKE versions

### DIFF
--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -4,5 +4,5 @@ goss:
 	GOSS_CONTAINER=$$(kubectl get pods -l release=$(RELEASE) -o name | awk -F'/' 'NR==1{ print $$NF }') && \
 	echo Testing with pod: $$GOSS_CONTAINER && \
 	kubectl cp test/*.yaml $$GOSS_CONTAINER:/tmp/goss.yaml && \
-	kubectl exec $$GOSS_CONTAINER -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o goss && chmod +rx ./goss && ./goss validate --color --format documentation"
+	kubectl exec $$GOSS_CONTAINER -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o goss && chmod +rx ./goss && ./goss validate --retry-timeout 30s --sleep 5s --color --format documentation"
 

--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -13,4 +13,6 @@ KIBANA_SUITE:
   - 7.0.x
   - 5.x
 KUBERNETES_VERSION:
+  - '1.10'
   - '1.11'
+  - '1.12'

--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -59,7 +59,7 @@ k8s: apply creds
 
 up: k8s
 	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default || true
-	helm init --wait --upgrade
+	for i in 1 2 3 4 5; do helm init --wait --upgrade && break || sleep 5; done
 
 integration: creds
 	cd ../../$(CHART)/examples/$(SUITE) && \


### PR DESCRIPTION
Also added some reliability improvements to reduce test flakiness

* Retry goss validate every 5 seconds for up to 30 seconds. (was occasionally failing on Kibana tests)
* Retry helm init 5 times