### PR TITLE
[helm] make more explicit that helm 3 is not supported

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -6,8 +6,8 @@ This helm chart is a lightweight way to configure and run our official [Elastics
 
 ## Requirements
 
-* [Helm](https://helm.sh/) >= 2.8.0 (see parent [README](../README.md) for more details)
-* Kubernetes >= 1.8
+* [Helm](https://helm.sh/) >=2.8.0 and <3.0.0 (see parent [README](../README.md) for more details)
+* Kubernetes >=1.8
 * Minimum cluster requirements include the following to run this chart with default settings. All of these settings are configurable.
   * Three Kubernetes nodes to respect the default "hard" affinity settings
   * 1GB of RAM for the JVM heap

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -6,8 +6,8 @@ This helm chart is a lightweight way to configure and run our official [Filebeat
 
 ## Requirements
 
-* Kubernetes >= 1.9
-* [Helm](https://helm.sh/) >= 2.8.0 (see parent [README](../README.md) for more details)
+* [Helm](https://helm.sh/) >=2.8.0 and <3.0.0 (see parent [README](../README.md) for more details)
+* Kubernetes >=1.9
 
 ## Usage notes and getting started
 * The default Filebeat configuration file for this chart is configured to use an Elasticsearch endpoint. Without any additional changes, Filebeat will send documents to the service URL that the Elasticsearch helm chart sets up by default. You may either set the `ELASTICSEARCH_HOSTS` environment variable in `extraEnvs` to override this endpoint or modify the default `filebeatConfig` to change this behavior.

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -6,8 +6,8 @@ This helm chart is a lightweight way to configure and run our official [Kibana d
 
 ## Requirements
 
-* Kubernetes >= 1.9
-* [Helm](https://helm.sh/) >= 2.8.0 (see parent [README](../README.md) for more details)
+* [Helm](https://helm.sh/) >=2.8.0 and <3.0.0 (see parent [README](../README.md) for more details)
+* Kubernetes >=1.9
 
 ## Installing
 

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -6,8 +6,8 @@ This helm chart is a lightweight way to configure and run our official [Logstash
 
 ## Requirements
 
-* [Helm](https://helm.sh/) >= 2.8.0 (see parent [README](../README.md) for more details)
-* Kubernetes >= 1.8
+* [Helm](https://helm.sh/) >=2.8.0 and <3.0.0 (see parent [README](../README.md) for more details)
+* Kubernetes >=1.8
 
 ## Usage notes and getting started
 

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -20,8 +20,8 @@ The workaround is to use `--force` argument for `helm upgrade` command which wil
 
 ## Requirements
 
-* Kubernetes >= 1.9
-* [Helm](https://helm.sh/) >= 2.8.0 (see parent [README](../README.md) for more details)
+* [Helm](https://helm.sh/) >=2.8.0 and <3.0.0 (see parent [README](../README.md) for more details)
+* Kubernetes >=1.9
 
 ## Installing
 


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
