### PR TITLE
Add custom labels to pods

### DIFF
--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 6 }}

--- a/filebeat/tests/filebeat_test.py
+++ b/filebeat/tests/filebeat_test.py
@@ -88,12 +88,12 @@ updateStrategy: OnDelete
 
 def test_host_networking():
     config = '''
-hostNetworking: true    
+hostNetworking: true
 '''
     r = helm_template(config)
     assert r['daemonset'][name]['spec']['template']['spec']['hostNetwork'] is True
     config = '''
-hostNetworking: false    
+hostNetworking: false
 '''
     r = helm_template(config)
     assert 'hostNetwork' not in r['daemonset'][name]['spec']['template']['spec']
@@ -201,6 +201,7 @@ labels:
 '''
     r = helm_template(config)
     assert r['daemonset'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'filebeat'
+    assert r['daemonset'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'filebeat'
 
 
 def test_adding_a_node_selector():

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         app: kibana
         release: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -380,6 +380,7 @@ labels:
 '''
      r = helm_template(config)
      assert r['deployment'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'kibana'
+     assert r['deployment'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'kibana'
 
 def test_adding_a_secret_mount_with_subpath():
     config = '''

--- a/logstash/templates/statefulset.yaml
+++ b/logstash/templates/statefulset.yaml
@@ -42,6 +42,9 @@ spec:
         chart: "{{ .Chart.Name }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -480,6 +480,7 @@ labels:
 '''
     r = helm_template(config)
     assert r['statefulset'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'logstash'
+    assert r['statefulset'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'logstash'
 
 
 def test_pod_security_policy():

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 6 }}

--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -238,6 +238,7 @@ labels:
 '''
     r = helm_template(config)
     assert r['daemonset'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'metricbeat'
+    assert r['daemonset'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'metricbeat'
 
 def test_setting_fullnameOverride():
     config = '''


### PR DESCRIPTION
Propagate custom labels to all pods for filebeat, kibana, logstash & metricbeat
Related to #383
Fix #384

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`