### PR TITLE
[elasticsearch] add hat-chart example for hot-cold architecture.

### DIFF
--- a/elasticsearch/examples/hot-cold/Chart.yaml
+++ b/elasticsearch/examples/hot-cold/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: Elasticsearch Hot Cold Example
+home: https://github.com/elastic/helm-charts
+name: elasticsearch-host-cold
+version: 1.0.0
+sources:
+  - https://github.com/elastic/elasticsearch

--- a/elasticsearch/examples/hot-cold/Makefile
+++ b/elasticsearch/examples/hot-cold/Makefile
@@ -1,0 +1,15 @@
+default: test
+
+include ../../../helpers/examples.mk
+
+RELEASE := helm-es-hot-cold
+
+install:
+	helm init --client-only
+	helm dependency update
+	helm upgrade --wait --timeout=600 --install $(RELEASE) .
+
+test: install goss
+
+purge:
+	helm del --purge $(RELEASE)

--- a/elasticsearch/examples/hot-cold/requirements.yaml
+++ b/elasticsearch/examples/hot-cold/requirements.yaml
@@ -1,0 +1,20 @@
+dependencies:
+  - name: elasticsearch
+    repository: "https://helm.elastic.co"
+    version: "*"
+    alias: es-data-hot
+  - name: elasticsearch
+    repository: "https://helm.elastic.co"
+    version: "*"
+    alias: es-data-warm
+  - name: elasticsearch
+    repository: "https://helm.elastic.co"
+    version: "*"
+    alias: es-data-cold
+  - name: elasticsearch
+    repository: "https://helm.elastic.co"
+    version: "*"
+    alias: es-master
+  - name: kibana
+    repository: "https://helm.elastic.co"
+    version: "*"

--- a/elasticsearch/examples/hot-cold/test/goss.yaml
+++ b/elasticsearch/examples/hot-cold/test/goss.yaml
@@ -1,0 +1,9 @@
+http:
+  http://localhost:9200/_cluster/health:
+    status: 200
+    timeout: 2000
+    body:
+      - 'green'
+      - '"cluster_name":"hot-cold"'
+      - '"number_of_nodes":6'
+      - '"number_of_data_nodes":3'

--- a/elasticsearch/examples/hot-cold/values.yaml
+++ b/elasticsearch/examples/hot-cold/values.yaml
@@ -1,0 +1,79 @@
+# To define common settings, it may be useful to use YAML anchors to use the same
+# base settings for both node types (data + master)
+es-defaults: &defaults
+  clusterName: "logging"
+  # masterService is not needed since by default it is computed from cluster name and not group name.
+
+# The data nodes
+es-data-hot:
+  <<: *defaults
+  nodeGroup: "data-hot"
+  esConfig:
+    elasticsearch.yml: |
+      node:
+        attr:
+          data: hot
+  roles:
+    master: "false"
+    ingest: "true"
+    data: "true"
+  replicas: 1
+
+es-data-warm:
+  <<: *defaults
+  nodeGroup: "data-warm"
+  esConfig:
+    elasticsearch.yml: |
+      node:
+        attr:
+          data: warm
+  roles:
+    master: "false"
+    ingest: "false"
+    data: "true"
+  replicas: 1
+
+es-data-cold:
+  <<: *defaults
+  nodeGroup: "data-cold"
+  esConfig:
+    elasticsearch.yml: |
+      node:
+        attr:
+          data: cold
+  roles:
+    master: "false"
+    ingest: "false"
+    data: "true"
+  replicas: 1
+
+# The master nodes
+es-master:
+  <<: *defaults
+  nodeGroup: "master"
+  roles:
+    master: "true"
+    ingest: "false"
+    data: "false"
+  esJavaOpts: "-Xms512m -Xmx512m"
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: 20m
+    limits:
+      memory: "1Gi"
+      cpu: "2"
+
+kibana:
+  elasticsearchHosts: http://logging-data-hot:9200
+  resources:
+    limits:
+      cpu: 2
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 1Gi
+  kibanaConfig:
+    kibana.yml: |
+      server.name: kibana
+      server.host: "0"


### PR DESCRIPTION
This PR is for an initial discussion about documenting a hot-cold architecture using a "hat chart".

If you like the idea, I can go forward adding documentation for it.

Potential problems with current approach:

- Versions to be used in requirements.yaml
- Presence of unrelated "kibana" subchart, useful but maybe out of scope
- `helm install .` approach vs maintaining a repository with hosted chart

---

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
