### PR TITLE
Remove in_cluster config from add_kubernetes_metadata

### DIFF
--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -8,8 +8,7 @@ filebeatConfig:
       containers.ids:
       - '*'
       processors:
-      - add_kubernetes_metadata:
-          in_cluster: true
+      - add_kubernetes_metadata: ~
 
     output.elasticsearch:
       host: '${NODE_NAME}'


### PR DESCRIPTION
This PR removes `in_cluster` config from Filebeat's `add_kubernetes_metadata` processor.
This configuration was removed by https://github.com/elastic/beats/pull/13051 and https://github.com/elastic/beats/pull/13651

cc: @exekias 