### PR TITLE
Conditional init container, default to disabled

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -104,6 +104,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.sysctlInitContainer.enabled }}
       initContainers:
       - name: configure-sysctl
         securityContext:
@@ -116,6 +117,7 @@ spec:
       {{- if .Values.extraInitContainers }}
 {{ tpl .Values.extraInitContainers . | indent 6 }}
       {{- end }}
+{{- end }}
       containers:
       - name: "{{ template "name" . }}"
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -82,6 +82,10 @@ def test_defaults():
             'name': 'node.ingest',
             'value': 'true'
         },
+        {
+            'name': 'sysctlInitContainer.enabled',
+            'value': 'true'
+        },
     ]
 
     c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -159,3 +159,6 @@ ingress:
 
 nameOverride: ""
 fullnameOverride: ""
+
+sysctlInitContainer:
+  enabled: false


### PR DESCRIPTION
Not everyone can run privileged containers, even though `vm.max_map_count` is set on the platform.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

_It's unclear whether the chart version in `README.md` is bumped automatically_