### PR TITLE
Add an example, tests and README.md hints for installation of filebeat on a single node cluster implementation

### DIFF
--- a/filebeat/examples/microk8s/Makefile
+++ b/filebeat/examples/microk8s/Makefile
@@ -1,0 +1,13 @@
+default: test
+
+include ../../../helpers/examples.mk
+
+RELEASE := helm-filebeat-default
+
+install:
+	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+
+test: install goss
+
+purge:
+	helm del --purge $(RELEASE)

--- a/filebeat/examples/microk8s/test/goss.yaml
+++ b/filebeat/examples/microk8s/test/goss.yaml
@@ -1,0 +1,51 @@
+port:
+  tcp:5066:
+    listening: true
+    ip:
+    - '127.0.0.1'
+
+mount:
+  /usr/share/filebeat/data:
+    exists: true
+  /run/docker.sock:
+    exists: true
+  /var/lib/docker/containers:
+    exists: true
+    opts:
+      - ro
+  /var/log:
+    exists: true
+    opts:
+      - ro
+  /usr/share/filebeat/filebeat.yml:
+    exists: true
+    opts:
+      - ro
+
+user:
+  filebeat:
+    exists: true
+    uid: 1000
+    gid: 1000
+
+http:
+  http://elasticsearch-master:9200/_cat/indices:
+    status: 200
+    timeout: 2000
+    body:
+      - 'filebeat-7.5.1'
+
+file:
+  /usr/share/filebeat/filebeat.yml:
+    exists: true
+    contains:
+      - 'add_kubernetes_metadata'
+      - 'output.elasticsearch'
+      - 'elasticsearch-master:9200'
+
+command:
+  cd /usr/share/filebeat && filebeat test output:
+    exit-status: 0
+    stdout:
+      - 'elasticsearch: http://elasticsearch-master:9200'
+      - 'version: 7.5.1'

--- a/filebeat/examples/microk8s/values.yaml
+++ b/filebeat/examples/microk8s/values.yaml
@@ -1,0 +1,10 @@
+extraVolumeMounts:
+  - name: varlog
+    mountPath: /var/log/
+    readOnly: true
+
+extraVolumes:
+  - name: varlog
+    hostPath:
+      path: /var/log/
+      type: ''


### PR DESCRIPTION


- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
