### PR TITLE
Certificate has no subjectAltName

### DIFF
--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -21,7 +21,7 @@ secrets:
 		docker.elastic.co/elasticsearch/elasticsearch:$(STACK_VERSION) \
 		/bin/sh -c " \
 			elasticsearch-certutil ca --out /app/elastic-stack-ca.p12 --pass '' && \
-			elasticsearch-certutil cert --name security-master --ca /app/elastic-stack-ca.p12 --pass '' --ca-pass '' --out /app/elastic-certificates.p12" && \
+			elasticsearch-certutil cert --name security-master --dns security-master --ca /app/elastic-stack-ca.p12 --pass '' --ca-pass '' --out /app/elastic-certificates.p12" && \
 	docker cp elastic-helm-charts-certs:/app/elastic-certificates.p12 ./ && \
 	docker rm -f elastic-helm-charts-certs && \
 	openssl pkcs12 -nodes -passin pass:'' -in elastic-certificates.p12 -out elastic-certificate.pem && \


### PR DESCRIPTION
Fix 'Certificate has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818'
