### PR TITLE
Fix octal literal to work in both Python 2 and Python 3

### DIFF
--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -136,7 +136,7 @@ metricbeatConfig:
 
     d = r['daemonset'][name]['spec']['template']['spec']
 
-    assert {'configMap': {'name': name + '-config', 'defaultMode': 0600}, 'name': project + '-config'} in d['volumes']
+    assert {'configMap': {'name': name + '-config', 'defaultMode': 0o600}, 'name': project + '-config'} in d['volumes']
     assert {'mountPath': '/usr/share/metricbeat/metricbeat.yml', 'name': project + '-config', 'subPath': 'metricbeat.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
     assert {'mountPath': '/usr/share/metricbeat/other-config.yml', 'name': project + '-config', 'subPath': 'other-config.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
 


### PR DESCRIPTION
@Crazybus A repeat of #188 on a different file.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
