### PR TITLE
Make it possible to override the endpoint template.

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -28,8 +28,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "endpoints" -}}
-{{- $replicas := .replicas | int }}
-{{- $uname := printf "%s-%s" .clusterName .nodeGroup }}
+{{- $replicas := .Values.replicas | int }}
+{{- $uname := printf "%s-%s" .Values.clusterName .Values.nodeGroup }}
   {{- range $i, $e := untilStep 0 $replicas 1 -}}
 {{ $uname }}-{{ $i }},
   {{- end -}}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -233,7 +233,7 @@ spec:
           {{- if eq .Values.roles.master "true" }}
           {{- if ge (int (include "esMajorVersion" .)) 7 }}
           - name: cluster.initial_master_nodes
-            value: "{{ template "endpoints" .Values }}"
+            value: "{{ template "endpoints" . }}"
           {{- else }}
           - name: discovery.zen.minimum_master_nodes
             value: "{{ .Values.minimumMasterNodes }}"


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

We would like to use the elasticsearch chart as a subchart, where the name of the resource needs to match the release name (the common structure used by many charts, like the official mariadb chart). 

This was quite easy to do by overriding the helm template for `uname` and `masterService` (replacing their content with `{{ .Release.Name }}-elasticsearch`), but the `endpoints` template also needs to be overridden, and due to the way parameters are passed the trick above doesn't work.

This change simply passes moves the specification of `.Values` to the helm template, enabling overrides to access top-level parameters like `.Release.Name`. The behavior stays unchanged. This template is also not used anywhere else. 