### PR TITLE
Update issue template to include `helm get release` output

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,10 +11,11 @@ about: Create a report to help us improve
 
 **Helm Version:**
 
-**Values.yaml:**
+**`helm get release` output**
+
+e.g. `helm get elasticsearch` (replace `elasticsearch` with the name of your helm release)
 
 ```
-key: value
 ```
 
 **Describe the bug:**


### PR DESCRIPTION
`helm get release` includes the users values.yaml, and the final merged values and all of the deployed resources and metadata. I end up asking for this in almost all bug report issues. This command is way better. 