### PR TITLE
Always run from the relative parent directory

### DIFF
--- a/helpers/bumper.py
+++ b/helpers/bumper.py
@@ -5,7 +5,7 @@ import glob
 import subprocess
 import fileinput
 
-os.chdir('../')
+os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 
 versions = {
     5: '5.6.16',

--- a/helpers/release.py
+++ b/helpers/release.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import yaml
 
-os.chdir('..')
+os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 
 bucket = 'gs://' + os.environ['GCS_BUCKET']
 


### PR DESCRIPTION
This is mainly to prevent the bumper.py script from modifying the wrong
files if it is run from a different directory.

Addresses: https://github.com/elastic/helm-charts/pull/96#discussion_r276026487