### PR TITLE
Had to add a couple extra mounts to get MetricBeat to pick up all the…

### DIFF
--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -65,8 +65,14 @@ spec:
       - name: varrundockersock
         hostPath:
           path: /var/run/docker.sock
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
       {{- if .Values.extraVolumes }}
-{{ tpl .Values.extraVolumes . | indent 6 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -140,6 +146,12 @@ spec:
         - name: varrundockersock
           mountPath: /var/run/docker.sock
           readOnly: true
+        - name: proc
+          mountPath: /hostfs/proc
+          readOnly: true
+        - name: cgroup
+          mountPath: /hostfs/sys/fs/cgroup
+          readOnly: true
         {{- if .Values.extraVolumeMounts }}
-{{ tpl .Values.extraVolumeMounts . | indent 8 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           name: {{ template "fullname" . }}-config
       {{- end }}
       {{- if .Values.extraVolumes }}
-{{ tpl .Values.extraVolumes . | indent 6 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -115,5 +115,5 @@ spec:
           subPath: {{ $path }}
         {{- end }}
         {{- if .Values.extraVolumeMounts }}
-{{ tpl .Values.extraVolumeMounts . | indent 8 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}

--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -2,7 +2,6 @@ import os
 import sys
 sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
 from helpers import helm_template
-import yaml
 
 project = 'metricbeat'
 name = 'release-name-' + project
@@ -166,10 +165,10 @@ secretMounts:
 
 def test_adding_a_extra_volume_with_volume_mount():
     config = '''
-extraVolumes: |
+extraVolumes:
   - name: extras
     emptyDir: {}
-extraVolumeMounts: |
+extraVolumeMounts:
   - name: extras
     mountPath: /usr/share/extras
     readOnly: true

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -73,12 +73,12 @@ extraEnvs: []
 #  - name: MY_ENVIRONMENT_VAR
 #    value: the_value_goes_here
 
-extraVolumeMounts: ""
+extraVolumeMounts: []
   # - name: extras
   #   mountPath: /usr/share/extras
   #   readOnly: true
 
-extraVolumes: ""
+extraVolumes: []
   # - name: extras
   #   emptyDir: {}
 


### PR DESCRIPTION
… metrics from the host nodes on Digital Ocean. In the process, noticed that the extraMount setting is configured different then the rest- changed it to be consistent. Not being a metricbeat expert, it is possible there was a better way to do this?

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
