### PR TITLE
[helm-tester] make docker image build less verbose

### DIFF
--- a/helpers/helm-tester/Dockerfile
+++ b/helpers/helm-tester/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 ENV HELM_VERSION=2.15.1
 
-RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+RUN wget --no-verbose https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     tar xfv helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/ && \
     rm -rf linux-amd64 && \


### PR DESCRIPTION
This remove ~500 lines of wget progress bar during [template-testing jobs](https://devops-ci.elastic.co/view/Helm%20Charts/job/elastic+helm-charts+master+template-testing/) and so make job logs 50% slimmer and easier to scan if we need to troubleshoot something.