### PR TITLE
Add CI jobs for filebeat chart

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+master+integration-filebeat.yml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: elastic+helm-charts+master+integration-filebeat
+    display-name: elastic / helm-charts - master - integration filebeat
+    description: Master - integration filebeat
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: FILEBEAT_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -26,10 +26,12 @@
         - name: elastic+helm-charts+master+integration-elasticsearch
           current-parameters: true
     - multijob:
-        name: kibana integration testing
+        name: integration testing
         condition: ALWAYS
         projects:
         - name: elastic+helm-charts+master+integration-kibana
+          current-parameters: true
+        - name: elastic+helm-charts+master+integration-filebeat
           current-parameters: true
     publishers:
     - trigger-parameterized-builds:

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-filebeat.yml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+integration-filebeat
+    display-name: elastic / helm-charts - pull-request - integration filebeat
+    description: Pull request - integration filebeat
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: FILEBEAT_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        set +x
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs/elastic+helm-charts+pull-request.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request.yml
@@ -39,10 +39,13 @@
           current-parameters: true
           predefined-parameters: branch_specifier=${ghprbActualCommit}
     - multijob:
-        name: kibana integration testing
+        name: integration testing
         condition: ALWAYS
         projects:
         - name: elastic+helm-charts+pull-request+integration-kibana
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
+        - name: elastic+helm-charts+pull-request+integration-filebeat
           current-parameters: true
           predefined-parameters: branch_specifier=${ghprbActualCommit}
     publishers:


### PR DESCRIPTION
This is being added separately so we can already start running automated tests for https://github.com/elastic/helm-charts/pull/121