### PR TITLE
[kibana] Add subPath support to secretMounts

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -112,6 +112,9 @@ spec:
           {{- range .Values.secretMounts }}
           - name: {{ .name }}
             mountPath: {{ .path }}
+            {{- if .subPath }}
+            subPath: {{ .subPath }}
+            {{- end }}
           {{- end }}
           {{- range $path, $config := .Values.kibanaConfig }}
           - name: kibanaconfig

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -364,3 +364,33 @@ labels:
 '''
      r = helm_template(config)
      assert r['deployment'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'kibana'
+
+def test_adding_a_secret_mount_with_subpath():
+    config = '''
+secretMounts:
+  - name: elastic-certificates
+    secretName: elastic-certs
+    path: /usr/share/elasticsearch/config/certs
+    subPath: cert.crt
+'''
+    r = helm_template(config)
+    d = r['deployment'][name]['spec']['template']['spec']
+    assert d['containers'][0]['volumeMounts'][-1] == {
+        'mountPath': '/usr/share/elasticsearch/config/certs',
+        'subPath': 'cert.crt',
+        'name': 'elastic-certificates'
+    }
+
+def test_adding_a_secret_mount_without_subpath():
+    config = '''
+secretMounts:
+  - name: elastic-certificates
+    secretName: elastic-certs
+    path: /usr/share/elasticsearch/config/certs
+'''
+    r = helm_template(config)
+    d = r['deployment'][name]['spec']['template']['spec']
+    assert d['containers'][0]['volumeMounts'][-1] == {
+        'mountPath': '/usr/share/elasticsearch/config/certs',
+        'name': 'elastic-certificates'
+    }

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -16,9 +16,10 @@ extraEnvs: []
 # This is useful for mounting certificates for security and for mounting
 # the X-Pack license
 secretMounts: []
-#  - name: elastic-certificates
-#    secretName: elastic-certificates
-#    path: /usr/share/elasticsearch/config/certs
+#  - name: kibana-keystore
+#    secretName: kibana-keystore
+#    path: /usr/share/kibana/data/kibana.keystore
+#    subPath: kibana.keystore # optional
 
 image: "docker.elastic.co/kibana/kibana"
 imageTag: "7.2.0"


### PR DESCRIPTION
Fixes: #229

This is needed in situation where you need to mount a specific secret as
a file in a directory that contains other files. This was added for the
Elasticsearch chart to make it possible to mount the keystore, the same
option is needed for Kibana too as seen in in #229.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
