### PR TITLE
Prefixed helper functions with chart name

### DIFF
--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Watch all cluster members come up.
-  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "uname" . }} -w
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "elasticsearch.uname" . }} -w
 2. Test cluster health using Helm test.
   $ helm test {{ .Release.Name }}

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "elasticsearch.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,16 +10,16 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "elasticsearch.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "uname" -}}
+{{- define "elasticsearch.uname" -}}
 {{ .Values.clusterName }}-{{ .Values.nodeGroup }}
 {{- end -}}
 
-{{- define "masterService" -}}
+{{- define "elasticsearch.masterService" -}}
 {{- if empty .Values.masterService -}}
 {{ .Values.clusterName }}-master
 {{- else -}}
@@ -27,7 +27,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{- define "endpoints" -}}
+{{- define "elasticsearch.endpoints" -}}
 {{- $replicas := int (toString (.Values.replicas)) }}
 {{- $uname := printf "%s-%s" .Values.clusterName .Values.nodeGroup }}
   {{- range $i, $e := untilStep 0 $replicas 1 -}}
@@ -35,7 +35,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 
-{{- define "esMajorVersion" -}}
+{{- define "elasticsearch.esMajorVersion" -}}
 {{- if .Values.esMajorVersion -}}
 {{ .Values.esMajorVersion }}
 {{- else -}}

--- a/elasticsearch/templates/configmap.yaml
+++ b/elasticsearch/templates/configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "uname" . }}-config
+  name: {{ template "elasticsearch.uname" . }}-config
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
-    app: "{{ template "uname" . }}"
+    app: "{{ template "elasticsearch.uname" . }}"
 data:
 {{- range $path, $config := .Values.esConfig }}
   {{ $path }}: |

--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "uname" . -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
 {{- $servicePort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: {{ template "elasticsearch.ingress.apiVersion" . }}

--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -3,10 +3,10 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: "{{ template "uname" . }}-pdb"
+  name: "{{ template "elasticsearch.uname" . }}-pdb"
 spec:
   maxUnavailable: {{ .Values.maxUnavailable }}
   selector:
     matchLabels:
-      app: "{{ template "uname" . }}"
+      app: "{{ template "elasticsearch.uname" . }}"
 {{- end }}

--- a/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.create -}}
-{{- $fullName := include "uname" . -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/elasticsearch/templates/role.yaml
+++ b/elasticsearch/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- $fullName := include "uname" . -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/elasticsearch/templates/rolebinding.yaml
+++ b/elasticsearch/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- $fullName := include "uname" . -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -2,12 +2,12 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "uname" . }}
+  name: {{ template "elasticsearch.uname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
-    app: "{{ template "uname" . }}"
+    app: "{{ template "elasticsearch.uname" . }}"
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4}}
 {{- end }}
@@ -19,7 +19,7 @@ spec:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
-    app: "{{ template "uname" . }}"
+    app: "{{ template "elasticsearch.uname" . }}"
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     protocol: TCP
@@ -34,12 +34,12 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "uname" . }}-headless
+  name: {{ template "elasticsearch.uname" . }}-headless
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
-    app: "{{ template "uname" . }}"
+    app: "{{ template "elasticsearch.uname" . }}"
 {{- if .Values.service.labelsHeadless }}
 {{ toYaml .Values.service.labelsHeadless | indent 4 }}
 {{- end }}
@@ -50,7 +50,7 @@ spec:
   # Create endpoints also if the related pod isn't ready
   publishNotReadyAddresses: true
   selector:
-    app: "{{ template "uname" . }}"
+    app: "{{ template "elasticsearch.uname" . }}"
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     port: {{ .Values.httpPort }}

--- a/elasticsearch/templates/serviceaccount.yaml
+++ b/elasticsearch/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- $fullName := include "uname" . -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -2,22 +2,22 @@
 apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
-  name: {{ template "uname" . }}
+  name: {{ template "elasticsearch.uname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
-    app: "{{ template "uname" . }}"
+    app: "{{ template "elasticsearch.uname" . }}"
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   annotations:
-    esMajorVersion: "{{ include "esMajorVersion" . }}"
+    esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"
 spec:
-  serviceName: {{ template "uname" . }}-headless
+  serviceName: {{ template "elasticsearch.uname" . }}-headless
   selector:
     matchLabels:
-      app: "{{ template "uname" . }}"
+      app: "{{ template "elasticsearch.uname" . }}"
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
@@ -25,7 +25,7 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ template "uname" . }}
+      name: {{ template "elasticsearch.uname" . }}
     {{- with .Values.persistence.annotations  }}
       annotations:
 {{ toYaml . | indent 8 }}
@@ -35,15 +35,16 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: "{{ template "uname" . }}"
+      name: "{{ template "elasticsearch.uname" . }}"
       labels:
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: "{{ .Chart.Name }}"
-        app: "{{ template "uname" . }}"
+        app: "{{ template "elasticsearch.uname" . }}"
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+        app: "{{ template "elasticsearch.uname" . }}"
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -62,7 +63,7 @@ spec:
         fsGroup: {{ .Values.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
         {{- end }}
       {{- if .Values.rbac.create }}
-      serviceAccountName: "{{ template "uname" . }}"
+      serviceAccountName: "{{ template "elasticsearch.uname" . }}"
       {{- else if not (eq .Values.rbac.serviceAccountName "") }}
       serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
       {{- end }}
@@ -88,7 +89,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - "{{ template "uname" .}}"
+                - "{{ template "elasticsearch.uname" .}}"
             topologyKey: {{ .Values.antiAffinityTopologyKey }}
       {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
@@ -101,7 +102,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - "{{ template "uname" . }}"
+                  - "{{ template "elasticsearch.uname" . }}"
       {{- end }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:
@@ -117,7 +118,7 @@ spec:
         {{- if .Values.esConfig }}
         - name: esconfig
           configMap:
-            name: {{ template "uname" . }}-config
+            name: {{ template "elasticsearch.uname" . }}-config
         {{- end }}
 {{- if .Values.keystore }}
         - name: keystore
@@ -186,7 +187,7 @@ spec:
 {{ tpl .Values.extraInitContainers . | indent 6 }}
       {{- end }}
       containers:
-      - name: "{{ template "name" . }}"
+      - name: "{{ template "elasticsearch.name" . }}"
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -239,20 +240,20 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           {{- if eq .Values.roles.master "true" }}
-          {{- if ge (int (include "esMajorVersion" .)) 7 }}
+          {{- if ge (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: cluster.initial_master_nodes
-            value: "{{ template "endpoints" . }}"
+            value: "{{ template "elasticsearch.endpoints" . }}"
           {{- else }}
           - name: discovery.zen.minimum_master_nodes
             value: "{{ .Values.minimumMasterNodes }}"
           {{- end }}
           {{- end }}
-          {{- if lt (int (include "esMajorVersion" .)) 7 }}
+          {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts
-            value: "{{ template "masterService" . }}-headless"
+            value: "{{ template "elasticsearch.masterService" . }}-headless"
           {{- else }}
           - name: discovery.seed_hosts
-            value: "{{ template "masterService" . }}-headless"
+            value: "{{ template "elasticsearch.masterService" . }}-headless"
           {{- end }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"
@@ -269,7 +270,7 @@ spec:
 {{- end }}
         volumeMounts:
           {{- if .Values.persistence.enabled }}
-          - name: "{{ template "uname" . }}"
+          - name: "{{ template "elasticsearch.uname" . }}"
             mountPath: /usr/share/elasticsearch/data
           {{- end }}
 {{ if .Values.keystore }}
@@ -313,13 +314,13 @@ spec:
               else
                 BASIC_AUTH=''
               fi
-              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "masterService" . }}:{{ .Values.httpPort }}${path}
+              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "elasticsearch.masterService" . }}:{{ .Values.httpPort }}${path}
           }
 
           cleanup () {
             while true ; do
               local master="$(http "/_cat/master?h=node" || echo "")"
-              if [[ $master == "{{ template "masterService" . }}"* && $master != "${NODE_NAME}" ]]; then
+              if [[ $master == "{{ template "elasticsearch.masterService" . }}"* && $master != "${NODE_NAME}" ]]; then
                 echo "This node is not master."
                 break
               fi

--- a/elasticsearch/templates/test/test-elasticsearch-health.yaml
+++ b/elasticsearch/templates/test/test-elasticsearch-health.yaml
@@ -14,5 +14,5 @@ spec:
       - "-c"
       - |
         #!/usr/bin/env bash -e
-        curl -XGET --fail '{{ template "uname" . }}:{{ .Values.httpPort }}/_cluster/health?{{ .Values.clusterHealthCheckParams }}'
+        curl -XGET --fail '{{ template "elasticsearch.uname" . }}:{{ .Values.httpPort }}/_cluster/health?{{ .Values.clusterHealthCheckParams }}'
   restartPolicy: Never

--- a/filebeat/templates/NOTES.txt
+++ b/filebeat/templates/NOTES.txt
@@ -1,2 +1,2 @@
 1. Watch all containers come up.
-  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "fullname" . }} -w
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "filebeat.fullname" . }} -w

--- a/filebeat/templates/_helpers.tpl
+++ b/filebeat/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "filebeat.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "filebeat.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Use the fullname if the serviceAccount value is not set
 */}}
-{{- define "serviceAccount" -}}
+{{- define "filebeat.serviceAccount" -}}
 {{- if .Values.serviceAccount }}
 {{- .Values.serviceAccount -}}
 {{- else }}

--- a/filebeat/templates/clusterrole.yaml
+++ b/filebeat/templates/clusterrole.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "serviceAccount" . }}-cluster-role
+  name: {{ template "filebeat.serviceAccount" . }}-cluster-role
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "filebeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/filebeat/templates/clusterrolebinding.yaml
+++ b/filebeat/templates/clusterrolebinding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "serviceAccount" . }}-cluster-role-binding
+  name: {{ template "filebeat.serviceAccount" . }}-cluster-role-binding
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "filebeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "serviceAccount" . }}-cluster-role
+  name: {{ template "filebeat.serviceAccount" . }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ template "serviceAccount" . }}
+  name: {{ template "filebeat.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/filebeat/templates/configmap.yaml
+++ b/filebeat/templates/configmap.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ template "filebeat.fullname" . }}-config
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "filebeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "filebeat.fullname" . }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "filebeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: "{{ template "fullname" . }}"
+      app: "{{ template "filebeat.fullname" . }}"
       release: {{ .Release.Name | quote }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
@@ -28,9 +28,9 @@ spec:
         {{- if .Values.filebeatConfig }}
         configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
-      name: "{{ template "fullname" . }}"
+      name: "{{ template "filebeat.fullname" . }}"
       labels:
-        app: "{{ template "fullname" . }}"
+        app: "{{ template "filebeat.fullname" . }}"
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
@@ -47,7 +47,7 @@ spec:
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 -}}
       {{- end }}
-      serviceAccountName: {{ template "serviceAccount" . }}
+      serviceAccountName: {{ template "filebeat.serviceAccount" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
       {{- if .Values.hostNetworking }}
       hostNetwork: true
@@ -63,11 +63,11 @@ spec:
       - name: filebeat-config
         configMap:
           defaultMode: 0600
-          name: {{ template "fullname" . }}-config
+          name: {{ template "filebeat.fullname" . }}-config
       {{- end }}
       - name: data
         hostPath:
-          path: {{ .Values.hostPathRoot }}/{{ template "fullname" . }}-{{ .Release.Namespace }}-data
+          path: {{ .Values.hostPathRoot }}/{{ template "filebeat.fullname" . }}-{{ .Release.Namespace }}-data
           type: DirectoryOrCreate
       - name: varlibdockercontainers
         hostPath:

--- a/filebeat/templates/serviceaccount.yaml
+++ b/filebeat/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "serviceAccount" . }}
+  name: {{ template "filebeat.serviceAccount" . }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "filebeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "kibana.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "kibana.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/kibana/templates/configmap.yaml
+++ b/kibana/templates/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ template "kibana.fullname" . }}-config
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name | quote }}

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "kibana.fullname" . }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name | quote }}
@@ -47,7 +47,7 @@ spec:
         {{- if .Values.kibanaConfig }}
         - name: kibanaconfig
           configMap:
-            name: {{ template "fullname" . }}-config
+            name: {{ template "kibana.fullname" . }}-config
         {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/kibana/templates/ingress.yaml
+++ b/kibana/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "fullname" . -}}
+{{- $fullName := include "kibana.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: {{ template "kibana.ingress.apiVersion" . }}

--- a/kibana/templates/service.yaml
+++ b/kibana/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "kibana.fullname" . }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/NOTES.txt
+++ b/logstash/templates/NOTES.txt
@@ -1,2 +1,2 @@
 1. Watch all cluster members come up.
-  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "fullname" . }} -w
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "logstash.fullname" . }} -w

--- a/logstash/templates/_helpers.tpl
+++ b/logstash/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "logstash.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "logstash.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/logstash/templates/configmap-config.yaml
+++ b/logstash/templates/configmap-config.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ template "logstash.fullname" . }}-config
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/configmap-pipeline.yaml
+++ b/logstash/templates/configmap-pipeline.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-pipeline
+  name: {{ template "logstash.fullname" . }}-pipeline
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/poddisruptionbudget.yaml
+++ b/logstash/templates/poddisruptionbudget.yaml
@@ -3,9 +3,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: "{{ template "fullname" . }}-pdb"
+  name: "{{ template "logstash.fullname" . }}-pdb"
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -13,5 +13,5 @@ spec:
   maxUnavailable: {{ .Values.maxUnavailable }}
   selector:
     matchLabels:
-      app: "{{ template "fullname" . }}"
+      app: "{{ template "logstash.fullname" . }}"
 {{- end }}

--- a/logstash/templates/podsecuritypolicy.yaml
+++ b/logstash/templates/podsecuritypolicy.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.podSecurityPolicy.create -}}
-{{- $fullName := include "fullname" . -}}
+{{- $fullName := include "logstash.fullname" . -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/role.yaml
+++ b/logstash/templates/role.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.rbac.create -}}
-{{- $fullName := include "fullname" . -}}
+{{- $fullName := include "logstash.fullname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $fullName | quote }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/rolebinding.yaml
+++ b/logstash/templates/rolebinding.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.rbac.create -}}
-{{- $fullName := include "fullname" . -}}
+{{- $fullName := include "logstash.fullname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $fullName | quote }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/service.yaml
+++ b/logstash/templates/service.yaml
@@ -3,9 +3,9 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: "{{ template "fullname" . }}"
+  name: "{{ template "logstash.fullname" . }}"
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/serviceaccount.yaml
+++ b/logstash/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- $fullName := include "fullname" . -}}
+{{- $fullName := include "logstash.fullname" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,7 +9,7 @@ metadata:
   name: {{ .Values.rbac.serviceAccountName | quote }}
   {{- end }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/logstash/templates/statefulset.yaml
+++ b/logstash/templates/statefulset.yaml
@@ -2,9 +2,9 @@
 apiVersion: {{ template "logstash.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "logstash.fullname" . }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -13,11 +13,11 @@ metadata:
     {{- end }}
 spec:
   {{- if .Values.service }}
-  serviceName: {{ template "fullname" . }}
+  serviceName: {{ template "logstash.fullname" . }}
   {{- end }}
   selector:
     matchLabels:
-      app: "{{ template "fullname" . }}"
+      app: "{{ template "logstash.fullname" . }}"
       release: {{ .Release.Name | quote }}
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
@@ -26,7 +26,7 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ template "fullname" . }}
+      name: {{ template "logstash.fullname" . }}
     {{- with .Values.persistence.annotations  }}
       annotations:
 {{ toYaml . | indent 8 }}
@@ -36,9 +36,9 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: "{{ template "fullname" . }}"
+      name: "{{ template "logstash.fullname" . }}"
       labels:
-        app: "{{ template "fullname" . }}"
+        app: "{{ template "logstash.fullname" . }}"
         chart: "{{ .Chart.Name }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
@@ -61,7 +61,7 @@ spec:
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
       {{- if .Values.rbac.create }}
-      serviceAccountName: "{{ template "fullname" . }}"
+      serviceAccountName: "{{ template "logstash.fullname" . }}"
       {{- else if not (eq .Values.rbac.serviceAccountName "") }}
       serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
       {{- end }}
@@ -87,7 +87,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - "{{ template "fullname" .}}"
+                - "{{ template "logstash.fullname" .}}"
             topologyKey: {{ .Values.antiAffinityTopologyKey }}
       {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
@@ -100,7 +100,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - "{{ template "fullname" . }}"
+                  - "{{ template "logstash.fullname" . }}"
       {{- end }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:
@@ -116,12 +116,12 @@ spec:
         {{- if .Values.logstashConfig }}
         - name: logstashconfig
           configMap:
-            name: {{ template "fullname" . }}-config
+            name: {{ template "logstash.fullname" . }}-config
         {{- end }}
         {{- if .Values.logstashPipeline }}
         - name: logstashpipeline
           configMap:
-            name: {{ template "fullname" . }}-pipeline
+            name: {{ template "logstash.fullname" . }}-pipeline
         {{- end }}
       {{- if .Values.extraVolumes }}
 {{ tpl .Values.extraVolumes . | indent 8 }}
@@ -135,7 +135,7 @@ spec:
 {{ tpl .Values.extraInitContainers . | indent 6 }}
       {{- end }}
       containers:
-      - name: "{{ template "name" . }}"
+      - name: "{{ template "logstash.name" . }}"
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -157,7 +157,7 @@ spec:
 {{- end }}
         volumeMounts:
           {{- if .Values.persistence.enabled }}
-          - name: "{{ template "fullname" . }}"
+          - name: "{{ template "logstash.fullname" . }}"
             mountPath: /usr/share/logstash/data
           {{- end }}
           {{- range .Values.secretMounts }}

--- a/metricbeat/templates/NOTES.txt
+++ b/metricbeat/templates/NOTES.txt
@@ -1,2 +1,2 @@
 1. Watch all containers come up.
-  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "fullname" . }} -w
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "metricbeat.fullname" . }} -w

--- a/metricbeat/templates/_helpers.tpl
+++ b/metricbeat/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "metricbeat.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "metricbeat.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Use the fullname if the serviceAccount value is not set
 */}}
-{{- define "serviceAccount" -}}
+{{- define "metricbeat.serviceAccount" -}}
 {{- if .Values.serviceAccount }}
 {{- .Values.serviceAccount -}}
 {{- else }}

--- a/metricbeat/templates/clusterrole.yaml
+++ b/metricbeat/templates/clusterrole.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "serviceAccount" . }}-cluster-role
+  name: {{ template "metricbeat.serviceAccount" . }}-cluster-role
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "metricbeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/metricbeat/templates/clusterrolebinding.yaml
+++ b/metricbeat/templates/clusterrolebinding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "serviceAccount" . }}-cluster-role-binding
+  name: {{ template "metricbeat.serviceAccount" . }}-cluster-role-binding
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "metricbeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "serviceAccount" . }}-cluster-role
+  name: {{ template "metricbeat.serviceAccount" . }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ template "serviceAccount" . }}
+  name: {{ template "metricbeat.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/metricbeat/templates/configmap.yaml
+++ b/metricbeat/templates/configmap.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ template "metricbeat.fullname" . }}-config
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "metricbeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "metricbeat.fullname" . }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "metricbeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: "{{ template "fullname" . }}"
+      app: "{{ template "metricbeat.fullname" . }}"
       release: {{ .Release.Name | quote }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
@@ -28,9 +28,9 @@ spec:
         {{- if .Values.metricbeatConfig }}
         configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
-      name: "{{ template "fullname" . }}"
+      name: "{{ template "metricbeat.fullname" . }}"
       labels:
-        app: "{{ template "fullname" . }}"
+        app: "{{ template "metricbeat.fullname" . }}"
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
@@ -44,7 +44,7 @@ spec:
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 -}}
       {{- end }}
-      serviceAccountName: {{ template "serviceAccount" . }}
+      serviceAccountName: {{ template "metricbeat.serviceAccount" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
       volumes:
       {{- range .Values.secretMounts }}
@@ -56,11 +56,11 @@ spec:
       - name: metricbeat-config
         configMap:
           defaultMode: 0600
-          name: {{ template "fullname" . }}-config
+          name: {{ template "metricbeat.fullname" . }}-config
       {{- end }}
       - name: data
         hostPath:
-          path: {{ .Values.hostPathRoot }}/{{ template "fullname" . }}-{{ .Release.Namespace }}-data
+          path: {{ .Values.hostPathRoot }}/{{ template "metricbeat.fullname" . }}-{{ .Release.Namespace }}-data
           type: DirectoryOrCreate
       - name: varlibdockercontainers
         hostPath:

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: '{{ template "fullname" . }}-metrics'
+  name: '{{ template "metricbeat.fullname" . }}-metrics'
   labels:
-    app: '{{ template "fullname" . }}-metrics'
+    app: '{{ template "metricbeat.fullname" . }}-metrics'
     chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
@@ -12,7 +12,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: '{{ template "fullname" . }}-metrics'
+      app: '{{ template "metricbeat.fullname" . }}-metrics'
       chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
       heritage: '{{ .Release.Service }}'
       release: '{{ .Release.Name }}'
@@ -27,7 +27,7 @@ spec:
         configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
       labels:
-        app: '{{ template "fullname" . }}-metrics'
+        app: '{{ template "metricbeat.fullname" . }}-metrics'
         chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
@@ -36,7 +36,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 6 }}
       {{- end }}
-      serviceAccountName: {{ template "serviceAccount" . }}
+      serviceAccountName: {{ template "metricbeat.serviceAccount" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
       volumes:
       {{- range .Values.secretMounts }}
@@ -48,7 +48,7 @@ spec:
       - name: metricbeat-config
         configMap:
           defaultMode: 0600
-          name: {{ template "fullname" . }}-config
+          name: {{ template "metricbeat.fullname" . }}-config
       {{- end }}
       {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 6 }}

--- a/metricbeat/templates/serviceaccount.yaml
+++ b/metricbeat/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "serviceAccount" . }}
+  name: {{ template "metricbeat.serviceAccount" . }}
   labels:
-    app: "{{ template "fullname" . }}"
+    app: "{{ template "metricbeat.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}


### PR DESCRIPTION
It is a best practice to prefix helm template helper functions with the chart name. Since template functions are global, this can lead to bugs because the last function to be loaded will be used. The best solution is to prefix the template function with the chart name.

See [Named Tempaltes](https://helm.sh/docs/topics/chart_template_guide/named_templates/)

- [ *] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
