### PR TITLE
7.2.1-0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,34 @@
-## Unreleased - XXXX/XX/XX
+# Changelog
 
-### Metricbeat (WIP)
+---
+## 7.2.1-0 - 2019/07/01
 
+* [#195](https://github.com/elastic/helm-charts/pull/195) - @cclauss - Initial steps started to move all python2 code to python3
+* [#205](https://github.com/elastic/helm-charts/pull/205) - @Crazybus - Fixup and improve security example documentation
+
+
+### Elasticsearch
+
+* [#171](https://github.com/elastic/helm-charts/pull/171) - @naseemkullah - Run Elasticsearch as a non-root user
+* [#197](https://github.com/elastic/helm-charts/pull/197) - @tetianakravchenko - Add option to provide custom start/stop hooks
+* [#206](https://github.com/elastic/helm-charts/pull/206) - @Crazybus - Automatically detect esMajorVersion for default images
+* [#203](https://github.com/elastic/helm-charts/pull/203) - @Crazybus - Add testing for security context
+* [#220](https://github.com/elastic/helm-charts/pull/220) - @JorisAndrade -  Add option to disable sysctlInitContainer
+
+### Kibana
+
+* [#204](https://github.com/elastic/helm-charts/pull/204) - @Crazybus - Make imagePullPolicy actually do something
+* [#210](https://github.com/elastic/helm-charts/pull/210) - @cliedeman - Add Kibana pod annotations
+* [#217](https://github.com/elastic/helm-charts/pull/217) - @Crazybus - Update healthCheckPath to mention basePath usage
+
+### Filebeat
+
+* [#214](https://github.com/elastic/helm-charts/pull/214) - @dugouchet - Add additional labels
+
+### Metricbeat
+
+* [#127](https://github.com/elastic/helm-charts/pull/127) - @Crazybus - Add metricbeat chart
 * [#128](https://github.com/elastic/helm-charts/pull/128) - @Crazybus - Add ci jobs for metricbeat
-* [#127](https://github.com/elastic/helm-charts/pull/127) - @Crazybus - WIP add metricbeat chart
 
 ---
 ## 7.2.0 - 2019/07/01

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+helm-charts+master.svg)](https://devops-ci.elastic.co/job/elastic+helm-charts+master/)
 
-This functionality is in beta status and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but beta features are not subject to the support SLA of official GA features.
+This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 
 ## Charts
 

--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
 - email: helm-charts@elastic.co
   name: Elastic
 name: elasticsearch
-version: 7.2.0
+version: 7.2.1-0
 appVersion: 7.2.0
 sources:
   - https://github.com/elastic/elasticsearch

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -34,7 +34,7 @@ If you currently have a cluster deployed with the [helm/charts stable](https://g
   ```
 * Install it
   ```
-  helm install --name elasticsearch elastic/elasticsearch --version 7.2.0
+  helm install --name elasticsearch elastic/elasticsearch
   ```
 
 ## Compatibility
@@ -50,7 +50,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.2.0` of Elasticsearch it would look like this:
 
 ```
-helm install --name elasticsearch elastic/elasticsearch --version 7.2.0 --set imageTag=7.2.0
+helm install --name elasticsearch elastic/elasticsearch --set imageTag=7.2.0
 ```
 
 ## Configuration

--- a/filebeat/Chart.yaml
+++ b/filebeat/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
 - email: helm-charts@elastic.co
   name: Elastic
 name: filebeat
-version: 7.2.0
+version: 7.2.1-0
 appVersion: 7.2.0
 sources:
   - https://github.com/elastic/beats

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -21,7 +21,7 @@ This helm chart is a lightweight way to configure and run our official [Filebeat
   ```
 * Install it
   ```
-  helm install --name filebeat elastic/filebeat --version 7.2.0
+  helm install --name filebeat elastic/filebeat
   ```
 
 ## Compatibility
@@ -37,7 +37,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.2.0` of Filebeat it would look like this:
 
 ```
-helm install --name filebeat elastic/filebeat --version 7.2.0 --set imageTag=7.2.0
+helm install --name filebeat elastic/filebeat --set imageTag=7.2.0
 ```
 
 

--- a/helpers/bumper.py
+++ b/helpers/bumper.py
@@ -7,6 +7,8 @@ import fileinput
 
 os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 
+chart_version = '7.2.1-0'
+
 versions = {
     6: '6.8.1',
     7: '7.2.0',
@@ -26,7 +28,7 @@ file_patterns = [
 blacklist = re.compile(r".*127.0.0.1.*")
 
 for major, version in versions.iteritems():
-    r = re.compile(r"{0}\.[0-9]*\.[0-9]*".format(major))
+    r = re.compile(r"^({0})\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$".format(major))
     for pattern in file_patterns:
         for f in glob.glob(pattern):
             print(f)
@@ -34,4 +36,7 @@ for major, version in versions.iteritems():
                 if re.match(blacklist, line):
                     print(line.rstrip())
                 else:
-                    print(r.sub(version, line.rstrip()))
+                    if f.endswith('Chart.yaml') and line.startswith('version:'):
+                        print(r.sub(chart_version, line.rstrip()))
+                    else:
+                        print(r.sub(version, line.rstrip()))

--- a/helpers/release.md
+++ b/helpers/release.md
@@ -1,7 +1,7 @@
 # Release process
 
 * Update the [changelog](/CHANGELOG.md)
-* Update the stack versions in [bumper.py](/helpers/bumper.py) and run the script. This will update the versions in all the right places
+* Update the stack and chart versions in [bumper.py](/helpers/bumper.py) and run the script. This will update the versions in all the right places
 * Open a pull request and wait for a green build before merging
 * Create a [new release](https://github.com/elastic/helm-charts/releases/new) and include the latest changelog entry
 * Run the [release script](/helpers/release.py) to build and upload the artifact

--- a/kibana/Chart.yaml
+++ b/kibana/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
 - email: helm-charts@elastic.co
   name: Elastic
 name: kibana
-version: 7.2.0
+version: 7.2.1-0
 appVersion: 7.2.0
 sources:
   - https://github.com/elastic/kibana

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -17,7 +17,7 @@ This helm chart is a lightweight way to configure and run our official [Kibana d
   ```
 * Install it
   ```
-  helm install --name kibana elastic/kibana --version 7.2.0
+  helm install --name kibana elastic/kibana
   ```
 
 ## Compatibility
@@ -33,7 +33,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.2.0` of Kibana it would look like this:
 
 ```
-helm install --name kibana elastic/kibana --version 7.2.0 --set imageTag=7.2.0
+helm install --name kibana elastic/kibana --set imageTag=7.2.0
 ```
 
 ## Configuration

--- a/metricbeat/Chart.yaml
+++ b/metricbeat/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
 - email: helm-charts@elastic.co
   name: Elastic
 name: metricbeat
-version: 7.2.0
+version: 7.2.1-0
 appVersion: 7.2.0
 sources:
   - https://github.com/elastic/beats

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -17,7 +17,7 @@ This helm chart is a lightweight way to configure and run our official [Metricbe
   ```
 * Install it
   ```
-  helm install --name metricbeat elastic/metricbeat --version 7.2.0
+  helm install --name metricbeat elastic/metricbeat
   ```
 
 ## Compatibility
@@ -33,7 +33,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.2.0` of metricbeat it would look like this:
 
 ```
-helm install --name metricbeat elastic/metricbeat --version 7.2.0 --set imageTag=7.2.0
+helm install --name metricbeat elastic/metricbeat --set imageTag=7.2.0
 ```
 
 


### PR DESCRIPTION
Intermediate release to get the metricbeat chart live along wiht some
other nice changes.

* Dropped the `--version` specifier in the readmes. This was only needed
back when we had the alpha flag because otherwise `helm install
elastic/elasticsearch` failed because the helm client ignored these versions.
