### PR TITLE
Fix naming of headless node

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -21,7 +21,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "masterService" -}}
 {{- if empty .Values.masterService -}}
-{{ .Values.clusterName }}-master
+{{ .Values.clusterName }}-{{ .Values.nodeGroup }}
 {{- else -}}
 {{ .Values.masterService }}
 {{- end -}}


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Fixed incorect template parameters. Documentation ([# This should be set to clusterName + "-" + nodeGroup for your master group](https://github.com/elastic/helm-charts/blob/master/elasticsearch/values.yaml#L6)) did not match implementation.
* Service name depend on __uname__: [name: {{ template "uname" . }}-headless](https://github.com/elastic/helm-charts/blob/master/elasticsearch/templates/service.yaml#L34)
* Discover name depend on __masterService__: [value: "{{ template "masterService" . }}-headless"](https://github.com/elastic/helm-charts/blob/master/elasticsearch/templates/statefulset.yaml#L187)

values.yaml
```yaml
clusterName: "elasticsearch"
nodeGroup: "xxx"
```

Lead to error in startup:
```{"type": "server", "timestamp": "2019-06-24T21:05:19,992+0000", "level": "WARN", "component": "o.e.d.SeedHostsResolver", "cluster.name": "elasticsearch", "node.name": "elasticsearch-xxx-0",  "message": "failed to resolve host [elasticsearch-master-headless]" ...```