### PR TITLE
Freeze pip dependencies to make make pytest work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,10 @@
+atomicwrites==1.3.0
+attrs==19.1.0
+importlib-metadata==0.23
+more-itertools==7.2.0
+pluggy==0.13.0
+py==1.8.0
 pytest==4.1.0
 PyYAML==4.2b4
+six==1.12.0
+zipp==0.6.0


### PR DESCRIPTION
Updates requirements.txt same as elastic/helm-charts#309 did for helpers/helm-tester/requirements.txt

- freezing attrs to 19.1.0 fix `TypeError: attrib() got an unexpected keyword argument 'convert'` issue that we have with 19.2.0
- also freezing other dependencies for safety

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
