### PR TITLE
[meta] Update default kubernetes version in makefile

### DIFF
--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -1,6 +1,6 @@
 GOOGLE_PROJECT := elastic-ci-prod
 CLUSTER_NAME := helm-elasticsearch-test
-KUBERNETES_VERSION := 1.9.7-gke.6
+KUBERNETES_VERSION := 1.14
 CHART := elasticsearch
 SUITE := default
 NAMESPACE := helm-charts-testing


### PR DESCRIPTION
Addresses comments from #287.

This version is only used when someone is testing out the terraform
automation locally but still useful to keep updated to a known working
version.
