### PR TITLE
Use details tag around code backticks for 'helm get' output in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,13 @@ e.g. `helm get elasticsearch` (replace `elasticsearch` with the name of your hel
 
 *If you find some secrets in plain text in `helm get release` output you should use [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to managed them is a secure way (see [Security Example](https://github.com/elastic/helm-charts/blob/master/elasticsearch/examples/security/security.yml#L23-L38)).*
 
+<details>
+<summary>Output of helm get release</summary>
+
 ```
 ```
+
+</details>
 
 **Describe the bug:**
 


### PR DESCRIPTION
The output can be quite long and long output clutters up the issue description.

Note that the empty line is necessary in order for the code to be parsed correctly (see https://github.com/dear-github/dear-github/issues/166#issuecomment-322367328 for details).

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
