### PR TITLE
[meta] Add Kubernetes 1.14 and drop 1.11

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -27,6 +27,6 @@ METRICBEAT_SUITE:
   - security
   - 6.x
 KUBERNETES_VERSION:
-  - '1.11'
   - '1.12'
   - '1.13'
+  - '1.14'


### PR DESCRIPTION
Support for 1.11 has been dropped by GKE and 1.14 has been added

