### PR TITLE
[ci] Set terraform timeouts to 30 minutes

### DIFF
--- a/helpers/terraform/main.tf
+++ b/helpers/terraform/main.tf
@@ -23,4 +23,10 @@ resource "google_container_cluster" "cluster" {
   node_config = {
     machine_type = "${var.machine_type}"
   }
+
+  timeouts {
+    create = "30m"
+    delete = "30m"
+    update = "30m"
+  }
 }


### PR DESCRIPTION
Currently the master build GKE cleanup job is timing out after 10
minutes.

```
04:17:35 * google_container_cluster.cluster: Error waiting for deleting GKE cluster: timeout while waiting for state to become 'DONE' (last state: 'RUNNING', timeout: 10m0s)
```

The cluster does actually get cleaned up in the end. However it means
that the build is red and needs to be checked to see if it is really
gone or not.

https://devops-ci.elastic.co/job/elastic+helm-charts+master+cluster-cleanup/KUBERNETES_VERSION=1.12,label=docker&&virtual/4/console

