### PR TITLE
[elasticsearch] Fix bug in keystore initContainer

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -161,7 +161,7 @@ spec:
           done
 
           # Add the bootstrap password since otherwise the Elasticsearch entrypoint tries to do this on startup
-          [ ! -z "$ELASTIC_PASSWORD" ] && echo "$ELASTIC_PASSWORD" | elasticsearch-keystore add -x bootstrap.password
+          [ ! -z ${ELASTIC_PASSWORD+x} ] && echo "$ELASTIC_PASSWORD" | elasticsearch-keystore add -x bootstrap.password
 
           cp -a /usr/share/elasticsearch/config/elasticsearch.keystore /tmp/keystore/
         env: {{ toYaml .Values.extraEnvs | nindent 10 }}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

This fixes a bug in the `keystore` initContainer as reported in https://github.com/elastic/helm-charts/issues/280.  The root cause was using `set -u` and the variable unset check `[ ! -z "$ELASTIC_PASSWORD" ]`.  Doing the variable check this way violates `set -u` since it is considered to be accessing the variable.  The fix is to change the unset check to `[ ! -z ${ELASTIC_PASSWORD+x} ]` as per https://stackoverflow.com/a/13864829/684893.

Note the error that the `keystore` initContainer reports without the fix:

```sh
k8s-prod$ kubectl logs test-elasticsearch-master-0 -c keystore
Created elasticsearch keystore in /usr/share/elasticsearch/config
Adding file /tmp/keystoreSecrets/aws-credentials/s3.client.default.access_key to keystore key s3.client.default.access_key
Adding file /tmp/keystoreSecrets/aws-credentials/s3.client.default.secret_key to keystore key s3.client.default.secret_key
sh: line 12: ELASTIC_PASSWORD: unbound variable
```

You can verify the issue and the fix using these simple tests:

```sh
$ sh -c 'set -u; [ ! -z "$DOG" ] && echo $DOG'
sh: DOG: unbound variable
$ sh -c 'set -u; [ ! -z ${DOG+x} ] && echo $DOG'
(no error)
$ sh -c 'set -u; DOG='ruff'; [ ! -z ${DOG+x} ] && echo $DOG'
ruff
```