### PR TITLE
Adding Example for Kubernetes KIND

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -258,6 +258,15 @@ cd examples/docker-for-mac
 make
 ```
 
+#### KIND - Kubernetes
+
+It is also possible to run this chart using a Kubernetes [KIND (Kubernetes in Docker)](https://github.com/kubernetes-sigs/kind) cluster: 
+
+```
+cd examples/kubernetes-kind
+make
+```
+
 ## Clustering and Node Discovery
 
 This chart facilitates Elasticsearch node discovery and services by creating two `Service` definitions in Kubernetes, one with the name `$clusterName-$nodeGroup` and another named `$clusterName-$nodeGroup-headless`.

--- a/elasticsearch/examples/kubernetes-kind/Makefile
+++ b/elasticsearch/examples/kubernetes-kind/Makefile
@@ -1,0 +1,12 @@
+default: test
+
+RELEASE := helm-es-kind
+
+install:
+	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
+
+test: install
+	helm test $(RELEASE)
+
+purge:
+	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/kubernetes-kind/values.yaml
+++ b/elasticsearch/examples/kubernetes-kind/values.yaml
@@ -1,0 +1,37 @@
+---
+# Permit co-located instances for solitary minikube virtual machines.
+antiAffinity: "soft"
+
+# Shrink default JVM heap.
+esJavaOpts: "-Xmx128m -Xms128m"
+
+# Allocate smaller chunks of memory per pod.
+resources:
+  requests:
+    cpu: "100m"
+    memory: "512M"
+  limits:
+    cpu: "1000m"
+    memory: "512M"
+
+# Request smaller persistent volumes.
+volumeClaimTemplate:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "hostpath"
+  resources:
+    requests:
+      storage: 100M
+extraInitContainers: |
+  - name: create
+    image: busybox:1.28
+    command: ['mkdir', '/usr/share/elasticsearch/data/nodes/']  
+    volumeMounts:
+    - mountPath: /usr/share/elasticsearch/data
+      name: elasticsearch-master
+  - name: file-permissions
+    image: busybox:1.28
+    command: ['chown', '-R', '1000:1000', '/usr/share/elasticsearch/']
+    volumeMounts:
+    - mountPath: /usr/share/elasticsearch/data
+      name: elasticsearch-master
+      

--- a/elasticsearch/examples/kubernetes-kind/values.yaml
+++ b/elasticsearch/examples/kubernetes-kind/values.yaml
@@ -17,7 +17,7 @@ resources:
 # Request smaller persistent volumes.
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]
-  storageClassName: "hostpath"
+  storageClassName: "standard"
   resources:
     requests:
       storage: 100M

--- a/elasticsearch/examples/kubernetes-kind/values.yaml
+++ b/elasticsearch/examples/kubernetes-kind/values.yaml
@@ -17,7 +17,6 @@ resources:
 # Request smaller persistent volumes.
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]
-  storageClassName: "standard"
   resources:
     requests:
       storage: 100M


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

This PR adds support for running elastic for development purposes on Kubernetes KIND (https://github.com/kubernetes-sigs/kind) which for some reason require the directory to be created before using it for elasticsearch data. Hence the use of an initContainer. 