### PR TITLE
Update commands to be compatible with Helm v3

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -35,7 +35,7 @@ If you currently have a cluster deployed with the [helm/charts stable](https://g
   ```
 * Install it
   ```
-  helm install --name elasticsearch elastic/elasticsearch
+  helm install elasticsearch elastic/elasticsearch
   ```
 
 ### Using master branch
@@ -46,7 +46,7 @@ If you currently have a cluster deployed with the [helm/charts stable](https://g
   ```
 * Install it
   ```
-  helm install --name elasticsearch ./helm-charts/elasticsearch
+  helm install elasticsearch ./helm-charts/elasticsearch
   ```
 
 ## Compatibility
@@ -62,7 +62,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Elasticsearch it would look like this:
 
 ```
-helm install --name elasticsearch elastic/elasticsearch --set imageTag=7.4.1
+helm install elasticsearch elastic/elasticsearch --set imageTag=7.4.1
 ```
 
 ## Configuration

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -23,7 +23,7 @@ This helm chart is a lightweight way to configure and run our official [Filebeat
   ```
 * Install it
   ```
-  helm install --name filebeat elastic/filebeat
+  helm install filebeat elastic/filebeat
   ```
 
 ### Using master branch
@@ -34,7 +34,7 @@ This helm chart is a lightweight way to configure and run our official [Filebeat
   ```
 * Install it
   ```
-  helm install --name filebeat ./helm-charts/filebeat
+  helm install filebeat ./helm-charts/filebeat
   ```
 
 ## Compatibility
@@ -50,7 +50,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Filebeat it would look like this:
 
 ```
-helm install --name filebeat elastic/filebeat --set imageTag=7.4.1
+helm install filebeat elastic/filebeat --set imageTag=7.4.1
 ```
 
 

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -19,7 +19,7 @@ This helm chart is a lightweight way to configure and run our official [Kibana d
   ```
 * Install it
   ```
-  helm install --name kibana elastic/kibana
+  helm install kibana elastic/kibana
   ```
 
 ### Using master branch
@@ -30,7 +30,7 @@ This helm chart is a lightweight way to configure and run our official [Kibana d
   ```
 * Install it
   ```
-  helm install --name kibana ./helm-charts/kibana
+  helm install kibana ./helm-charts/kibana
   ```
 
 ## Compatibility
@@ -46,7 +46,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Kibana it would look like this:
 
 ```
-helm install --name kibana elastic/kibana --set imageTag=7.4.1
+helm install kibana elastic/kibana --set imageTag=7.4.1
 ```
 
 ## Configuration

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -28,7 +28,7 @@ This helm chart is a lightweight way to configure and run our official [Logstash
   ```
 * Install it
   ```
-  helm install --name logstash ./helm-charts/logstash
+  helm install logstash ./helm-charts/logstash
   ```
 
 ## Compatibility
@@ -44,7 +44,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Logstash it would look like this:
 
 ```
-helm install --name logstash elastic/logstash --set imageTag=7.4.1
+helm install logstash elastic/logstash --set imageTag=7.4.1
 ```
 
 ## Configuration

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -19,7 +19,7 @@ This helm chart is a lightweight way to configure and run our official [Metricbe
   ```
 * Install it
   ```
-  helm install --name metricbeat elastic/metricbeat
+  helm install metricbeat elastic/metricbeat
   ```
 
 ### Using master branch
@@ -30,7 +30,7 @@ This helm chart is a lightweight way to configure and run our official [Metricbe
   ```
 * Install it
   ```
-  helm install --name metricbeat ./helm-charts/metricbeat
+  helm install metricbeat ./helm-charts/metricbeat
   ```
 
 ## Compatibility
@@ -46,7 +46,7 @@ Examples of installing older major versions can be found in the [examples](./exa
 While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of metricbeat it would look like this:
 
 ```
-helm install --name metricbeat elastic/metricbeat --set imageTag=7.4.1
+helm install metricbeat elastic/metricbeat --set imageTag=7.4.1
 ```
 
 


### PR DESCRIPTION
In Helm v3, the release name is now mandatory, the `--name` arguments doesn't exist anymore.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
