### PR TITLE
[metricbeat] Fix default configuration for kubernetes module

### DIFF
--- a/metricbeat/examples/default/test/goss-metrics.yaml
+++ b/metricbeat/examples/default/test/goss-metrics.yaml
@@ -22,7 +22,8 @@ http:
     timeout: 2000
     body:
       - 'metricbeat-7.3.0'
-  http://elasticsearch-master:9200/_search?q=metricset.name:state_deployment:
+
+  'http://elasticsearch-master:9200/_search?q=metricset.name:state_container%20AND%20kubernetes.container.name:metricbeat':
     status: 200
     timeout: 2000
     body:

--- a/metricbeat/examples/default/test/goss.yaml
+++ b/metricbeat/examples/default/test/goss.yaml
@@ -30,7 +30,7 @@ http:
     timeout: 2000
     body:
       - 'metricbeat-7.3.0'
-  http://elasticsearch-master:9200/_search?q=metricset.name:container:
+  'http://elasticsearch-master:9200/_search?q=metricset.name:container%20AND%20kubernetes.container.name:metricbeat':
     status: 200
     timeout: 2000
     body:

--- a/metricbeat/examples/security/values.yaml
+++ b/metricbeat/examples/security/values.yaml
@@ -11,7 +11,8 @@ metricbeatConfig:
         - system
         - volume
       period: 10s
-      hosts: ["localhost:10255"]
+      host: "${NODE_NAME}"
+      hosts: ["${NODE_NAME}:10255"]
       processors:
       - add_kubernetes_metadata:
           in_cluster: true

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -105,6 +105,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 8 }}
 {{- end }}

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -14,7 +14,8 @@ metricbeatConfig:
         - system
         - volume
       period: 10s
-      hosts: ["localhost:10255"]
+      host: "${NODE_NAME}"
+      hosts: ["${NODE_NAME}:10255"]
       processors:
       - add_kubernetes_metadata:
           in_cluster: true


### PR DESCRIPTION
This configuration didn't work at all since the nodes localhost is not
reachable from the kubernetes pod. The test has also been fixed up to
make sure that the data coming in actually has proper fields in it. The
test was passing because the events were coming in but just with errors.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
