### PR TITLE
Add wildcard support for ingresses

### DIFF
--- a/apm-server/templates/ingress.yaml
+++ b/apm-server/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}

--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -20,14 +20,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -558,13 +558,13 @@ ingress:
   tls:
   - secretName: elastic-co-wildcard
     hosts:
-     - elasticsearch.elastic.co
+     - '*.elastic.co'
 '''
 
     r = helm_template(config)
     assert uname in r['ingress']
     i = r['ingress'][uname]['spec']
-    assert i['tls'][0]['hosts'][0] == 'elasticsearch.elastic.co'
+    assert i['tls'][0]['hosts'][0] == '*.elastic.co'
     assert i['tls'][0]['secretName'] == 'elastic-co-wildcard'
 
     assert i['rules'][0]['host'] == 'elasticsearch.elastic.co'

--- a/kibana/templates/ingress.yaml
+++ b/kibana/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}


### PR DESCRIPTION
Currently ingresses doesn't support wildcard hosts. This PR allow developers to use wildcard for ES. 
We could also update kibana and apm ingresses for tls but this will add breaking changes.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] Updated template tests in `${CHART}/tests/*.py` 

