### PR TITLE
Bump google terraform provider to the latest

### DIFF
--- a/helpers/terraform/main.tf
+++ b/helpers/terraform/main.tf
@@ -1,7 +1,7 @@
 provider "google" {
   project = "${var.project}"
   region  = "${var.primary_region}"
-  version = "1.13.0"
+  version = "2.13.0"
 }
 
 terraform {


### PR DESCRIPTION
The current version started failing a couple of days ago with some very
weird terraform crashes. The latest version is working as expected
though.

https://devops-ci.elastic.co/job/elastic+helm-charts+pull-request+cluster-creation/129/KUBERNETES_VERSION=1.12,label=docker&&virtual/console
