### PR TITLE
[elasticsearch] Drop version from chart label in service

### DIFF
--- a/elasticsearch/templates/configmap.yaml
+++ b/elasticsearch/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}"
     app: "{{ template "uname" . }}"
 data:
 {{- range $path, $config := .Values.esConfig }}

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}"
     app: "{{ template "uname" . }}"
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
@@ -15,7 +15,7 @@ spec:
   selector:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}"
     app: "{{ template "uname" . }}"
   ports:
   - name: http
@@ -35,7 +35,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}"
     app: "{{ template "uname" . }}"
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}"
     app: "{{ template "uname" . }}"
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value | quote }}
@@ -39,7 +39,7 @@ spec:
       labels:
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: "{{ .Chart.Name }}"
         app: "{{ template "uname" . }}"
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}


### PR DESCRIPTION
As identified in #284 having the version in the label would cause the
service to be recreated during a chart version upgrade.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
