### PR TITLE
[kibana] Explicitly set the targetPort to the defined http port

### DIFF
--- a/kibana/examples/default/test/goss.yaml
+++ b/kibana/examples/default/test/goss.yaml
@@ -8,3 +8,7 @@ http:
   http://localhost:5601/app/kibana:
     status: 200
     timeout: 2000
+
+  http://helm-kibana-default-kibana:5601/app/kibana:
+    status: 200
+    timeout: 2000

--- a/kibana/templates/service.yaml
+++ b/kibana/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
     - port: {{ .Values.service.port }}
       protocol: TCP
       name: http
+      targetPort: {{ .Values.httpPort }}
   selector:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name | quote }}

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -21,6 +21,7 @@ def test_defaults():
     assert s['ports'][0]['port'] == 5601
     assert s['ports'][0]['name'] == 'http'
     assert s['ports'][0]['protocol'] == 'TCP'
+    assert s['ports'][0]['targetPort'] == 5601
 
     c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
     assert c['name'] == 'kibana'
@@ -72,6 +73,8 @@ def test_overriding_the_port():
 
     c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
     assert c['ports'][0]['containerPort'] == 5602
+
+    assert r['service'][name]['spec']['ports'][0]['targetPort'] == 5602
 
 
 def test_adding_image_pull_secrets():


### PR DESCRIPTION
Fixes #133

Before this it wasn't possible to change the service port to anything
other than 5601. E.g. if the `service.port` was changed to `80` then the
targetPort would also be set to 80 even though Kibana was listening on
5601.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
