### PR TITLE
Fixed indent on elasticsearch extraVolumes tpl. Was causing parsing errors.

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -112,7 +112,7 @@ spec:
             name: {{ template "uname" . }}-config
         {{- end }}
       {{- if .Values.extraVolumes }}
-{{ tpl .Values.extraVolumes . | indent 6 }}
+{{ tpl .Values.extraVolumes . | indent 8 }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION

Fixed indent on elasticsearch extraVolumes tpl. Was causing parsing errors.

