### PR TITLE
[meta] Add dependency download to release script

### DIFF
--- a/helpers/release.py
+++ b/helpers/release.py
@@ -30,6 +30,9 @@ for release in glob.glob('*/*.tgz'):
 for filepath in glob.iglob('*/Chart.yaml'):
     chart = os.path.split(os.path.dirname(filepath))[-1]
 
+    # Download dependencies
+    run(['helm', 'dependency', 'update', chart])
+
     # Package up the chart
     run(['helm', 'package', chart, '--destination', chart])
 


### PR DESCRIPTION
This is needed for metricbeat to download the child charts
