### PR TITLE
[metricbeat] Remove default kube static metrics host to avoid co…

### DIFF
--- a/metricbeat/examples/security/values.yaml
+++ b/metricbeat/examples/security/values.yaml
@@ -61,7 +61,7 @@ metricbeatConfig:
         - state_pod
         - state_container
       period: 10s
-      hosts: ["${KUBE_STATE_METRICS_HOSTS:kube-state-metrics:8080}"]
+      hosts: ["${KUBE_STATE_METRICS_HOSTS}"]
     output.elasticsearch:
       username: '${ELASTICSEARCH_USERNAME}'
       password: '${ELASTICSEARCH_PASSWORD}'

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -58,7 +58,7 @@ metricbeatConfig:
         - state_pod
         - state_container
       period: 10s
-      hosts: ["${KUBE_STATE_METRICS_HOSTS:kube-state-metrics:8080}"]
+      hosts: ["${KUBE_STATE_METRICS_HOSTS}"]
     output.elasticsearch:
       hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
 


### PR DESCRIPTION
This default value is never used since the environment variable is
always being set for the deployment. See
https://github.com/elastic/helm-charts/issues/283#issuecomment-532708548
for more information.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
