### PR TITLE
[elasticsearch] Fix pvc annotations with multiple fields

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ template "uname" . }}
     {{- with .Values.persistence.annotations  }}
       annotations:
-    {{ toYaml . | indent 4 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
     spec:
 {{ toYaml .Values.volumeClaimTemplate | indent 6 }}

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -343,7 +343,20 @@ persistence:
 '''
     r = helm_template(config)
     annotations = r['statefulset'][uname]['spec']['volumeClaimTemplates'][0]['metadata']['annotations']
-    assert {'volume.beta.kubernetes.io/storage-class': 'id'} == annotations
+    assert annotations['volume.beta.kubernetes.io/storage-class'] == 'id'
+
+def test_adding_multiple_persistence_annotations():
+    config = '''
+    persistence:
+      annotations:
+        hello: world
+        world: hello
+    '''
+    r = helm_template(config)
+    annotations = r['statefulset'][uname]['spec']['volumeClaimTemplates'][0]['metadata']['annotations']
+
+    assert annotations['hello'] == 'world'
+    assert annotations['world'] == 'hello'
 
 
 def test_adding_a_secret_mount():


### PR DESCRIPTION
Fixes: #183

This worked just fine if there was only 1 annotation being added. When
adding multiple annotations the extra whitespace was causing it to
break.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
