### PR TITLE
use same env variable as application

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -96,8 +96,8 @@ spec:
                     local path="${1}"
                     set -- -XGET -s --fail
 
-                    if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
-                      set -- "$@" -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+                    if [ -n "${ELASTICSEARCH_USERNAME}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
+                      set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
                     fi
 
                     curl -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}"


### PR DESCRIPTION
Signed-off-by: Riccardo Piccoli <riccardo.piccoli@softonic.com>

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

It appears that env vars used by kibana are `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`, but readiness uses `ELASTIC_USERNAME` and `ELASTIC_PASSWORD`. This causes kibana to be unready, unless we also configure `ELASTIC_` vars.