### PR TITLE
Add working examples for running Elasticsearch and Kibana on ope…

### DIFF
--- a/elasticsearch/examples/openshift/Makefile
+++ b/elasticsearch/examples/openshift/Makefile
@@ -1,0 +1,15 @@
+default: test
+include ../../../helpers/examples.mk
+
+RELEASE := elasticsearch
+
+template:
+	helm template --values ./values.yaml ../../
+
+install:
+	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
+
+test: install goss
+
+purge:
+	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/openshift/Makefile
+++ b/elasticsearch/examples/openshift/Makefile
@@ -7,7 +7,7 @@ template:
 	helm template --values ./values.yaml ../../
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
+	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 

--- a/elasticsearch/examples/openshift/test/goss.yaml
+++ b/elasticsearch/examples/openshift/test/goss.yaml
@@ -1,0 +1,17 @@
+http:
+  http://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    body:
+      - 'green'
+      - '"number_of_nodes":3'
+      - '"number_of_data_nodes":3'
+
+  http://localhost:9200:
+    status: 200
+    timeout: 2000
+    body:
+      - '"number" : "7.3.0"'
+      - '"cluster_name" : "elasticsearch"'
+      - '"name" : "elasticsearch-master-0"'
+      - 'You Know, for Search'

--- a/elasticsearch/examples/openshift/values.yaml
+++ b/elasticsearch/examples/openshift/values.yaml
@@ -1,0 +1,10 @@
+---
+
+securityContext:
+  runAsUser: null
+
+podSecurityContext:
+  fsGroup: null
+
+sysctlInitContainer:
+  enabled: false

--- a/kibana/examples/openshift/Makefile
+++ b/kibana/examples/openshift/Makefile
@@ -7,7 +7,7 @@ template:
 	helm template --values ./values.yml ../../
 
 install: 
-	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../ ; \
+	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../
 
 test: install goss
 	

--- a/kibana/examples/openshift/Makefile
+++ b/kibana/examples/openshift/Makefile
@@ -1,0 +1,15 @@
+default: test
+include ../../../helpers/examples.mk
+
+RELEASE := kibana
+
+template:
+	helm template --values ./values.yml ../../
+
+install: 
+	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../ ; \
+
+test: install goss
+	
+purge:
+	helm del --purge $(RELEASE)

--- a/kibana/examples/openshift/test/goss.yaml
+++ b/kibana/examples/openshift/test/goss.yaml
@@ -1,0 +1,4 @@
+http:
+  http://localhost:5601/app/kibana:
+    status: 200
+    timeout: 2000

--- a/kibana/examples/openshift/values.yml
+++ b/kibana/examples/openshift/values.yml
@@ -1,0 +1,4 @@
+---
+
+fsGroup: null
+runAsUser: null

--- a/kibana/examples/openshift/values.yml
+++ b/kibana/examples/openshift/values.yml
@@ -1,4 +1,7 @@
 ---
 
-fsGroup: null
-runAsUser: null
+podSecurityContext:
+  fsGroup: null
+
+securityContext:
+  runAsUser: null


### PR DESCRIPTION
Closes: #15

We don't currently have automated testing for openshift clusters however
these have been manually tested and confirmed to work. For now having
an example on how to do this is nice but in the future we can consider
adding a value to pragmatically disable these features with something
like `openshift: true`

Special thanks to @geogdog for getting these working and providing the
correct changes needed.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
