### PR TITLE
[elasticsearch] add masterHeadlessService template

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -27,6 +27,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "masterHeadlessService" -}}
+{{- if contains "." (include "masterService" .) -}}
+{{ template "masterService" . }}
+{{- else -}}
+{{ template "masterService" . }}-headless
+{{- end -}}
+{{- end -}}
+
 {{- define "endpoints" -}}
 {{- $replicas := .replicas | int }}
 {{- $uname := printf "%s-%s" .clusterName .nodeGroup }}

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "uname" -}}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -181,10 +181,10 @@ spec:
           {{- end }}
           {{- if lt (int .Values.esMajorVersion) 7 }}
           - name: discovery.zen.ping.unicast.hosts
-            value: "{{ template "masterService" . }}-headless"
+            value: "{{ template "masterHeadlessService" . }}"
           {{- else }}
           - name: discovery.seed_hosts
-            value: "{{ template "masterService" . }}-headless"
+            value: "{{ template "masterHeadlessService" . }}"
           {{- end }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"

--- a/filebeat/templates/_helpers.tpl
+++ b/filebeat/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -11,6 +11,14 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
-{{- $name := default .Release.Name .Values.nameOverride -}}
-{{- printf "%s-%s" $name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

In case of inter-namespace es cluster migration, `.Values.masterService` needs to contain full dns name like `es-master.ns.svc.cluster.local`.

As https://github.com/elastic/helm-charts/compare/master...kimxogus:elasticsearch/master-headless-service-helper?expand=1#diff-84f8d4f2bcce071fcd77bb865b4fc4a7L187 just append `-headless` to `{{ template "masterService" . }}`, discovery fails.

This PR adds a helper to remove `-headless` suffix if `.Values.masterService` contains `.` to fix this issue.