### PR TITLE
[helm-tester] migrate to python 3

### DIFF
--- a/helpers/helm-tester/Dockerfile
+++ b/helpers/helm-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-onbuild
+FROM python:3.6-onbuild
 
 ENV HELM_VERSION=2.14.0
 

--- a/helpers/helm-tester/Dockerfile
+++ b/helpers/helm-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-onbuild
+FROM python:3.7
 
 ENV HELM_VERSION=2.14.0
 
@@ -8,3 +8,8 @@ RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-li
     rm -rf linux-amd64 && \
     HOME=/ helm init --client-only && \
     chmod 777 -R /.helm
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
+
+COPY . /usr/src/app


### PR DESCRIPTION
Does what it says on the tin

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
