### PR TITLE
Beats icons

### DIFF
--- a/filebeat/Chart.yaml
+++ b/filebeat/Chart.yaml
@@ -9,4 +9,4 @@ version: 7.4.1
 appVersion: 7.4.1
 sources:
   - https://github.com/elastic/beats
-icon: https://helm.elastic.co/icons/filebeat.png
+icon: https://helm.elastic.co/icons/beats.png

--- a/metricbeat/Chart.yaml
+++ b/metricbeat/Chart.yaml
@@ -9,4 +9,4 @@ version: 7.4.1
 appVersion: 7.4.1
 sources:
   - https://github.com/elastic/beats
-icon: https://helm.elastic.co/icons/metricbeat.png
+icon: https://helm.elastic.co/icons/beats.png


### PR DESCRIPTION
- uploaded beats icons to https://helm.elastic.co/icons/beats.png
- fixed icons name in `*beats/Chart.yml`

These icons will be available on https://hub.helm.sh/charts/elastic after next release.