### PR TITLE
[metricbeat] change min k8s version due to used apiVersions

### DIFF
--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -6,7 +6,7 @@ This helm chart is a lightweight way to configure and run our official [Metricbe
 
 ## Requirements
 
-* Kubernetes >= 1.8
+* Kubernetes >= 1.9
 * [Helm](https://helm.sh/) >= 2.8.0
 
 ## Installing


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
