### PR TITLE
bump metricbeat to latest chart and app version

### DIFF
--- a/metricbeat/requirements.lock
+++ b/metricbeat/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.6.0
-digest: sha256:111c5be854f72db1996a198a473a3e69bd50b7c5f046cf03ee4733d62a612874
-generated: 2019-06-11T09:46:07.710748+02:00
+  version: 2.4.1
+digest: sha256:89fdea6b5f048652fc2d562ff59338a8cbf25f9053dc28976a1271b4387692b1
+generated: "2019-11-01T10:31:40.002896+01:00"

--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: 'kube-state-metrics'
-    version: '1.6.0'
+    version: '2.4.1'
     repository: '@stable'


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.1.0, py-1.8.0, pluggy-0.13.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /app/metricbeat, inifile:
collecting ... collected 15 items

tests/metricbeat_test.py::test_defaults PASSED
tests/metricbeat_test.py::test_adding_envs PASSED
tests/metricbeat_test.py::test_adding_image_pull_secrets PASSED
tests/metricbeat_test.py::test_adding_tolerations PASSED
tests/metricbeat_test.py::test_override_the_default_update_strategy PASSED
tests/metricbeat_test.py::test_setting_a_custom_service_account PASSED
tests/metricbeat_test.py::test_self_managing_rbac_resources PASSED
tests/metricbeat_test.py::test_setting_pod_security_context PASSED
tests/metricbeat_test.py::test_adding_in_metricbeat_config PASSED
tests/metricbeat_test.py::test_adding_a_secret_mount PASSED
tests/metricbeat_test.py::test_adding_a_extra_volume_with_volume_mount PASSED
tests/metricbeat_test.py::test_adding_a_node_selector PASSED
tests/metricbeat_test.py::test_adding_an_affinity_rule PASSED
tests/metricbeat_test.py::test_cluster_role_rules PASSED
tests/metricbeat_test.py::test_adding_pod_labels PASSED

=============================== warnings summary ===============================
tests/metricbeat_test.py::test_defaults
  /usr/local/lib/python3.7/site-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    if not isinstance(key, collections.Hashable):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 15 passed, 1 warnings in 23.84 seconds ====================
```