### PR TITLE
[meta] Increase the retry timeout for goss

### DIFF
--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -6,5 +6,5 @@ goss:
 	GOSS_CONTAINER=$$(kubectl get --no-headers=true pods -l $(GOSS_SELECTOR) -o custom-columns=:metadata.name | sed -n 1p ) && \
 	echo Testing with pod: $$GOSS_CONTAINER && \
 	kubectl cp test/$(GOSS_FILE) $$GOSS_CONTAINER:/tmp/$(GOSS_FILE) && \
-	kubectl exec $$GOSS_CONTAINER -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o goss && chmod +rx ./goss && ./goss --gossfile $(GOSS_FILE) validate --retry-timeout 30s --sleep 5s --color --format documentation"
+	kubectl exec $$GOSS_CONTAINER -- sh -c "cd /tmp/ && curl -s -L https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64 -o goss && chmod +rx ./goss && ./goss --gossfile $(GOSS_FILE) validate --retry-timeout 300s --sleep 5s --color --format documentation"
 


### PR DESCRIPTION
The current timeout of 30 seconds is sometimes just not enough time for
the metricbeat goss testing. Increasing this to 300 (5 minutes) means we
won't be getting any false positives failing the build like in #206 