### PR TITLE
[ci] add JJBB job definitions

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,49 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: devops-ci
+
+##### JOB DEFAULTS
+
+- job:
+    project-type: matrix
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 100
+    parameters:
+    - string:
+        name: branch_specifier
+        default: master
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    properties:
+    - github:
+        url: https://github.com/elastic/helm-charts/
+    - inject:
+        properties-content: HOME=$JENKINS_HOME
+    node: master
+    scm:
+    - git:
+        name: origin
+        credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        reference-repo: /var/lib/jenkins/.git-references/helm-charts.git
+        branches:
+        - ${branch_specifier}
+        url: git@github.com:elastic/helm-charts.git
+        basedir: ''
+        wipe-workspace: 'True'
+    vault:
+      url: https://secrets.elastic.co:8200
+      role_id: cff5d4e0-61bf-2497-645f-fcf019d10c13
+    wrappers:
+    - ansicolor
+    - timeout:
+        type: absolute
+        timeout: 360
+        fail: true
+    - timestamps
+    publishers:
+    - email:
+        recipients: infra-root+build@elastic.co

--- a/.ci/jobs/elastic+helm-charts+master+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+master+cluster-cleanup.yml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: elastic+helm-charts+master+cluster-cleanup
+    display-name: elastic / helm-charts - master - cluster cleanup
+    description: Master - cluster cleanup
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+master+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+master+cluster-creation.yml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: elastic+helm-charts+master+cluster-creation
+    display-name: elastic / helm-charts - master - cluster creation
+    description: Master - cluster creation
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+master+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+master+integration-elasticsearch.yml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: elastic+helm-charts+master+integration-elasticsearch
+    display-name: elastic / helm-charts - master - integration elasticsearch
+    description: Master - integration elasticsearch
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: ES_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs/elastic+helm-charts+master+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+master+integration-kibana.yml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: elastic+helm-charts+master+integration-kibana
+    display-name: elastic / helm-charts - master - integration kibana
+    description: Master - integration kibana
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KIBANA_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs/elastic+helm-charts+master+template-testing.yml
+++ b/.ci/jobs/elastic+helm-charts+master+template-testing.yml
@@ -1,0 +1,25 @@
+---
+- job:
+    name: elastic+helm-charts+master+template-testing
+    display-name: elastic / helm-charts - master - template testing
+    description: Master - template testing
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: CHART
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        cd ${CHART}
+        make test

--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: elastic+helm-charts+master
+    display-name: elastic / helm-charts - master
+    description: Master branch testing
+    project-type: multijob
+    scm:
+    - git:
+        wipe-workspace: 'False'
+    triggers:
+    - timed: H H(02-04) * * *
+    - github
+    builders:
+    - multijob:
+        name: template testing and kubernetes cluster creation
+        condition: SUCCESSFUL
+        projects:
+        - name: elastic+helm-charts+master+template-testing
+          current-parameters: true
+        - name: elastic+helm-charts+master+cluster-creation
+          current-parameters: true
+    - multijob:
+        name: elasticsearch integration testing
+        condition: ALWAYS
+        projects:
+        - name: elastic+helm-charts+master+integration-elasticsearch
+          current-parameters: true
+    - multijob:
+        name: kibana integration testing
+        condition: ALWAYS
+        projects:
+        - name: elastic+helm-charts+master+integration-kibana
+          current-parameters: true
+    publishers:
+    - trigger-parameterized-builds:
+      - project: elastic+helm-charts+master+cluster-cleanup
+        current-parameters: true
+        trigger-with-no-params: false

--- a/.ci/jobs/elastic+helm-charts+pull-request+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+cluster-cleanup.yml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+cluster-cleanup
+    display-name: elastic / helm-charts - pull-request - cluster cleanup
+    description: Pull request - cluster cleanup
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+pull-request+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+cluster-creation.yml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+cluster-creation
+    display-name: elastic / helm-charts - pull-request - cluster creation
+    description: Pull request - cluster creation
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-elasticsearch.yml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+integration-elasticsearch
+    display-name: elastic / helm-charts - pull-request - integration elasticsearch
+    description: Pull request - integration elasticsearch
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: ES_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-kibana.yml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+integration-kibana
+    display-name: elastic / helm-charts - pull-request - integration kibana
+    description: Pull request - integration kibana
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KIBANA_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs/elastic+helm-charts+pull-request+template-testing.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+template-testing.yml
@@ -1,0 +1,25 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+template-testing
+    display-name: elastic / helm-charts - pull-request - template testing
+    description: Pull request - template testing
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: CHART
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        cd ${CHART}
+        make test

--- a/.ci/jobs/elastic+helm-charts+pull-request.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request.yml
@@ -1,0 +1,53 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request
+    display-name: elastic / helm-charts - pull-request
+    description: Pull request testing
+    project-type: multijob
+    concurrent: true
+    scm:
+    - git:
+        branches:
+        - $ghprbActualCommit
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+        basedir: elasticsearch
+        wipe-workspace: 'False'
+    triggers:
+    - github-pull-request:
+        github-hooks: true
+        org-list:
+        - elastic
+        allow-whitelist-orgs-as-admins: true
+        cancel-builds-on-update: true
+        status-context: devops-ci
+    builders:
+    - multijob:
+        name: template testing and kubernetes cluster creation
+        condition: SUCCESSFUL
+        projects:
+        - name: elastic+helm-charts+pull-request+template-testing
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
+        - name: elastic+helm-charts+pull-request+cluster-creation
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
+    - multijob:
+        name: elasticsearch integration testing
+        condition: ALWAYS
+        projects:
+        - name: elastic+helm-charts+pull-request+integration-elasticsearch
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
+    - multijob:
+        name: kibana integration testing
+        condition: ALWAYS
+        projects:
+        - name: elastic+helm-charts+pull-request+integration-kibana
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
+    publishers:
+    - trigger-parameterized-builds:
+      - project: elastic+helm-charts+pull-request+cluster-cleanup
+        current-parameters: true
+        trigger-with-no-params: false
+        predefined-parameters: branch_specifier=${ghprbActualCommit}


### PR DESCRIPTION
Add JJBB job definitions to the repo so they can be managed here.

* Update job config to use new auto-generated `inject-passwords`
section. 

* Note that the publisher `infra-root+build@elastic.co` is now the
default, so it'll be appended to the list of existing publishers on any
jobs that have them, like the `trigger-parameterized-builds` publisher
for `elastic+helm-charts+pull-request`. If that's _not_ the behavior
that we want, let me know and I'll update it.