### PR TITLE
Add commented out example of a useful post start hook

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -233,7 +233,19 @@ lifecycle: {}
   #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
   # postStart:
   #   exec:
-  #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+  #     command:
+  #       - bash
+  #       - -c
+  #       - |
+  #         #!/bin/bash
+  #         # Add a template to adjust number of shards/replicas
+  #         TEMPLATE_NAME=my_template
+  #         INDEX_PATTERN="logstash-*"
+  #         SHARD_COUNT=8
+  #         REPLICA_COUNT=1
+  #         ES_URL=http://localhost:9200
+  #         while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
+  #         curl -XPUT "$ES_URL/_template/$TEMPLATE_NAME" -H 'Content-Type: application/json' -d'{"index_patterns":['\""$INDEX_PATTERN"\"'],"settings":{"number_of_shards":'$SHARD_COUNT',"number_of_replicas":'$REPLICA_COUNT'}}'
 
 sysctlInitContainer:
   enabled: true


### PR DESCRIPTION
This post start lifecycle hook will configure templates if not using logstash/filebeat, but rather something does not support managing templates (at the time of this commit) such as fluent bit.

Will come  in handy for others to have it commented out there.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [n/a] README.md updated with any new values or changes
- [n/a] Updated template tests in `${CHART}/tests/*.py` 
- [n/a] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
