### PR TITLE
[helm-tester] freeze all pip dependencies

### DIFF
--- a/helpers/helm-tester/requirements.txt
+++ b/helpers/helm-tester/requirements.txt
@@ -1,2 +1,10 @@
+atomicwrites==1.3.0
+attrs==19.1.0
+importlib-metadata==0.23
+more-itertools==7.2.0
+pluggy==0.13.0
+py==1.8.0
 pytest==4.1.0
 PyYAML==4.2b4
+six==1.12.0
+zipp==0.6.0


### PR DESCRIPTION
- Freezing attrs to 19.1.0 fix `TypeError: attrib() got an unexpected keyword argument 'convert'` issue that we have with 19.2.0
- Also freezing other dependencies for safety

Fix #308 