### PR TITLE
publishNotReadyAddresses not working

### DIFF
--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -37,6 +37,8 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ template "uname" . }}"
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   clusterIP: None # This is needed for statefulset hostnames like elasticsearch-0 to resolve
   # Create endpoints also if the related pod isn't ready


### PR DESCRIPTION
according to https://github.com/kubernetes/kubernetes/issues/58662 the `publishNotReadyAddresses: true` is not working. Instead they suggest this annotation as workaround: `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"`

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
