### PR TITLE
[filebeat|metricbeat] Override probes commands

### DIFF
--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -94,22 +94,8 @@ spec:
         - "-E"
         - "http.enabled=true"
         livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - |
-              #!/usr/bin/env bash -e
-              curl --fail 127.0.0.1:5066
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - |
-              #!/usr/bin/env bash -e
-              filebeat test output
 {{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -39,12 +39,26 @@ imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 
 livenessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        curl --fail 127.0.0.1:5066
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
 
 readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        filebeat test output
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -93,22 +93,8 @@ spec:
         - "-E"
         - "http.enabled=true"
         livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - |
-              #!/usr/bin/env bash -e
-              curl --fail 127.0.0.1:5066
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - |
-              #!/usr/bin/env bash -e
-              metricbeat test output
 {{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -68,21 +68,8 @@ spec:
           - "-E"
           - "http.enabled=true"
         livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - |
-              #!/usr/bin/env bash -e
-              curl --fail 127.0.0.1:5066
+{{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - |
-              #!/usr/bin/env bash -e
-              metricbeat test output
 {{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -91,12 +91,26 @@ imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 
 livenessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        curl --fail 127.0.0.1:5066
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
 
 readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        metricbeat test output
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10


### PR DESCRIPTION
Some outputs can't be tested using `filebeat test output` or `metricbeat test output` commands.

Having these commands hardcoded in `ReadinessProbe` prevent to use Filebeat / Metricbeat with outputs which haven't implemented the test command.

Fix #316 and #325 
