### PR TITLE
Bump the version number for the new upgrade test

### DIFF
--- a/elasticsearch/examples/upgrade/test/goss.yaml
+++ b/elasticsearch/examples/upgrade/test/goss.yaml
@@ -11,7 +11,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "7.0.0"'
+      - '"number" : "7.0.1"'
       - '"cluster_name" : "upgrade"'
       - '"name" : "upgrade-master-0"'
       - 'You Know, for Search'


### PR DESCRIPTION
I had this pull request opened at the same time as the version bump so
this one just missed out.
