### PR TITLE
[logstash] remove goss port test

### DIFF
--- a/logstash/examples/6.x/Makefile
+++ b/logstash/examples/6.x/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-six
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE)  --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE)  --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 

--- a/logstash/examples/6.x/test/goss.yaml
+++ b/logstash/examples/6.x/test/goss.yaml
@@ -1,9 +1,3 @@
-port:
-  tcp:9600:
-    listening: true
-    ip:
-    - '0.0.0.0'
-
 user:
   logstash:
     exists: true

--- a/logstash/examples/default/Makefile
+++ b/logstash/examples/default/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-default
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/logstash/examples/default/test/goss.yaml
+++ b/logstash/examples/default/test/goss.yaml
@@ -1,9 +1,3 @@
-port:
-  tcp:9600:
-    listening: true
-    ip:
-    - '0.0.0.0'
-
 user:
   logstash:
     exists: true

--- a/logstash/examples/elasticsearch/Makefile
+++ b/logstash/examples/elasticsearch/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-elasticsearch
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/logstash/examples/elasticsearch/test/goss.yaml
+++ b/logstash/examples/elasticsearch/test/goss.yaml
@@ -1,9 +1,3 @@
-port:
-  tcp:9600:
-    listening: true
-    ip:
-    - '0.0.0.0'
-
 mount:
   /usr/share/logstash/data:
     exists: true

--- a/logstash/examples/oss/Makefile
+++ b/logstash/examples/oss/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-oss
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE)  --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE)  --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/logstash/examples/oss/test/goss.yaml
+++ b/logstash/examples/oss/test/goss.yaml
@@ -1,9 +1,3 @@
-port:
-  tcp:9600:
-    listening: true
-    ip:
-    - '0.0.0.0'
-
 user:
   logstash:
     exists: true


### PR DESCRIPTION
Goss port test for `tcp:9600` is failing on GKE 1.12 due to https://github.com/aelsabbahy/goss/issues/149.

We already had this issue with Elasticsearch goss tests in https://github.com/elastic/helm-charts/commit/de1fef380e94ef6c5a0665f7c7aa4bdbb0385d0a.
