### PR TITLE
bump elastic stack versions to 6.8.5 and 7.4.2

### DIFF
--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   name: Elastic
 name: elasticsearch
 version: 7.4.1
-appVersion: 7.4.1
+appVersion: 7.4.2
 sources:
   - https://github.com/elastic/elasticsearch
 icon: https://helm.elastic.co/icons/elasticsearch.png

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -55,14 +55,14 @@ This chart is tested with the latest supported versions. The currently tested ve
 
 | 6.x   | 7.x   |
 | ----- | ----- |
-| 6.8.4 | 7.4.1 |
+| 6.8.5 | 7.4.2 |
 
 Examples of installing older major versions can be found in the [examples](./examples) directory.
 
-While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Elasticsearch it would look like this:
+While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.2` of Elasticsearch it would look like this:
 
 ```
-helm install --name elasticsearch elastic/elasticsearch --set imageTag=7.4.1
+helm install --name elasticsearch elastic/elasticsearch --set imageTag=7.4.2
 ```
 
 ## Configuration
@@ -83,7 +83,7 @@ helm install --name elasticsearch elastic/elasticsearch --set imageTag=7.4.1
 | `extraInitContainers`         | Templatable string of additional init containers to be passed to the `tpl` function                                                                                                                                                                                                                                        | `""`                                                                                                                      |
 | `secretMounts`                | Allows you easily mount a secret as a file inside the statefulset. Useful for mounting certificates and other secrets. See [values.yaml](./values.yaml) for an example                                                                                                                                                     | `[]`                                                                                                                      |
 | `image`                       | The Elasticsearch docker image                                                                                                                                                                                                                                                                                             | `docker.elastic.co/elasticsearch/elasticsearch`                                                                           |
-| `imageTag`                    | The Elasticsearch docker image tag                                                                                                                                                                                                                                                                                         | `7.4.1`                                                                                                                   |
+| `imageTag`                    | The Elasticsearch docker image tag                                                                                                                                                                                                                                                                                         | `7.4.2`                                                                                                                   |
 | `imagePullPolicy`             | The Kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) value                                                                                                                                                                                                             | `IfNotPresent`                                                                                                            |
 | `podAnnotations`              | Configurable [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) applied to all Elasticsearch pods                                                                                                                                                                               | `{}`                                                                                                                      |
 | `labels`                      | Configurable [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to all Elasticsearch pods                                                                                                                                                                                          | `{}`                                                                                                                      |

--- a/elasticsearch/examples/6.x/test/goss.yaml
+++ b/elasticsearch/examples/6.x/test/goss.yaml
@@ -11,7 +11,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "6.8.4"'
+      - '"number" : "6.8.5"'
       - '"cluster_name" : "six"'
       - '"name" : "six-master-0"'
       - 'You Know, for Search'

--- a/elasticsearch/examples/6.x/values.yaml
+++ b/elasticsearch/examples/6.x/values.yaml
@@ -1,4 +1,4 @@
 ---
 
 clusterName: "six"
-imageTag: "6.8.4"
+imageTag: "6.8.5"

--- a/elasticsearch/examples/default/test/goss.yaml
+++ b/elasticsearch/examples/default/test/goss.yaml
@@ -15,7 +15,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "7.4.1"'
+      - '"number" : "7.4.2"'
       - '"cluster_name" : "elasticsearch"'
       - '"name" : "elasticsearch-master-0"'
       - 'You Know, for Search'

--- a/elasticsearch/examples/openshift/test/goss.yaml
+++ b/elasticsearch/examples/openshift/test/goss.yaml
@@ -11,7 +11,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "7.4.1"'
+      - '"number" : "7.4.2"'
       - '"cluster_name" : "elasticsearch"'
       - '"name" : "elasticsearch-master-0"'
       - 'You Know, for Search'

--- a/elasticsearch/examples/oss/test/goss.yaml
+++ b/elasticsearch/examples/oss/test/goss.yaml
@@ -11,7 +11,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "7.4.1"'
+      - '"number" : "7.4.2"'
       - '"cluster_name" : "oss"'
       - '"name" : "oss-master-0"'
       - 'You Know, for Search'

--- a/elasticsearch/examples/upgrade/test/goss.yaml
+++ b/elasticsearch/examples/upgrade/test/goss.yaml
@@ -11,7 +11,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "7.4.1"'
+      - '"number" : "7.4.2"'
       - '"cluster_name" : "upgrade"'
       - '"name" : "upgrade-master-0"'
       - 'You Know, for Search'

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -43,7 +43,7 @@ secretMounts: []
 #    path: /usr/share/elasticsearch/config/certs
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "7.4.1"
+imageTag: "7.4.2"
 imagePullPolicy: "IfNotPresent"
 
 podAnnotations: {}

--- a/filebeat/Chart.yaml
+++ b/filebeat/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   name: Elastic
 name: filebeat
 version: 7.4.1
-appVersion: 7.4.1
+appVersion: 7.4.2
 sources:
   - https://github.com/elastic/beats
 icon: https://helm.elastic.co/icons/beats.png

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -43,14 +43,14 @@ This chart is tested with the latest supported versions. The currently tested ve
 
 | 6.x   | 7.x   |
 | ----- | ----- |
-| 6.8.4 | 7.4.1 |
+| 6.8.5 | 7.4.2 |
 
 Examples of installing older major versions can be found in the [examples](./examples) directory.
 
-While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Filebeat it would look like this:
+While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.2` of Filebeat it would look like this:
 
 ```
-helm install --name filebeat elastic/filebeat --set imageTag=7.4.1
+helm install --name filebeat elastic/filebeat --set imageTag=7.4.2
 ```
 
 
@@ -64,7 +64,7 @@ helm install --name filebeat elastic/filebeat --set imageTag=7.4.1
 | `hostPathRoot`           | Fully-qualified [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) that will be used to persist Filebeat registry data                                                                                                                               | `/var/lib`                                                                                                                |
 | `hostNetworking`         | Use host networking in the daemonset so that hostname is reported correctly
 | `image`                  | The Filebeat docker image                                                                                                                                                                                                                                                   | `docker.elastic.co/beats/filebeat`                                                                                        |
-| `imageTag`               | The Filebeat docker image tag                                                                                                                                                                                                                                               | `7.4.1`                                                                                                                   |
+| `imageTag`               | The Filebeat docker image tag                                                                                                                                                                                                                                               | `7.4.2`                                                                                                                   |
 | `imagePullPolicy`        | The Kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) value                                                                                                                                                              | `IfNotPresent`                                                                                                            |
 | `imagePullSecrets`       | Configuration for [imagePullSecrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) so that you can use a private registry for your image                                                        | `[]`                                                                                                                      |
 | `managedServiceAccount`  | Whether the `serviceAccount` should be managed by this helm chart. Set this to `false` in order to manage your own service account and related roles.                                                                                                                       | `true`                                                                                                                    |

--- a/filebeat/examples/6.x/test/goss.yaml
+++ b/filebeat/examples/6.x/test/goss.yaml
@@ -18,4 +18,4 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'filebeat-6.8.4'
+      - 'filebeat-6.8.5'

--- a/filebeat/examples/6.x/values.yaml
+++ b/filebeat/examples/6.x/values.yaml
@@ -1,4 +1,4 @@
-imageTag: 6.8.4
+imageTag: 6.8.5
 
 extraEnvs:
   - name: ELASTICSEARCH_HOSTS

--- a/filebeat/examples/default/test/goss.yaml
+++ b/filebeat/examples/default/test/goss.yaml
@@ -29,7 +29,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'filebeat-7.4.1'
+      - 'filebeat-7.4.2'
 
 file:
   /usr/share/filebeat/filebeat.yml:
@@ -44,4 +44,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://elasticsearch-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/filebeat/examples/oss/test/goss.yaml
+++ b/filebeat/examples/oss/test/goss.yaml
@@ -19,4 +19,4 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'filebeat-7.4.1'
+      - 'filebeat-7.4.2'

--- a/filebeat/examples/security/test/goss.yaml
+++ b/filebeat/examples/security/test/goss.yaml
@@ -3,7 +3,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'filebeat-7.4.1'
+      - 'filebeat-7.4.2'
     allow-insecure: true
     username: '{{ .Env.ELASTICSEARCH_USERNAME }}'
     password: '{{ .Env.ELASTICSEARCH_PASSWORD }}'

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -35,7 +35,7 @@ extraVolumes: []
 hostPathRoot: /var/lib
 hostNetworking: true
 image: "docker.elastic.co/beats/filebeat"
-imageTag: "7.4.1"
+imageTag: "7.4.2"
 imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 

--- a/helpers/bumper.py
+++ b/helpers/bumper.py
@@ -10,8 +10,8 @@ os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 chart_version = '7.4.1'
 
 versions = {
-    6: '6.8.4',
-    7: '7.4.1',
+    6: '6.8.5',
+    7: '7.4.2',
 }
 
 file_patterns = [

--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -1,7 +1,7 @@
 GOSS_VERSION := v0.3.6
 GOSS_FILE ?= goss.yaml
 GOSS_SELECTOR ?= release=$(RELEASE)
-STACK_VERSION := 7.4.1
+STACK_VERSION := 7.4.2
 
 goss:
 	GOSS_CONTAINER=$$(kubectl get --no-headers=true pods -l $(GOSS_SELECTOR) -o custom-columns=:metadata.name | sed -n 1p ) && \

--- a/kibana/Chart.yaml
+++ b/kibana/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   name: Elastic
 name: kibana
 version: 7.4.1
-appVersion: 7.4.1
+appVersion: 7.4.2
 sources:
   - https://github.com/elastic/kibana
 icon: https://helm.elastic.co/icons/kibana.png

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -39,14 +39,14 @@ This chart is tested with the latest supported versions. The currently tested ve
 
 | 6.x   | 7.x   |
 | ----- | ----- |
-| 6.8.4 | 7.4.1 |
+| 6.8.5 | 7.4.2 |
 
 Examples of installing older major versions can be found in the [examples](./examples) directory.
 
-While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Kibana it would look like this:
+While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.2` of Kibana it would look like this:
 
 ```
-helm install --name kibana elastic/kibana --set imageTag=7.4.1
+helm install --name kibana elastic/kibana --set imageTag=7.4.2
 ```
 
 ## Configuration
@@ -59,7 +59,7 @@ helm install --name kibana elastic/kibana --set imageTag=7.4.1
 | `extraEnvs`               | Extra [environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config) which will be appended to the `env:` definition for the container                                                                                                             | `[]`                                                                                                                      |
 | `secretMounts`            | Allows you easily mount a secret as a file inside the deployment. Useful for mounting certificates and other secrets. See [values.yaml](./values.yaml) for an example                                                                                                                                                                                          | `[]`                                                                                                                      |
 | `image`                   | The Kibana docker image                                                                                                                                                                                                                                                                                                                                        | `docker.elastic.co/kibana/kibana`                                                                                         |
-| `imageTag`                | The Kibana docker image tag                                                                                                                                                                                                                                                                                                                                    | `7.4.1`                                                                                                                   |
+| `imageTag`                | The Kibana docker image tag                                                                                                                                                                                                                                                                                                                                    | `7.4.2`                                                                                                                   |
 | `imagePullPolicy`         | The Kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) value                                                                                                                                                                                                                                                 | `IfNotPresent`                                                                                                            |
 | `podAnnotations`          | Configurable [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) applied to all Kibana pods                                                                                                                                                                                                                          | `{}`                                                                                                                      |
 | `resources`               | Allows you to set the [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) for the statefulset                                                                                                                                                                                                                   | `requests.cpu: 100m`<br>`requests.memory: 500Mi`<br>`limits.cpu: 1000m`<br>`limits.memory: 2Gi`                             |

--- a/kibana/examples/6.x/test/goss.yaml
+++ b/kibana/examples/6.x/test/goss.yaml
@@ -3,7 +3,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number":"6.8.4"'
+      - '"number":"6.8.5"'
 
   http://localhost:5601/app/kibana:
     status: 200

--- a/kibana/examples/6.x/values.yml
+++ b/kibana/examples/6.x/values.yml
@@ -1,4 +1,4 @@
 ---
 
-imageTag: 6.8.4
+imageTag: 6.8.5
 elasticsearchHosts: "http://six-master:9200"

--- a/kibana/examples/default/test/goss.yaml
+++ b/kibana/examples/default/test/goss.yaml
@@ -3,7 +3,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number":"7.4.1"'
+      - '"number":"7.4.2"'
 
   http://localhost:5601/app/kibana:
     status: 200

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -22,7 +22,7 @@ secretMounts: []
 #    subPath: kibana.keystore # optional
 
 image: "docker.elastic.co/kibana/kibana"
-imageTag: "7.4.1"
+imageTag: "7.4.2"
 imagePullPolicy: "IfNotPresent"
 
 # additionals labels

--- a/logstash/Chart.yaml
+++ b/logstash/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   name: Elastic
 name: logstash
 version: 7.4.1
-appVersion: 7.4.1
+appVersion: 7.4.2
 sources:
   - https://github.com/elastic/logstash
 icon: https://helm.elastic.co/icons/logstash.png

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -37,14 +37,14 @@ This chart is tested with the latest supported versions. The currently tested ve
 
 | 6.x   | 7.x   |
 | ----- | ----- |
-| 6.8.4 | 7.4.1 |
+| 6.8.5 | 7.4.2 |
 
 Examples of installing older major versions can be found in the [examples](./examples) directory.
 
-While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of Logstash it would look like this:
+While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.2` of Logstash it would look like this:
 
 ```
-helm install --name logstash elastic/logstash --set imageTag=7.4.1
+helm install --name logstash elastic/logstash --set imageTag=7.4.2
 ```
 
 ## Configuration
@@ -61,7 +61,7 @@ helm install --name logstash elastic/logstash --set imageTag=7.4.1
 | `image`                       | The Logstash docker image                                                                                                                                                                                                                                                                                                  | `docker.elastic.co/logstash/logstash`                                                                                     |
 | `imagePullPolicy`             | The Kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) value                                                                                                                                                                                                             | `IfNotPresent`                                                                                                            |
 | `imagePullSecrets`            | Configuration for [imagePullSecrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) so that you can use a private registry for your image                                                                                                       | `[]`                                                                                                                      |
-| `imageTag`                    | The Logstash docker image tag                                                                                                                                                                                                                                                                                              | `7.4.1`                                                                                                                   |
+| `imageTag`                    | The Logstash docker image tag                                                                                                                                                                                                                                                                                              | `7.4.2`                                                                                                                   |
 | `extraInitContainers`         | Templatable string of additional init containers to be passed to the `tpl` function                                                                                                                                                                                                                                        | `""`                                                                                                                      |
 | `httpPort`                    | The http port that Kubernetes will use for the healthchecks and the service.                                                                                                                                                                                                                                               | `9600`                                                                                                                    |
 | `labels`                      | Configurable [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to all Logstash pods                                                                                                                                                                                              | `{}`                                                                                                                      |

--- a/logstash/examples/6.x/test/goss.yaml
+++ b/logstash/examples/6.x/test/goss.yaml
@@ -10,7 +10,7 @@ http:
     timeout: 2000
     body:
       - '"host" : "helm-logstash-six-logstash-0"'
-      - '"version" : "6.8.4"'
+      - '"version" : "6.8.5"'
       - '"http_address" : "0.0.0.0:9600"'
       - '"name" : "helm-logstash-six-logstash-0"'
 

--- a/logstash/examples/6.x/values.yaml
+++ b/logstash/examples/6.x/values.yaml
@@ -1,3 +1,3 @@
 ---
 
-imageTag: "6.8.4"
+imageTag: "6.8.5"

--- a/logstash/examples/default/test/goss.yaml
+++ b/logstash/examples/default/test/goss.yaml
@@ -10,7 +10,7 @@ http:
     timeout: 2000
     body:
       - '"host" : "helm-logstash-default-logstash-0"'
-      - '"version" : "7.4.1"'
+      - '"version" : "7.4.2"'
       - '"http_address" : "0.0.0.0:9600"'
       - '"name" : "helm-logstash-default-logstash-0"'
       - '"status" : "green"'

--- a/logstash/examples/elasticsearch/test/goss.yaml
+++ b/logstash/examples/elasticsearch/test/goss.yaml
@@ -22,7 +22,7 @@ http:
     timeout: 2000
     body:
       - '"host" : "helm-logstash-elasticsearch-logstash-0"'
-      - '"version" : "7.4.1"'
+      - '"version" : "7.4.2"'
       - '"http_address" : "0.0.0.0:9600"'
       - '"name" : "helm-logstash-elasticsearch-logstash-0"'
       - '"status" : "green"'

--- a/logstash/examples/oss/test/goss.yaml
+++ b/logstash/examples/oss/test/goss.yaml
@@ -10,7 +10,7 @@ http:
     timeout: 2000
     body:
       - '"host" : "helm-logstash-oss-logstash-0"'
-      - '"version" : "7.4.1"'
+      - '"version" : "7.4.2"'
       - '"http_address" : "0.0.0.0:9600"'
       - '"name" : "helm-logstash-oss-logstash-0"'
       - '"status" : "green"'

--- a/logstash/values.yaml
+++ b/logstash/values.yaml
@@ -32,7 +32,7 @@ extraEnvs: []
 secretMounts: []
 
 image: "docker.elastic.co/logstash/logstash"
-imageTag: "7.4.1"
+imageTag: "7.4.2"
 imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 

--- a/metricbeat/Chart.yaml
+++ b/metricbeat/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   name: Elastic
 name: metricbeat
 version: 7.4.1
-appVersion: 7.4.1
+appVersion: 7.4.2
 sources:
   - https://github.com/elastic/beats
 icon: https://helm.elastic.co/icons/beats.png

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -39,14 +39,14 @@ This chart is tested with the latest supported versions. The currently tested ve
 
 | 6.x   | 7.x   |
 | ----- | ----- |
-| 6.8.4 | 7.4.1 |
+| 6.8.5 | 7.4.2 |
 
 Examples of installing older major versions can be found in the [examples](./examples) directory.
 
-While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.1` of metricbeat it would look like this:
+While only the latest releases are tested, it is possible to easily install old or new releases by overriding the `imageTag`. To install version `7.4.2` of metricbeat it would look like this:
 
 ```
-helm install --name metricbeat elastic/metricbeat --set imageTag=7.4.1
+helm install --name metricbeat elastic/metricbeat --set imageTag=7.4.2
 ```
 
 
@@ -59,7 +59,7 @@ helm install --name metricbeat elastic/metricbeat --set imageTag=7.4.1
 | `extraVolumes`           | Templatable string of additional volumes to be passed to the `tpl` function                                                                                                                                                                                                 | `""`                                                                                                                      |
 | `hostPathRoot`           | Fully-qualified [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) that will be used to persist Metricbeat registry data                                                                                                                             | `/var/lib`                                                                                                                |
 | `image`                  | The Metricbeat docker image                                                                                                                                                                                                                                                 | `docker.elastic.co/beats/metricbeat`                                                                                      |
-| `imageTag`               | The Metricbeat docker image tag                                                                                                                                                                                                                                             | `7.4.1`                                                                                                                   |
+| `imageTag`               | The Metricbeat docker image tag                                                                                                                                                                                                                                             | `7.4.2`                                                                                                                   |
 | `imagePullPolicy`        | The Kubernetes [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) value                                                                                                                                                              | `IfNotPresent`                                                                                                            |
 | `imagePullSecrets`       | Configuration for [imagePullSecrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) so that you can use a private registry for your image                                                        | `[]`                                                                                                                      |
 | `labels`                 | Configurable [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to all Metricbeat pods                                                                                                                                              | `{}`                                                                                                                      |

--- a/metricbeat/examples/6.x/test/goss-metrics.yaml
+++ b/metricbeat/examples/6.x/test/goss-metrics.yaml
@@ -21,12 +21,12 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-6.8.4'
+      - 'metricbeat-6.8.5'
   http://six-master:9200/_search?q=metricset.name:state_deployment:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-6.8.4'
+      - 'metricbeat-6.8.5'
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
@@ -40,4 +40,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://six-master:9200'
-      - 'version: 6.8.4'
+      - 'version: 6.8.5'

--- a/metricbeat/examples/6.x/test/goss.yaml
+++ b/metricbeat/examples/6.x/test/goss.yaml
@@ -29,12 +29,12 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-6.8.4'
+      - 'metricbeat-6.8.5'
   http://six-master:9200/_search?q=metricset.name:container:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-6.8.4'
+      - 'metricbeat-6.8.5'
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
@@ -48,4 +48,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://six-master:9200'
-      - 'version: 6.8.4'
+      - 'version: 6.8.5'

--- a/metricbeat/examples/6.x/values.yaml
+++ b/metricbeat/examples/6.x/values.yaml
@@ -1,4 +1,4 @@
-imageTag: 6.8.4
+imageTag: 6.8.5
 
 extraEnvs:
   - name: ELASTICSEARCH_HOSTS

--- a/metricbeat/examples/default/test/goss-metrics.yaml
+++ b/metricbeat/examples/default/test/goss-metrics.yaml
@@ -21,13 +21,13 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
 
   'http://elasticsearch-master:9200/_search?q=metricset.name:state_container%20AND%20kubernetes.container.name:metricbeat':
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
@@ -42,4 +42,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://elasticsearch-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/metricbeat/examples/default/test/goss.yaml
+++ b/metricbeat/examples/default/test/goss.yaml
@@ -29,12 +29,12 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
   'http://elasticsearch-master:9200/_search?q=metricset.name:container%20AND%20kubernetes.container.name:metricbeat':
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
@@ -49,4 +49,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://elasticsearch-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/metricbeat/examples/oss/test/goss-metrics.yaml
+++ b/metricbeat/examples/oss/test/goss-metrics.yaml
@@ -21,12 +21,12 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
   http://oss-master:9200/_search?q=metricset.name:state_deployment:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
@@ -40,4 +40,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://oss-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/metricbeat/examples/oss/test/goss.yaml
+++ b/metricbeat/examples/oss/test/goss.yaml
@@ -29,12 +29,12 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
   http://oss-master:9200/_search?q=metricset.name:container:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
@@ -48,4 +48,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: http://oss-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/metricbeat/examples/security/test/goss-metrics.yaml
+++ b/metricbeat/examples/security/test/goss-metrics.yaml
@@ -21,7 +21,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
     allow-insecure: true
     username: '{{ .Env.ELASTICSEARCH_USERNAME }}'
     password: '{{ .Env.ELASTICSEARCH_PASSWORD }}'
@@ -29,7 +29,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
     allow-insecure: true
     username: '{{ .Env.ELASTICSEARCH_USERNAME }}'
     password: '{{ .Env.ELASTICSEARCH_PASSWORD }}'
@@ -46,4 +46,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: https://security-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/metricbeat/examples/security/test/goss.yaml
+++ b/metricbeat/examples/security/test/goss.yaml
@@ -29,7 +29,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
     allow-insecure: true
     username: '{{ .Env.ELASTICSEARCH_USERNAME }}'
     password: '{{ .Env.ELASTICSEARCH_PASSWORD }}'
@@ -37,7 +37,7 @@ http:
     status: 200
     timeout: 2000
     body:
-      - 'metricbeat-7.4.1'
+      - 'metricbeat-7.4.2'
     allow-insecure: true
     username: '{{ .Env.ELASTICSEARCH_USERNAME }}'
     password: '{{ .Env.ELASTICSEARCH_PASSWORD }}'
@@ -54,4 +54,4 @@ command:
     exit-status: 0
     stdout:
       - 'elasticsearch: https://security-master:9200'
-      - 'version: 7.4.1'
+      - 'version: 7.4.2'

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -86,7 +86,7 @@ extraVolumes: []
 hostPathRoot: /var/lib
 
 image: "docker.elastic.co/beats/metricbeat"
-imageTag: "7.4.1"
+imageTag: "7.4.2"
 imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 


### PR DESCRIPTION
Update elastic stack default versions:
- 6.8.4 => 6.8.5
- 7.4.1 => 7.4.2

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
