### PR TITLE
[metricbeat] Enable events access to cluster role

### DIFF
--- a/metricbeat/templates/clusterrole.yaml
+++ b/metricbeat/templates/clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - events
   verbs:
   - get
   - list


### PR DESCRIPTION
Metricbeat apparently needs access to events. I had to manually make this change to the clusterrole when installing the chart due to the following error:

`Performing a resource sync err kubernetes api: Failure 403 events is forbidden: User "system:serviceaccount:monitoring:metricbeat-metricbeat" cannot list resource "events" in API group "" at the cluster scope for *v1.EventList`

I haven't tried `filebeat` yet so I'm not sure this change is also required for it.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
