### PR TITLE
fix "; \" when there is no additional command in the makefiles

### DIFF
--- a/elasticsearch/examples/6.x/Makefile
+++ b/elasticsearch/examples/6.x/Makefile
@@ -4,10 +4,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-six
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
+	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 

--- a/elasticsearch/examples/config/Makefile
+++ b/elasticsearch/examples/config/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-config
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
+	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
 
 secrets:
 	kubectl delete secret elastic-config-credentials elastic-config-secret elastic-config-slack elastic-config-custom-path || true

--- a/elasticsearch/examples/default/Makefile
+++ b/elasticsearch/examples/default/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-default
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../ ; \
+	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../ ; \
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/elasticsearch/examples/oss/Makefile
+++ b/elasticsearch/examples/oss/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-oss
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../ ; \
+	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 

--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -5,8 +5,8 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-security
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../ ; \
-	
+	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../
+
 purge:
 	kubectl delete secrets elastic-credentials elastic-certificates elastic-certificate-pem || true
 	helm del --purge $(RELEASE)

--- a/kibana/examples/6.x/Makefile
+++ b/kibana/examples/6.x/Makefile
@@ -4,8 +4,8 @@ include ../../../helpers/examples.mk
 RELEASE := helm-kibana-six
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../ ; \
-	
+	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../
+
 purge:
 	helm del --purge $(RELEASE)
 

--- a/kibana/examples/default/Makefile
+++ b/kibana/examples/default/Makefile
@@ -5,7 +5,7 @@ RELEASE := helm-kibana-default
 
 install:
 	echo "Goss container: $(GOSS_CONTAINER)"
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../ ; \
+	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/kibana/examples/oss/Makefile
+++ b/kibana/examples/oss/Makefile
@@ -3,10 +3,10 @@ include ../../../helpers/examples.mk
 
 RELEASE := helm-kibana-oss
 
-install: 
-	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../ ; \
+install:
+	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../
 
 test: install goss
-	
+
 purge:
 	helm del --purge $(RELEASE)

--- a/kibana/examples/security/Makefile
+++ b/kibana/examples/security/Makefile
@@ -4,10 +4,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-kibana-security
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../ ; \
+	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../
 
 test: secrets install goss
-	
+
 purge:
 	kubectl delete secret kibana || true
 	helm del --purge $(RELEASE)


### PR DESCRIPTION
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Related to https://github.com/elastic/helm-charts/pull/263#discussion_r326090218