### PR TITLE
[elasticsearch]  add workaround to fix kind example

### DIFF
--- a/elasticsearch/examples/kubernetes-kind/Makefile
+++ b/elasticsearch/examples/kubernetes-kind/Makefile
@@ -3,6 +3,7 @@ default: test
 RELEASE := helm-es-kind
 
 install:
+	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
 
 test: install

--- a/elasticsearch/examples/kubernetes-kind/README.md
+++ b/elasticsearch/examples/kubernetes-kind/README.md
@@ -1,0 +1,21 @@
+# KIND
+
+An example of configuration for deploying Elasticsearch chart on [Kind][].
+
+You can use `make install` to deploy it.
+
+Note that this configuration should be used for test only and isn't recommended
+for production.
+
+## Current issue
+
+There is currently an [kind issue][] with mount points created from PVCs not writeable by non-root users.
+[kubernetes-sigs/kind#1157][] should fix it in a future release.
+
+Meanwhile, the workaround is to install manually [Rancher Local Path Provisioner][] and use `local-path` storage class for Elasticsearch volumes (see [Makefile][] instructions).
+
+[Kind]: https://kind.sigs.k8s.io/
+[Kind issue]: https://github.com/kubernetes-sigs/kind/issues/830
+[Kubernetes-sigs/kind#1157]: https://github.com/kubernetes-sigs/kind/pull/1157
+[Rancher Local Path Provisioner]: https://github.com/rancher/local-path-provisioner
+[Makefile]: ./Makefile#L5

--- a/elasticsearch/examples/kubernetes-kind/values.yaml
+++ b/elasticsearch/examples/kubernetes-kind/values.yaml
@@ -17,20 +17,7 @@ resources:
 # Request smaller persistent volumes.
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "local-path"
   resources:
     requests:
       storage: 100M
-extraInitContainers: |
-  - name: create
-    image: busybox:1.28
-    command: ['mkdir', '/usr/share/elasticsearch/data/nodes/']
-    volumeMounts:
-    - mountPath: /usr/share/elasticsearch/data
-      name: elasticsearch-master
-  - name: file-permissions
-    image: busybox:1.28
-    command: ['chown', '-R', '1000:1000', '/usr/share/elasticsearch/']
-    volumeMounts:
-    - mountPath: /usr/share/elasticsearch/data
-      name: elasticsearch-master
-


### PR DESCRIPTION
Add workaround to fix kind mount points created from PVCs not writeable by non-root users issue.

FIx #429