### PR TITLE
optional labels for kibana ingress

### DIFF
--- a/kibana/templates/ingress.yaml
+++ b/kibana/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.ingress.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
I am running multiple IngressControllers and I need to add labels to my Ingress objects to select which controller to use.

Config example for values.yml:
```
ingress:
  enabled: true
  annotations:
    ingress.kubernetes.io/protocol: https
  labels:
    my-ingress: internal
```