### PR TITLE
[apm-server] add ci tests for apm-server chart

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+master+integration-apm-server.yml
@@ -1,0 +1,39 @@
+---
+- job:
+    name: elastic+helm-charts+master+integration-apm-server
+    display-name: elastic / helm-charts - master - integration apm-server
+    description: Master - integration apm-server
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: APM_SERVER_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -37,6 +37,8 @@
           current-parameters: true
         - name: elastic+helm-charts+master+integration-logstash
           current-parameters: true
+        - name: elastic+helm-charts+master+integration-apm-server
+          current-parameters: true
     publishers:
     - trigger-parameterized-builds:
       - project: elastic+helm-charts+master+cluster-cleanup

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-apm-server.yml
@@ -1,0 +1,39 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+integration-apm-server
+    display-name: elastic / helm-charts - pull-request - integration apm-server
+    description: Pull request - integration apm-server
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: APM_SERVER_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs/elastic+helm-charts+pull-request.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request.yml
@@ -54,6 +54,9 @@
         - name: elastic+helm-charts+pull-request+integration-logstash
           current-parameters: true
           predefined-parameters: branch_specifier=${ghprbActualCommit}
+        - name: elastic+helm-charts+pull-request+integration-apm-server
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
     publishers:
     - trigger-parameterized-builds:
       - project: elastic+helm-charts+pull-request+cluster-cleanup

--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -32,6 +32,11 @@ LOGSTASH_SUITE:
   - oss
   - elasticsearch
   - 6.x
+APM_SERVER_SUITE:
+  - default
+  - oss
+  - security
+  - 6.x
 KUBERNETES_VERSION:
   - '1.13'
   - '1.14'


### PR DESCRIPTION
This is being added to make sure that automated testing for the WIP apm-server chart is happening in #324 (like in #128).



