### PR TITLE
[elasticsearch] Fix sidecar container resources test

### DIFF
--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -461,6 +461,7 @@ initResources:
 
 def test_adding_resources_to_sidecar_container():
     config = '''
+masterTerminationFix: true
 sidecarResources:
   limits:
     cpu: "100m"


### PR DESCRIPTION
This PR was tested and merged in after the sidecar was disabled by
default in https://github.com/elastic/helm-charts/pull/194

