### PR TITLE
[kibana] Explicitly test for a 200 for readinessProbe

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -100,7 +100,13 @@ spec:
                       set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
                     fi
 
-                    curl -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}"
+                    STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}")
+                    if [[ "${STATUS}" -eq 200 ]]; then
+                      exit 0
+                    fi
+
+                    echo "Error: Got HTTP code ${STATUS} but expected a 200"
+                    exit 1
                 }
 
                 http "{{ .Values.healthCheckPath }}"


### PR DESCRIPTION
If authentication wasn't configured correctly the Kibana readinessProbe
would still pass since `curl --fail` doesn't consider a redirect to be a
failure. If authentication fails Kibana would redirect you back to the
login page so this readinessProbe always passed for security clusters.
The tests are going to fail until #272 is merged and this PR has been
rebased on top of it.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
