### PR TITLE
Elasticsearch: do not include heritage selector

### DIFF
--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -20,7 +20,6 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"


### PR DESCRIPTION
According to https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md, service selector should not contain heritage.

It would break (future) migration from helm 2 to helm 3 (during the rolling update only, there could be a downtime when only old nodes with old labels are ready but service has been updated to new selector).

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
