### PR TITLE
Drop 1.10 from GKE testing suite

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -13,6 +13,5 @@ KIBANA_SUITE:
   - 5.x
   - 6.x
 KUBERNETES_VERSION:
-  - '1.10'
   - '1.11'
   - '1.12'


### PR DESCRIPTION
1.10 has been deprecated and it is no longer possible to create new
clusters with this version https://cloud.google.com/kubernetes-engine/docs/release-notes#deprecations

See failing build at https://devops-ci.elastic.co/job/elastic+helm-charts+master+cluster-creation/KUBERNETES_VERSION=1.10,label=docker&&virtual/52/console

```
* google_container_cluster.cluster: googleapi: Error 400: No valid versions with the prefix "1.10" found., badRequest
```