### PR TITLE
[meta] format with black python scripts

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
@@ -17,4 +17,6 @@
         #!/usr/local/bin/runbld
         set -euo pipefail
 
+        virtualenv venv && source venv/bin/activate
+        pip install -r requirements.txt
         make lint-python

--- a/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
@@ -1,0 +1,20 @@
+---
+- job:
+    name: elastic+helm-charts+master+lint-python
+    display-name: elastic / helm-charts - master - lint python
+    description: Master - lint python
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        make lint-python

--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -17,6 +17,8 @@
         projects:
         - name: elastic+helm-charts+master+template-testing
           current-parameters: true
+        - name: elastic+helm-charts+master+lint-python
+          current-parameters: true
         - name: elastic+helm-charts+master+cluster-creation
           current-parameters: true
     - multijob:

--- a/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
@@ -1,0 +1,20 @@
+---
+- job:
+    name: elastic+helm-charts+pull-request+lint-python
+    display-name: elastic / helm-charts - pull-request - lint python
+    description: Pull request - lint python
+    scm:
+    - git:
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        make lint-python

--- a/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
@@ -17,4 +17,6 @@
         #!/usr/local/bin/runbld
         set -euo pipefail
 
+        virtualenv venv && source venv/bin/activate
+        pip install -r requirements.txt
         make lint-python

--- a/.ci/jobs/elastic+helm-charts+pull-request.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request.yml
@@ -28,6 +28,9 @@
         - name: elastic+helm-charts+pull-request+template-testing
           current-parameters: true
           predefined-parameters: branch_specifier=${ghprbActualCommit}
+        - name: elastic+helm-charts+pull-request+lint-python
+          current-parameters: true
+          predefined-parameters: branch_specifier=${ghprbActualCommit}
         - name: elastic+helm-charts+pull-request+cluster-creation
           current-parameters: true
           predefined-parameters: branch_specifier=${ghprbActualCommit}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include helpers/common.mk

--- a/apm-server/tests/apmserver_test.py
+++ b/apm-server/tests/apmserver_test.py
@@ -1,130 +1,150 @@
 import os
 import sys
-sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../helpers"))
 from helpers import helm_template
 
-project = 'apm-server'
-name = 'release-name-' + project
+project = "apm-server"
+name = "release-name-" + project
 
 
 def test_defaults():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    assert name in r['deployment']
-    assert name in r['service']
+    assert name in r["deployment"]
+    assert name in r["service"]
 
-    s = r['service'][name]['spec']
-    assert s['ports'][0]['port'] == 8200
-    assert s['ports'][0]['name'] == 'http'
-    assert s['ports'][0]['protocol'] == 'TCP'
-    assert s['ports'][0]['targetPort'] == 8200
+    s = r["service"][name]["spec"]
+    assert s["ports"][0]["port"] == 8200
+    assert s["ports"][0]["name"] == "http"
+    assert s["ports"][0]["protocol"] == "TCP"
+    assert s["ports"][0]["targetPort"] == 8200
 
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['name'] == 'apm-server'
-    assert c['image'].startswith('docker.elastic.co/apm/apm-server:')
-    assert c['ports'][0]['containerPort'] == 8200
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["name"] == "apm-server"
+    assert c["image"].startswith("docker.elastic.co/apm/apm-server:")
+    assert c["ports"][0]["containerPort"] == 8200
 
 
 def test_adding_a_extra_container():
-    config = '''
+    config = """
 extraContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraContainer = r['deployment'][name]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainer
+    extraContainer = r["deployment"][name]["spec"]["template"]["spec"]["containers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainer
 
 
 def test_adding_a_extra_init_container():
-    config = '''
+    config = """
 extraInitContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraInitContainer = r['deployment'][name]['spec']['template']['spec']['initContainers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraInitContainer
+    extraInitContainer = r["deployment"][name]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraInitContainer
 
 
 def test_adding_envs():
-    config = '''
+    config = """
 extraEnvs:
 - name: LOG_LEVEL
   value: DEBUG
-'''
+"""
     r = helm_template(config)
-    envs = r['deployment'][name]['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'LOG_LEVEL', 'value': 'DEBUG'} in envs
+    envs = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "LOG_LEVEL", "value": "DEBUG"} in envs
 
 
 def test_adding_image_pull_secrets():
-    config = '''
+    config = """
 imagePullSecrets:
   - name: test-registry
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['imagePullSecrets'][0]['name'] == 'test-registry'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
+        == "test-registry"
+    )
 
 
 def test_adding_tolerations():
-    config = '''
+    config = """
 tolerations:
 - key: "key1"
   operator: "Equal"
   value: "value1"
   effect: "NoExecute"
   tolerationSeconds: 3600
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['tolerations'][0]['key'] == 'key1'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["tolerations"][0]["key"]
+        == "key1"
+    )
 
 
 def test_override_the_default_update_strategy():
-    config = '''
+    config = """
 updateStrategy:
   type: "OnDelete"
-'''
+"""
 
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['strategy']['type'] == 'OnDelete'
+    assert r["deployment"][name]["spec"]["strategy"]["type"] == "OnDelete"
 
 
 def test_setting_a_custom_service_account():
-    config = '''
+    config = """
 serviceAccount: notdefault
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['serviceAccountName'] == 'notdefault'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["serviceAccountName"]
+        == "notdefault"
+    )
 
 
 def test_self_managing_rbac_resources():
-    config = '''
+    config = """
 managedServiceAccount: false
-'''
+"""
     r = helm_template(config)
-    assert 'serviceaccount' not in r
-    assert 'clusterrole' not in r
-    assert 'clusterrolebinding' not in r
+    assert "serviceaccount" not in r
+    assert "clusterrole" not in r
+    assert "clusterrolebinding" not in r
 
 
 def test_setting_pod_security_context():
-    config = '''
+    config = """
 podSecurityContext:
   runAsUser: 1001
   privileged: false
-'''
+"""
     r = helm_template(config)
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['runAsUser'] == 1001
-    assert c['securityContext']['privileged'] is False
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["runAsUser"] == 1001
+    assert c["securityContext"]["privileged"] is False
 
 
 def test_adding_in_apm_config():
-    config = '''
+    config = """
 apmConfig:
   apm-server.yml: |
     key:
@@ -133,51 +153,65 @@ apmConfig:
 
   other-config.yml: |
     hello = world
-'''
+"""
     r = helm_template(config)
-    print(r['configmap'].keys())
-    c = r['configmap'][name + '-config']['data']
+    print(r["configmap"].keys())
+    c = r["configmap"][name + "-config"]["data"]
 
-    assert 'apm-server.yml' in c
-    assert 'other-config.yml' in c
+    assert "apm-server.yml" in c
+    assert "other-config.yml" in c
 
-    assert 'nestedkey: value' in c['apm-server.yml']
-    assert 'dot.notation: test' in c['apm-server.yml']
+    assert "nestedkey: value" in c["apm-server.yml"]
+    assert "dot.notation: test" in c["apm-server.yml"]
 
-    assert 'hello = world' in c['other-config.yml']
+    assert "hello = world" in c["other-config.yml"]
 
-    d = r['deployment'][name]['spec']['template']['spec']
+    d = r["deployment"][name]["spec"]["template"]["spec"]
 
-    assert {'configMap': {'name': name + '-config', 'defaultMode': 0o600}, 'name': project + '-config'} in d['volumes']
-    assert {'mountPath': '/usr/share/apm-server/apm-server.yml', 'name': project + '-config', 'subPath': 'apm-server.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
-    assert {'mountPath': '/usr/share/apm-server/other-config.yml', 'name': project + '-config', 'subPath': 'other-config.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
+    assert {
+        "configMap": {"name": name + "-config", "defaultMode": 0o600},
+        "name": project + "-config",
+    } in d["volumes"]
+    assert {
+        "mountPath": "/usr/share/apm-server/apm-server.yml",
+        "name": project + "-config",
+        "subPath": "apm-server.yml",
+        "readOnly": True,
+    } in d["containers"][0]["volumeMounts"]
+    assert {
+        "mountPath": "/usr/share/apm-server/other-config.yml",
+        "name": project + "-config",
+        "subPath": "other-config.yml",
+        "readOnly": True,
+    } in d["containers"][0]["volumeMounts"]
 
-    assert 'configChecksum' in r['deployment'][name]['spec']['template']['metadata']['annotations'].keys()
+    assert (
+        "configChecksum"
+        in r["deployment"][name]["spec"]["template"]["metadata"]["annotations"].keys()
+    )
 
 
 def test_adding_a_secret_mount():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/apm-server/config/certs
-'''
+"""
     r = helm_template(config)
-    s = r['deployment'][name]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][0] == {
-        'mountPath': '/usr/share/apm-server/config/certs',
-        'name': 'elastic-certificates'
+    s = r["deployment"][name]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][0] == {
+        "mountPath": "/usr/share/apm-server/config/certs",
+        "name": "elastic-certificates",
     }
-    assert s['volumes'][0] == {
-        'name': 'elastic-certificates',
-        'secret': {
-            'secretName': 'elastic-certs'
-        }
+    assert s["volumes"][0] == {
+        "name": "elastic-certificates",
+        "secret": {"secretName": "elastic-certs"},
     }
 
 
 def test_adding_a_extra_volume_with_volume_mount():
-    config = '''
+    config = """
 extraVolumes:
   - name: extras
     emptyDir: {}
@@ -185,34 +219,46 @@ extraVolumeMounts:
   - name: extras
     mountPath: /usr/share/extras
     readOnly: true
-'''
+"""
     r = helm_template(config)
-    extraVolume = r['deployment'][name]['spec']['template']['spec']['volumes']
-    assert {'name': 'extras', 'emptyDir': {}} in extraVolume
-    extraVolumeMounts = r['deployment'][name]['spec']['template']['spec']['containers'][0]['volumeMounts']
-    assert {'name': 'extras', 'mountPath': '/usr/share/extras', 'readOnly': True} in extraVolumeMounts
+    extraVolume = r["deployment"][name]["spec"]["template"]["spec"]["volumes"]
+    assert {"name": "extras", "emptyDir": {}} in extraVolume
+    extraVolumeMounts = r["deployment"][name]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["volumeMounts"]
+    assert {
+        "name": "extras",
+        "mountPath": "/usr/share/extras",
+        "readOnly": True,
+    } in extraVolumeMounts
 
 
 def test_adding_pod_labels():
-    config = '''
+    config = """
 labels:
   app.kubernetes.io/name: apm-server
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'apm-server'
+    assert (
+        r["deployment"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        == "apm-server"
+    )
 
 
 def test_adding_a_node_selector():
-    config = '''
+    config = """
 nodeSelector:
   disktype: ssd
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['nodeSelector']['disktype'] == 'ssd'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["nodeSelector"]["disktype"]
+        == "ssd"
+    )
 
 
 def test_adding_an_affinity_rule():
-    config = '''
+    config = """
 affinity:
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -223,24 +269,30 @@ affinity:
           values:
           - apm-server
       topologyKey: kubernetes.io/hostname
-'''
+"""
 
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['affinity']['podAntiAffinity'][
-        'requiredDuringSchedulingIgnoredDuringExecution'][0]['topologyKey'] == 'kubernetes.io/hostname'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["affinity"][
+            "podAntiAffinity"
+        ]["requiredDuringSchedulingIgnoredDuringExecution"][0]["topologyKey"]
+        == "kubernetes.io/hostname"
+    )
 
 
 def test_priority_class_name():
-    config = '''
+    config = """
 priorityClassName: ""
-'''
+"""
     r = helm_template(config)
-    spec = r['deployment'][name]['spec']['template']['spec']
-    assert 'priorityClassName' not in spec
+    spec = r["deployment"][name]["spec"]["template"]["spec"]
+    assert "priorityClassName" not in spec
 
-    config = '''
+    config = """
 priorityClassName: "highest"
-'''
+"""
     r = helm_template(config)
-    priority_class_name = r['deployment'][name]['spec']['template']['spec']['priorityClassName']
+    priority_class_name = r["deployment"][name]["spec"]["template"]["spec"][
+        "priorityClassName"
+    ]
     assert priority_class_name == "highest"

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -1,316 +1,290 @@
 import os
 import sys
-sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../helpers"))
 from helpers import helm_template
 import yaml
 
-clusterName = 'elasticsearch'
-nodeGroup = 'master'
-uname = clusterName + '-' + nodeGroup
+clusterName = "elasticsearch"
+nodeGroup = "master"
+uname = clusterName + "-" + nodeGroup
 
 
 def test_defaults():
-    config = '''
-    '''
+    config = """
+    """
 
     r = helm_template(config)
 
     # Statefulset
-    assert r['statefulset'][uname]['spec']['replicas'] == 3
-    assert r['statefulset'][uname]['spec']['updateStrategy'] == {
-        'type': 'RollingUpdate'}
-    assert r['statefulset'][uname]['spec']['podManagementPolicy'] == 'Parallel'
-    assert r['statefulset'][uname]['spec']['serviceName'] == uname + '-headless'
-    assert r['statefulset'][uname]['spec']['template']['spec']['affinity']['podAntiAffinity']['requiredDuringSchedulingIgnoredDuringExecution'][0] == \
-        {
-            "labelSelector": {
-                "matchExpressions": [
-                    {
-                        "key": "app",
-                        "operator": "In",
-                        "values": [
-                            uname
-                        ]
-                    }
-                ]
-            },
-            "topologyKey": "kubernetes.io/hostname"
+    assert r["statefulset"][uname]["spec"]["replicas"] == 3
+    assert r["statefulset"][uname]["spec"]["updateStrategy"] == {
+        "type": "RollingUpdate"
+    }
+    assert r["statefulset"][uname]["spec"]["podManagementPolicy"] == "Parallel"
+    assert r["statefulset"][uname]["spec"]["serviceName"] == uname + "-headless"
+    assert r["statefulset"][uname]["spec"]["template"]["spec"]["affinity"][
+        "podAntiAffinity"
+    ]["requiredDuringSchedulingIgnoredDuringExecution"][0] == {
+        "labelSelector": {
+            "matchExpressions": [{"key": "app", "operator": "In", "values": [uname]}]
+        },
+        "topologyKey": "kubernetes.io/hostname",
     }
 
     # Default environment variables
     env_vars = [
         {
-            'name': 'node.name',
-            'valueFrom': {
-                'fieldRef': {
-                    'fieldPath': 'metadata.name'
-                }
-            }
+            "name": "node.name",
+            "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}},
         },
         {
-            'name': 'cluster.initial_master_nodes',
-            'value': uname + '-0,' +
-                     uname + '-1,' +
-                     uname + '-2,'
+            "name": "cluster.initial_master_nodes",
+            "value": uname + "-0," + uname + "-1," + uname + "-2,",
         },
-        {
-            'name': 'discovery.seed_hosts',
-            'value': uname + '-headless'
-
-        },
-        {
-            'name': 'network.host',
-            'value': '0.0.0.0'
-        },
-        {
-            'name': 'cluster.name',
-            'value': clusterName
-        },
-        {
-            'name': 'ES_JAVA_OPTS',
-            'value': '-Xmx1g -Xms1g'
-        },
-        {
-            'name': 'node.master',
-            'value': 'true'
-        },
-        {
-            'name': 'node.data',
-            'value': 'true'
-        },
-        {
-            'name': 'node.ingest',
-            'value': 'true'
-        },
+        {"name": "discovery.seed_hosts", "value": uname + "-headless"},
+        {"name": "network.host", "value": "0.0.0.0"},
+        {"name": "cluster.name", "value": clusterName},
+        {"name": "ES_JAVA_OPTS", "value": "-Xmx1g -Xms1g"},
+        {"name": "node.master", "value": "true"},
+        {"name": "node.data", "value": "true"},
+        {"name": "node.ingest", "value": "true"},
     ]
 
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
     for env in env_vars:
-        assert env in c['env']
+        assert env in c["env"]
 
     # Image
-    assert c['image'].startswith(
-        'docker.elastic.co/elasticsearch/elasticsearch:')
-    assert c['imagePullPolicy'] == 'IfNotPresent'
-    assert c['name'] == 'elasticsearch'
+    assert c["image"].startswith("docker.elastic.co/elasticsearch/elasticsearch:")
+    assert c["imagePullPolicy"] == "IfNotPresent"
+    assert c["name"] == "elasticsearch"
 
     # Ports
-    assert c['ports'][0] == {'name': 'http', 'containerPort': 9200}
-    assert c['ports'][1] == {'name': 'transport', 'containerPort': 9300}
+    assert c["ports"][0] == {"name": "http", "containerPort": 9200}
+    assert c["ports"][1] == {"name": "transport", "containerPort": 9300}
 
     # Health checks
-    assert c['readinessProbe']['failureThreshold'] == 3
-    assert c['readinessProbe']['initialDelaySeconds'] == 10
-    assert c['readinessProbe']['periodSeconds'] == 10
-    assert c['readinessProbe']['successThreshold'] == 3
-    assert c['readinessProbe']['timeoutSeconds'] == 5
+    assert c["readinessProbe"]["failureThreshold"] == 3
+    assert c["readinessProbe"]["initialDelaySeconds"] == 10
+    assert c["readinessProbe"]["periodSeconds"] == 10
+    assert c["readinessProbe"]["successThreshold"] == 3
+    assert c["readinessProbe"]["timeoutSeconds"] == 5
 
-    assert 'curl' in c['readinessProbe']['exec']['command'][-1]
-    assert 'http://127.0.0.1:9200' in c['readinessProbe']['exec']['command'][-1]
-    assert '/_cluster/health?timeout=0s' in c['readinessProbe']['exec']['command'][-1]
+    assert "curl" in c["readinessProbe"]["exec"]["command"][-1]
+    assert "http://127.0.0.1:9200" in c["readinessProbe"]["exec"]["command"][-1]
+    assert "/_cluster/health?timeout=0s" in c["readinessProbe"]["exec"]["command"][-1]
 
     # Resources
-    assert c['resources'] == {
-        'requests': {
-            'cpu': '1000m',
-            'memory': '2Gi'
-        },
-        'limits': {
-            'cpu': '1000m',
-            'memory': '2Gi'
-        }
+    assert c["resources"] == {
+        "requests": {"cpu": "1000m", "memory": "2Gi"},
+        "limits": {"cpu": "1000m", "memory": "2Gi"},
     }
 
     # Mounts
-    assert c['volumeMounts'][0]['mountPath'] == '/usr/share/elasticsearch/data'
-    assert c['volumeMounts'][0]['name'] == uname
+    assert c["volumeMounts"][0]["mountPath"] == "/usr/share/elasticsearch/data"
+    assert c["volumeMounts"][0]["name"] == uname
 
-    v = r['statefulset'][uname]['spec']['volumeClaimTemplates'][0]
-    assert v['metadata']['name'] == uname
-    assert v['spec']['accessModes'] == ['ReadWriteOnce']
-    assert v['spec']['resources']['requests']['storage'] == '30Gi'
+    v = r["statefulset"][uname]["spec"]["volumeClaimTemplates"][0]
+    assert v["metadata"]["name"] == uname
+    assert v["spec"]["accessModes"] == ["ReadWriteOnce"]
+    assert v["spec"]["resources"]["requests"]["storage"] == "30Gi"
 
     # Init container
-    i = r['statefulset'][uname]['spec']['template']['spec']['initContainers'][0]
-    assert i['name'] == 'configure-sysctl'
-    assert i['command'] == ['sysctl', '-w', 'vm.max_map_count=262144']
-    assert i['image'].startswith(
-        'docker.elastic.co/elasticsearch/elasticsearch:')
-    assert i['securityContext'] == {
-        'privileged': True,
-        'runAsUser': 0
-    }
+    i = r["statefulset"][uname]["spec"]["template"]["spec"]["initContainers"][0]
+    assert i["name"] == "configure-sysctl"
+    assert i["command"] == ["sysctl", "-w", "vm.max_map_count=262144"]
+    assert i["image"].startswith("docker.elastic.co/elasticsearch/elasticsearch:")
+    assert i["securityContext"] == {"privileged": True, "runAsUser": 0}
 
     # Other
-    assert r['statefulset'][uname]['spec']['template']['spec']['securityContext'] == {
-        'fsGroup': 1000,
-        'runAsUser': 1000
+    assert r["statefulset"][uname]["spec"]["template"]["spec"]["securityContext"] == {
+        "fsGroup": 1000,
+        "runAsUser": 1000,
     }
-    assert r['statefulset'][uname]['spec']['template']['spec']['terminationGracePeriodSeconds'] == 120
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"][
+            "terminationGracePeriodSeconds"
+        ]
+        == 120
+    )
 
     # Pod disruption budget
-    assert r['poddisruptionbudget'][uname +
-                                    '-pdb']['spec']['maxUnavailable'] == 1
+    assert r["poddisruptionbudget"][uname + "-pdb"]["spec"]["maxUnavailable"] == 1
 
     # Service
-    s = r['service'][uname]
-    assert s['metadata']['name'] == uname
-    assert s['metadata']['annotations'] == {}
-    assert s['spec']['type'] == 'ClusterIP'
-    assert len(s['spec']['ports']) == 2
-    assert s['spec']['ports'][0] == {
-        'name': 'http', 'port': 9200, 'protocol': 'TCP'}
-    assert s['spec']['ports'][1] == {
-        'name': 'transport', 'port': 9300, 'protocol': 'TCP'}
+    s = r["service"][uname]
+    assert s["metadata"]["name"] == uname
+    assert s["metadata"]["annotations"] == {}
+    assert s["spec"]["type"] == "ClusterIP"
+    assert len(s["spec"]["ports"]) == 2
+    assert s["spec"]["ports"][0] == {"name": "http", "port": 9200, "protocol": "TCP"}
+    assert s["spec"]["ports"][1] == {
+        "name": "transport",
+        "port": 9300,
+        "protocol": "TCP",
+    }
 
     # Headless Service
-    h = r['service'][uname + '-headless']
-    assert h['spec']['clusterIP'] == 'None'
-    assert h['spec']['publishNotReadyAddresses'] == True
-    assert h['spec']['ports'][0]['name'] == 'http'
-    assert h['spec']['ports'][0]['port'] == 9200
-    assert h['spec']['ports'][1]['name'] == 'transport'
-    assert h['spec']['ports'][1]['port'] == 9300
+    h = r["service"][uname + "-headless"]
+    assert h["spec"]["clusterIP"] == "None"
+    assert h["spec"]["publishNotReadyAddresses"] == True
+    assert h["spec"]["ports"][0]["name"] == "http"
+    assert h["spec"]["ports"][0]["port"] == 9200
+    assert h["spec"]["ports"][1]["name"] == "transport"
+    assert h["spec"]["ports"][1]["port"] == 9300
 
     # Empty customizable defaults
-    assert 'imagePullSecrets' not in r['statefulset'][uname]['spec']['template']['spec']
-    assert 'tolerations' not in r['statefulset'][uname]['spec']['template']['spec']
-    assert 'nodeSelector' not in r['statefulset'][uname]['spec']['template']['spec']
-    assert 'ingress' not in r
+    assert "imagePullSecrets" not in r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert "tolerations" not in r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert "nodeSelector" not in r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert "ingress" not in r
 
 
 def test_increasing_the_replicas():
-    config = '''
+    config = """
 replicas: 5
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['replicas'] == 5
+    assert r["statefulset"][uname]["spec"]["replicas"] == 5
 
 
 def test_disabling_pod_disruption_budget():
-    config = '''
+    config = """
 maxUnavailable: false
-'''
+"""
     r = helm_template(config)
-    assert 'poddisruptionbudget' not in r
+    assert "poddisruptionbudget" not in r
 
 
 def test_overriding_the_image_and_tag():
-    config = '''
+    config = """
 image: customImage
 imageTag: 6.2.4
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['image'] == 'customImage:6.2.4'
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["image"]
+        == "customImage:6.2.4"
+    )
 
 
 def test_set_discovery_hosts_to_custom_master_service():
-    config = '''
+    config = """
 esMajorVersion: 6
 masterService: "elasticsearch-custommaster"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'discovery.zen.ping.unicast.hosts',
-            'value': 'elasticsearch-custommaster-headless'} in env
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {
+        "name": "discovery.zen.ping.unicast.hosts",
+        "value": "elasticsearch-custommaster-headless",
+    } in env
 
 
 def test_set_master_service_to_default_nodegroup_name_if_not_set():
-    config = '''
+    config = """
 esMajorVersion: 6
 nodeGroup: "data"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset']['elasticsearch-data']['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'discovery.zen.ping.unicast.hosts',
-            'value': 'elasticsearch-master-headless'} in env
+    env = r["statefulset"]["elasticsearch-data"]["spec"]["template"]["spec"][
+        "containers"
+    ][0]["env"]
+    assert {
+        "name": "discovery.zen.ping.unicast.hosts",
+        "value": "elasticsearch-master-headless",
+    } in env
 
 
 def test_set_master_service_to_default_nodegroup_name_with_custom_cluster_name():
-    config = '''
+    config = """
 esMajorVersion: 6
 clusterName: "custom"
 nodeGroup: "data"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset']['custom-data']['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'discovery.zen.ping.unicast.hosts',
-            'value': 'custom-master-headless'} in env
+    env = r["statefulset"]["custom-data"]["spec"]["template"]["spec"]["containers"][0][
+        "env"
+    ]
+    assert {
+        "name": "discovery.zen.ping.unicast.hosts",
+        "value": "custom-master-headless",
+    } in env
 
 
 def test_set_initial_master_nodes_when_using_v_7():
-    config = '''
+    config = """
 esMajorVersion: 7
 roles:
   master: "true"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['env']
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
     assert {
-            'name': 'cluster.initial_master_nodes',
-            'value': 'elasticsearch-master-0,' +
-                     'elasticsearch-master-1,' +
-                     'elasticsearch-master-2,'
-        } in env
+        "name": "cluster.initial_master_nodes",
+        "value": "elasticsearch-master-0,"
+        + "elasticsearch-master-1,"
+        + "elasticsearch-master-2,",
+    } in env
 
     for e in env:
-        assert e['name'] != 'discovery.zen.minimum_master_nodes'
+        assert e["name"] != "discovery.zen.minimum_master_nodes"
 
 
 def test_dont_set_initial_master_nodes_if_not_master_when_using_es_version_7():
-    config = '''
+    config = """
 esMajorVersion: 7
 roles:
   master: "false"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['env']
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
     for e in env:
-        assert e['name'] != 'cluster.initial_master_nodes'
+        assert e["name"] != "cluster.initial_master_nodes"
 
 
 def test_set_discovery_seed_host_when_using_v_7():
-    config = '''
+    config = """
 esMajorVersion: 7
 roles:
   master: "true"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['env']
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
     assert {
-            'name': 'discovery.seed_hosts',
-            'value': 'elasticsearch-master-headless'
-        } in env
+        "name": "discovery.seed_hosts",
+        "value": "elasticsearch-master-headless",
+    } in env
 
     for e in env:
-        assert e['name'] != 'discovery.zen.ping.unicast.hosts'
+        assert e["name"] != "discovery.zen.ping.unicast.hosts"
 
 
 def test_enabling_machine_learning_role():
-    config = '''
+    config = """
 roles:
   ml: "true"
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['env']
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
 
-    assert {'name': 'node.ml',
-            'value': 'true'} in env
+    assert {"name": "node.ml", "value": "true"} in env
 
 
 def test_adding_extra_env_vars():
-    config = '''
+    config = """
 extraEnvs:
   - name: hello
     value: world
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'hello', 'value': 'world'} in env
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "hello", "value": "world"} in env
 
 
 def test_adding_a_extra_volume_with_volume_mount():
-    config = '''
+    config = """
 extraVolumes: |
   - name: extras
     emptyDir: {}
@@ -318,170 +292,216 @@ extraVolumeMounts: |
   - name: extras
     mountPath: /usr/share/extras
     readOnly: true
-'''
+"""
     r = helm_template(config)
-    extraVolume = r['statefulset'][uname]['spec']['template']['spec']['volumes']
-    assert {'name': 'extras', 'emptyDir': {}} in extraVolume
-    extraVolumeMounts = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['volumeMounts']
-    assert {'name': 'extras', 'mountPath': '/usr/share/extras', 'readOnly': True} in extraVolumeMounts
+    extraVolume = r["statefulset"][uname]["spec"]["template"]["spec"]["volumes"]
+    assert {"name": "extras", "emptyDir": {}} in extraVolume
+    extraVolumeMounts = r["statefulset"][uname]["spec"]["template"]["spec"][
+        "containers"
+    ][0]["volumeMounts"]
+    assert {
+        "name": "extras",
+        "mountPath": "/usr/share/extras",
+        "readOnly": True,
+    } in extraVolumeMounts
 
 
 def test_adding_a_extra_container():
-    config = '''
+    config = """
 extraContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraContainer = r['statefulset'][uname]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainer
+    extraContainer = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainer
 
 
 def test_adding_a_extra_init_container():
-    config = '''
+    config = """
 extraInitContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraInitContainer = r['statefulset'][uname]['spec']['template']['spec']['initContainers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraInitContainer
+    extraInitContainer = r["statefulset"][uname]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraInitContainer
+
 
 def test_sysctl_init_container_disabled():
-    config = '''
+    config = """
 sysctlInitContainer:
   enabled: false
-'''
+"""
     r = helm_template(config)
-    initContainers = r['statefulset'][uname]['spec']['template']['spec']['initContainers']
+    initContainers = r["statefulset"][uname]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
     assert initContainers is None
 
+
 def test_sysctl_init_container_enabled():
-    config = '''
+    config = """
 sysctlInitContainer:
   enabled: true
-'''
+"""
     r = helm_template(config)
-    initContainers = r['statefulset'][uname]['spec']['template']['spec']['initContainers']
-    assert initContainers[0]['name'] == 'configure-sysctl'
+    initContainers = r["statefulset"][uname]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert initContainers[0]["name"] == "configure-sysctl"
+
 
 def test_sysctl_init_container_image():
-    config = '''
+    config = """
 image: customImage
 imageTag: 6.2.4
 imagePullPolicy: Never
 sysctlInitContainer:
   enabled: true
-'''
+"""
     r = helm_template(config)
-    initContainers = r['statefulset'][uname]['spec']['template']['spec']['initContainers']
-    assert initContainers[0]['image'] == 'customImage:6.2.4'
-    assert initContainers[0]['imagePullPolicy'] == 'Never'
+    initContainers = r["statefulset"][uname]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert initContainers[0]["image"] == "customImage:6.2.4"
+    assert initContainers[0]["imagePullPolicy"] == "Never"
+
 
 def test_adding_storageclass_annotation_to_volumeclaimtemplate():
-    config = '''
+    config = """
 persistence:
   annotations:
     volume.beta.kubernetes.io/storage-class: id
-'''
+"""
     r = helm_template(config)
-    annotations = r['statefulset'][uname]['spec']['volumeClaimTemplates'][0]['metadata']['annotations']
-    assert annotations['volume.beta.kubernetes.io/storage-class'] == 'id'
+    annotations = r["statefulset"][uname]["spec"]["volumeClaimTemplates"][0][
+        "metadata"
+    ]["annotations"]
+    assert annotations["volume.beta.kubernetes.io/storage-class"] == "id"
+
 
 def test_adding_multiple_persistence_annotations():
-    config = '''
+    config = """
     persistence:
       annotations:
         hello: world
         world: hello
-    '''
+    """
     r = helm_template(config)
-    annotations = r['statefulset'][uname]['spec']['volumeClaimTemplates'][0]['metadata']['annotations']
+    annotations = r["statefulset"][uname]["spec"]["volumeClaimTemplates"][0][
+        "metadata"
+    ]["annotations"]
 
-    assert annotations['hello'] == 'world'
-    assert annotations['world'] == 'hello'
+    assert annotations["hello"] == "world"
+    assert annotations["world"] == "hello"
 
 
 def test_adding_a_secret_mount():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/elasticsearch/config/certs
-'''
+"""
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/elasticsearch/config/certs',
-        'name': 'elastic-certificates'
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/elasticsearch/config/certs",
+        "name": "elastic-certificates",
     }
-    assert s['volumes'] == [{
-        'name': 'elastic-certificates',
-        'secret': {
-            'secretName': 'elastic-certs'
-        }
-    }]
+    assert s["volumes"] == [
+        {"name": "elastic-certificates", "secret": {"secretName": "elastic-certs"}}
+    ]
 
 
 def test_adding_a_secret_mount_with_subpath():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/elasticsearch/config/certs
     subPath: cert.crt
-'''
+"""
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/elasticsearch/config/certs',
-        'subPath': 'cert.crt',
-        'name': 'elastic-certificates'
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/elasticsearch/config/certs",
+        "subPath": "cert.crt",
+        "name": "elastic-certificates",
     }
 
 
 def test_adding_image_pull_secrets():
-    config = '''
+    config = """
 imagePullSecrets:
   - name: test-registry
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['imagePullSecrets'][0]['name'] == 'test-registry'
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["imagePullSecrets"][0][
+            "name"
+        ]
+        == "test-registry"
+    )
 
 
 def test_adding_tolerations():
-    config = '''
+    config = """
 tolerations:
 - key: "key1"
   operator: "Equal"
   value: "value1"
   effect: "NoExecute"
   tolerationSeconds: 3600
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['tolerations'][0]['key'] == 'key1'
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["tolerations"][0]["key"]
+        == "key1"
+    )
+
 
 def test_adding_pod_annotations():
-    config = '''
+    config = """
 podAnnotations:
   iam.amazonaws.com/role: es-role
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['metadata']['annotations']['iam.amazonaws.com/role'] == 'es-role'
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["metadata"]["annotations"][
+            "iam.amazonaws.com/role"
+        ]
+        == "es-role"
+    )
 
 
 def test_adding_a_node_selector():
-    config = '''
+    config = """
 nodeSelector:
   disktype: ssd
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['nodeSelector']['disktype'] == 'ssd'
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["nodeSelector"]["disktype"]
+        == "ssd"
+    )
+
 
 def test_adding_resources_to_initcontainer():
-    config = '''
+    config = """
 initResources:
   limits:
     cpu: "25m"
@@ -489,23 +509,18 @@ initResources:
   requests:
     cpu: "25m"
     memory: "128Mi"
-'''
+"""
     r = helm_template(config)
-    i = r['statefulset'][uname]['spec']['template']['spec']['initContainers'][0]
+    i = r["statefulset"][uname]["spec"]["template"]["spec"]["initContainers"][0]
 
-    assert i['resources'] == {
-        'requests': {
-            'cpu': '25m',
-            'memory': '128Mi'
-        },
-        'limits': {
-            'cpu': '25m',
-            'memory': '128Mi'
-        }
+    assert i["resources"] == {
+        "requests": {"cpu": "25m", "memory": "128Mi"},
+        "limits": {"cpu": "25m", "memory": "128Mi"},
     }
 
+
 def test_adding_resources_to_sidecar_container():
-    config = '''
+    config = """
 masterTerminationFix: true
 sidecarResources:
   limits:
@@ -514,23 +529,18 @@ sidecarResources:
   requests:
     cpu: "100m"
     memory: "128Mi"
-'''
+"""
     r = helm_template(config)
-    i = r['statefulset'][uname]['spec']['template']['spec']['containers'][1]
+    i = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][1]
 
-    assert i['resources'] == {
-        'requests': {
-            'cpu': '100m',
-            'memory': '128Mi'
-        },
-        'limits': {
-            'cpu': '100m',
-            'memory': '128Mi'
-        }
+    assert i["resources"] == {
+        "requests": {"cpu": "100m", "memory": "128Mi"},
+        "limits": {"cpu": "100m", "memory": "128Mi"},
     }
 
+
 def test_adding_a_node_affinity():
-    config = '''
+    config = """
 nodeAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 100
@@ -540,26 +550,26 @@ nodeAffinity:
         operator: In
         values:
         - myvalue
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['affinity']['nodeAffinity'] == {
-        'preferredDuringSchedulingIgnoredDuringExecution': [{
-            'weight': 100,
-            'preference': {
-                'matchExpressions': [{
-                    'key': 'mylabel',
-                    'operator': 'In',
-                    'values': [
-                        'myvalue'
+    assert r["statefulset"][uname]["spec"]["template"]["spec"]["affinity"][
+        "nodeAffinity"
+    ] == {
+        "preferredDuringSchedulingIgnoredDuringExecution": [
+            {
+                "weight": 100,
+                "preference": {
+                    "matchExpressions": [
+                        {"key": "mylabel", "operator": "In", "values": ["myvalue"]}
                     ]
-                }]
+                },
             }
-        }]
+        ]
     }
 
 
 def test_adding_an_ingress_rule():
-    config = '''
+    config = """
 ingress:
   enabled: true
   annotations:
@@ -571,38 +581,43 @@ ingress:
   - secretName: elastic-co-wildcard
     hosts:
      - elasticsearch.elastic.co
-'''
+"""
 
     r = helm_template(config)
-    assert uname in r['ingress']
-    i = r['ingress'][uname]['spec']
-    assert i['tls'][0]['hosts'][0] == 'elasticsearch.elastic.co'
-    assert i['tls'][0]['secretName'] == 'elastic-co-wildcard'
+    assert uname in r["ingress"]
+    i = r["ingress"][uname]["spec"]
+    assert i["tls"][0]["hosts"][0] == "elasticsearch.elastic.co"
+    assert i["tls"][0]["secretName"] == "elastic-co-wildcard"
 
-    assert i['rules'][0]['host'] == 'elasticsearch.elastic.co'
-    assert i['rules'][0]['http']['paths'][0]['path'] == '/'
-    assert i['rules'][0]['http']['paths'][0]['backend']['serviceName'] == uname
-    assert i['rules'][0]['http']['paths'][0]['backend']['servicePort'] == 9200
+    assert i["rules"][0]["host"] == "elasticsearch.elastic.co"
+    assert i["rules"][0]["http"]["paths"][0]["path"] == "/"
+    assert i["rules"][0]["http"]["paths"][0]["backend"]["serviceName"] == uname
+    assert i["rules"][0]["http"]["paths"][0]["backend"]["servicePort"] == 9200
 
 
 def test_changing_the_protocol():
-    config = '''
+    config = """
 protocol: https
-'''
+"""
     r = helm_template(config)
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
-    assert 'https://127.0.0.1:9200' in c['readinessProbe']['exec']['command'][-1]
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
+    assert "https://127.0.0.1:9200" in c["readinessProbe"]["exec"]["command"][-1]
+
 
 def test_changing_the_cluster_health_status():
-    config = '''
+    config = """
 clusterHealthCheckParams: 'wait_for_no_initializing_shards=true&timeout=60s'
-'''
+"""
     r = helm_template(config)
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
-    assert '/_cluster/health?wait_for_no_initializing_shards=true&timeout=60s' in c['readinessProbe']['exec']['command'][-1]
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
+    assert (
+        "/_cluster/health?wait_for_no_initializing_shards=true&timeout=60s"
+        in c["readinessProbe"]["exec"]["command"][-1]
+    )
+
 
 def test_adding_in_es_config():
-    config = '''
+    config = """
 esConfig:
   elasticsearch.yml: |
     key:
@@ -611,385 +626,452 @@ esConfig:
 
   log4j2.properties: |
     appender.rolling.name = rolling
-'''
+"""
     r = helm_template(config)
-    c = r['configmap'][uname + '-config']['data']
+    c = r["configmap"][uname + "-config"]["data"]
 
-    assert 'elasticsearch.yml' in c
-    assert 'log4j2.properties' in c
+    assert "elasticsearch.yml" in c
+    assert "log4j2.properties" in c
 
-    assert 'nestedkey: value' in c['elasticsearch.yml']
-    assert 'dot.notation: test' in c['elasticsearch.yml']
+    assert "nestedkey: value" in c["elasticsearch.yml"]
+    assert "dot.notation: test" in c["elasticsearch.yml"]
 
-    assert 'appender.rolling.name = rolling' in c['log4j2.properties']
+    assert "appender.rolling.name = rolling" in c["log4j2.properties"]
 
-    s = r['statefulset'][uname]['spec']['template']['spec']
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
 
-    assert {'configMap': {'name': 'elasticsearch-master-config'}, 'name': 'esconfig'} in s['volumes']
-    assert {'mountPath': '/usr/share/elasticsearch/config/elasticsearch.yml', 'name': 'esconfig', 'subPath': 'elasticsearch.yml'} in s['containers'][0]['volumeMounts']
-    assert {'mountPath': '/usr/share/elasticsearch/config/log4j2.properties', 'name': 'esconfig', 'subPath': 'log4j2.properties'} in s['containers'][0]['volumeMounts']
+    assert {
+        "configMap": {"name": "elasticsearch-master-config"},
+        "name": "esconfig",
+    } in s["volumes"]
+    assert {
+        "mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml",
+        "name": "esconfig",
+        "subPath": "elasticsearch.yml",
+    } in s["containers"][0]["volumeMounts"]
+    assert {
+        "mountPath": "/usr/share/elasticsearch/config/log4j2.properties",
+        "name": "esconfig",
+        "subPath": "log4j2.properties",
+    } in s["containers"][0]["volumeMounts"]
 
-    assert 'configchecksum' in r['statefulset'][uname]['spec']['template']['metadata']['annotations']
+    assert (
+        "configchecksum"
+        in r["statefulset"][uname]["spec"]["template"]["metadata"]["annotations"]
+    )
+
 
 def test_dont_add_data_volume_when_persistance_is_disabled():
-    config = '''
+    config = """
 persistence:
   enabled: false
-'''
+"""
     r = helm_template(config)
-    assert 'volumeClaimTemplates' not in r['statefulset'][uname]['spec']
-    assert r['statefulset'][uname]['spec']['template']['spec']['containers'][0]['volumeMounts'] == None
+    assert "volumeClaimTemplates" not in r["statefulset"][uname]["spec"]
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0][
+            "volumeMounts"
+        ]
+        == None
+    )
 
 
 def test_priority_class_name():
-    config = '''
+    config = """
 priorityClassName: ""
-'''
+"""
     r = helm_template(config)
-    spec = r['statefulset'][uname]['spec']['template']['spec']
-    assert 'priorityClassName' not in spec
+    spec = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert "priorityClassName" not in spec
 
-    config = '''
+    config = """
 priorityClassName: "highest"
-'''
+"""
     r = helm_template(config)
-    priority_class_name = r['statefulset'][uname]['spec']['template']['spec']['priorityClassName']
+    priority_class_name = r["statefulset"][uname]["spec"]["template"]["spec"][
+        "priorityClassName"
+    ]
     assert priority_class_name == "highest"
 
 
 def test_scheduler_name():
-    r = helm_template('')
-    spec = r['statefulset'][uname]['spec']['template']['spec']
-    assert 'schedulerName' not in spec
+    r = helm_template("")
+    spec = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert "schedulerName" not in spec
 
-    config = '''
+    config = """
 schedulerName: "stork"
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['schedulerName'] == "stork"
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["schedulerName"] == "stork"
+    )
 
 
 def test_adding_a_nodePort():
-    config = ''
+    config = ""
 
     r = helm_template(config)
 
-    assert 'nodePort' not in r['service'][uname]['spec']['ports'][0]
+    assert "nodePort" not in r["service"][uname]["spec"]["ports"][0]
 
-    config = '''
+    config = """
     service:
       nodePort: 30001
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['service'][uname]['spec']['ports'][0]['nodePort'] == 30001
+    assert r["service"][uname]["spec"]["ports"][0]["nodePort"] == 30001
 
 
 def test_adding_a_label_on_non_headless_service():
-    config = ''
+    config = ""
 
     r = helm_template(config)
 
-    assert 'label1' not in r['service'][uname]['metadata']['labels']
+    assert "label1" not in r["service"][uname]["metadata"]["labels"]
 
-    config = '''
+    config = """
     service:
       labels:
         label1: value1
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['service'][uname]['metadata']['labels']['label1'] == 'value1'
-
+    assert r["service"][uname]["metadata"]["labels"]["label1"] == "value1"
 
 
 def test_adding_a_label_on_headless_service():
-    config = ''
+    config = ""
 
     r = helm_template(config)
 
-    assert 'label1' not in r['service'][uname + '-headless']['metadata']['labels']
+    assert "label1" not in r["service"][uname + "-headless"]["metadata"]["labels"]
 
-    config = '''
+    config = """
     service:
       labelsHeadless:
         label1: value1
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['service'][uname + '-headless']['metadata']['labels']['label1'] == 'value1'
+    assert r["service"][uname + "-headless"]["metadata"]["labels"]["label1"] == "value1"
+
 
 def test_master_termination_fixed_enabled():
-    config = ''
+    config = ""
 
     r = helm_template(config)
 
-    assert len(r['statefulset'][uname]['spec']['template']['spec']['containers']) == 1
+    assert len(r["statefulset"][uname]["spec"]["template"]["spec"]["containers"]) == 1
 
-    config = '''
+    config = """
     masterTerminationFix: true
-    '''
+    """
 
     r = helm_template(config)
 
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][1]
-    assert c['name'] == 'elasticsearch-master-graceful-termination-handler'
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][1]
+    assert c["name"] == "elasticsearch-master-graceful-termination-handler"
+
 
 def test_lifecycle_hooks():
-    config = ''
+    config = ""
     r = helm_template(config)
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
-    assert 'lifecycle' not in c
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
+    assert "lifecycle" not in c
 
-    config = '''
+    config = """
     lifecycle:
       preStop:
         exec:
           command: ["/bin/bash","/preStop"]
-    '''
+    """
     r = helm_template(config)
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
 
-    assert c['lifecycle']['preStop']['exec']['command'] == ["/bin/bash","/preStop"]
+    assert c["lifecycle"]["preStop"]["exec"]["command"] == ["/bin/bash", "/preStop"]
+
 
 def test_esMajorVersion_detect_default_version():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['annotations']['esMajorVersion'] == '7'
+    assert r["statefulset"][uname]["metadata"]["annotations"]["esMajorVersion"] == "7"
+
 
 def test_esMajorVersion_default_to_7_if_not_elastic_image():
-    config = '''
+    config = """
     image: notElastic
     imageTag: 1.0.0
-    '''
+    """
 
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['annotations']['esMajorVersion'] == '7'
+    assert r["statefulset"][uname]["metadata"]["annotations"]["esMajorVersion"] == "7"
+
 
 def test_esMajorVersion_default_to_7_if_no_version_is_found():
-    config = '''
+    config = """
     imageTag: not_a_number
-    '''
+    """
 
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['annotations']['esMajorVersion'] == '7'
+    assert r["statefulset"][uname]["metadata"]["annotations"]["esMajorVersion"] == "7"
+
 
 def test_esMajorVersion_set_to_6_based_on_image_tag():
-    config = '''
+    config = """
     imageTag: 6.8.1
-    '''
+    """
 
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['annotations']['esMajorVersion'] == '6'
+    assert r["statefulset"][uname]["metadata"]["annotations"]["esMajorVersion"] == "6"
+
 
 def test_esMajorVersion_always_wins():
-    config = '''
+    config = """
     esMajorVersion: 7
     imageTag: 6.0.0
-    '''
+    """
 
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['annotations']['esMajorVersion'] == '7'
+    assert r["statefulset"][uname]["metadata"]["annotations"]["esMajorVersion"] == "7"
+
 
 def test_esMajorVersion_parse_image_tag_for_oss_image():
-    config = '''
+    config = """
     image: docker.elastic.co/elasticsearch/elasticsearch-oss
     imageTag: 6.3.2
-    '''
+    """
 
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['annotations']['esMajorVersion'] == '6'
+    assert r["statefulset"][uname]["metadata"]["annotations"]["esMajorVersion"] == "6"
+
 
 def test_set_pod_security_context():
-    config = ''
+    config = ""
     r = helm_template(config)
-    assert r['statefulset'][uname]['spec']['template']['spec']['securityContext']['fsGroup'] == 1000
-    assert r['statefulset'][uname]['spec']['template']['spec']['securityContext']['runAsUser'] == 1000
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["securityContext"][
+            "fsGroup"
+        ]
+        == 1000
+    )
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["securityContext"][
+            "runAsUser"
+        ]
+        == 1000
+    )
 
-    config = '''
+    config = """
     podSecurityContext:
       fsGroup: 1001
       other: test
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['statefulset'][uname]['spec']['template']['spec']['securityContext']['fsGroup'] == 1001
-    assert r['statefulset'][uname]['spec']['template']['spec']['securityContext']['other'] == 'test'
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["securityContext"][
+            "fsGroup"
+        ]
+        == 1001
+    )
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["securityContext"]["other"]
+        == "test"
+    )
+
 
 def test_fsGroup_backwards_compatability():
-    config = '''
+    config = """
     fsGroup: 1001
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['statefulset'][uname]['spec']['template']['spec']['securityContext']['fsGroup'] == 1001
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["securityContext"][
+            "fsGroup"
+        ]
+        == 1001
+    )
+
 
 def test_set_container_security_context():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['capabilities']['drop'] == ['ALL']
-    assert c['securityContext']['runAsNonRoot'] == True
-    assert c['securityContext']['runAsUser'] == 1000
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+    assert c["securityContext"]["runAsNonRoot"] == True
+    assert c["securityContext"]["runAsUser"] == 1000
 
-    config = '''
+    config = """
     securityContext:
       runAsUser: 1001
       other: test
-    '''
+    """
 
     r = helm_template(config)
-    c = r['statefulset'][uname]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['capabilities']['drop'] == ['ALL']
-    assert c['securityContext']['runAsNonRoot'] == True
-    assert c['securityContext']['runAsUser'] == 1001
-    assert c['securityContext']['other'] == 'test'
+    c = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+    assert c["securityContext"]["runAsNonRoot"] == True
+    assert c["securityContext"]["runAsUser"] == 1001
+    assert c["securityContext"]["other"] == "test"
+
 
 def test_adding_pod_labels():
-    config = '''
+    config = """
 labels:
   app.kubernetes.io/name: elasticsearch
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][uname]['metadata']['labels']['app.kubernetes.io/name'] == 'elasticsearch'
-    assert r['statefulset'][uname]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'elasticsearch'
+    assert (
+        r["statefulset"][uname]["metadata"]["labels"]["app.kubernetes.io/name"]
+        == "elasticsearch"
+    )
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
+        == "elasticsearch"
+    )
+
 
 def test_keystore_enable():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
 
-    assert s['volumes'] == None
+    assert s["volumes"] == None
 
-    config = '''
+    config = """
 keystore:
   - secretName: test
-    '''
+    """
 
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
 
-    assert {'name': 'keystore', 'emptyDir': {}} in s['volumes']
+    assert {"name": "keystore", "emptyDir": {}} in s["volumes"]
+
 
 def test_keystore_init_container():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    i = r['statefulset'][uname]['spec']['template']['spec']['initContainers'][-1]
+    i = r["statefulset"][uname]["spec"]["template"]["spec"]["initContainers"][-1]
 
-    assert i['name'] != 'keystore'
+    assert i["name"] != "keystore"
 
-    config = '''
+    config = """
 keystore:
   - secretName: test
-    '''
+    """
 
     r = helm_template(config)
-    i = r['statefulset'][uname]['spec']['template']['spec']['initContainers'][-1]
+    i = r["statefulset"][uname]["spec"]["template"]["spec"]["initContainers"][-1]
 
-    assert i['name'] == 'keystore'
+    assert i["name"] == "keystore"
+
 
 def test_keystore_init_container_image():
-    config = '''
+    config = """
 image: customImage
 imageTag: 6.2.4
 imagePullPolicy: Never
 keystore:
   - secretName: test
-'''
+"""
     r = helm_template(config)
-    i = r['statefulset'][uname]['spec']['template']['spec']['initContainers'][-1]
-    assert i['image'] == 'customImage:6.2.4'
-    assert i['imagePullPolicy'] == 'Never'
+    i = r["statefulset"][uname]["spec"]["template"]["spec"]["initContainers"][-1]
+    assert i["image"] == "customImage:6.2.4"
+    assert i["imagePullPolicy"] == "Never"
+
 
 def test_keystore_mount():
-    config = '''
+    config = """
 keystore:
   - secretName: test
-'''
+"""
 
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/elasticsearch/config/elasticsearch.keystore',
-        'subPath': 'elasticsearch.keystore',
-        'name': 'keystore'
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/elasticsearch/config/elasticsearch.keystore",
+        "subPath": "elasticsearch.keystore",
+        "name": "keystore",
     }
 
+
 def test_keystore_init_volume_mounts():
-    config = '''
+    config = """
 keystore:
   - secretName: test
   - secretName: test-with-custom-path
     items:
     - key: slack_url
       path: xpack.notification.slack.account.otheraccount.secure_url
-'''
+"""
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
-    assert s['initContainers'][-1]['volumeMounts'] == [
-            {
-              'mountPath': '/tmp/keystore',
-              'name': 'keystore'
-            },
-            {
-              'mountPath': '/tmp/keystoreSecrets/test',
-              'name': 'keystore-test'
-            },
-            {
-              'mountPath': '/tmp/keystoreSecrets/test-with-custom-path',
-              'name': 'keystore-test-with-custom-path'
-            }
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert s["initContainers"][-1]["volumeMounts"] == [
+        {"mountPath": "/tmp/keystore", "name": "keystore"},
+        {"mountPath": "/tmp/keystoreSecrets/test", "name": "keystore-test"},
+        {
+            "mountPath": "/tmp/keystoreSecrets/test-with-custom-path",
+            "name": "keystore-test-with-custom-path",
+        },
     ]
 
+
 def test_keystore_volumes():
-    config = '''
+    config = """
 keystore:
   - secretName: test
   - secretName: test-with-custom-path
     items:
     - key: slack_url
       path: xpack.notification.slack.account.otheraccount.secure_url
-'''
+"""
     r = helm_template(config)
-    s = r['statefulset'][uname]['spec']['template']['spec']
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
+
+    assert {"name": "keystore-test", "secret": {"secretName": "test"}} in s["volumes"]
 
     assert {
-             'name': 'keystore-test',
-             'secret': {
-                 'secretName': 'test'
-             }
-           } in s['volumes']
+        "name": "keystore-test-with-custom-path",
+        "secret": {
+            "secretName": "test-with-custom-path",
+            "items": [
+                {
+                    "key": "slack_url",
+                    "path": "xpack.notification.slack.account.otheraccount.secure_url",
+                }
+            ],
+        },
+    } in s["volumes"]
 
-    assert {
-             'name': 'keystore-test-with-custom-path',
-             'secret': {
-                 'secretName': 'test-with-custom-path',
-                 'items': [{
-                     'key': 'slack_url',
-                     'path': 'xpack.notification.slack.account.otheraccount.secure_url'
-                 }]
-             }
-           } in s['volumes']
+
 def test_pod_security_policy():
     ## Make sure the default config is not creating any resources
-    config = ''
-    resources = ('role', 'rolebinding', 'serviceaccount', 'podsecuritypolicy')
+    config = ""
+    resources = ("role", "rolebinding", "serviceaccount", "podsecuritypolicy")
     r = helm_template(config)
     for resource in resources:
         assert resource not in r
-    assert 'serviceAccountName' not in r['statefulset'][uname]['spec']['template']['spec']
+    assert (
+        "serviceAccountName" not in r["statefulset"][uname]["spec"]["template"]["spec"]
+    )
 
     ## Make sure all the resources are created with default values
-    config = '''
+    config = """
 rbac:
   create: true
   serviceAccountName: ""
@@ -997,21 +1079,35 @@ rbac:
 podSecurityPolicy:
   create: true
   name: ""
-'''
+"""
     r = helm_template(config)
     for resource in resources:
         assert resource in r
-    assert r['role'][uname]['rules'][0] == {"apiGroups": ["extensions"], "verbs": ["use"], "resources": ["podsecuritypolicies"], "resourceNames": [uname]}
-    assert r['rolebinding'][uname]['subjects'] == [{"kind": "ServiceAccount", "namespace": "default", "name": uname}]
-    assert r['rolebinding'][uname]['roleRef'] == {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": uname}
-    assert r['statefulset'][uname]['spec']['template']['spec']['serviceAccountName'] == uname
-    psp_spec = r['podsecuritypolicy'][uname]['spec']
-    assert psp_spec['privileged'] is True
+    assert r["role"][uname]["rules"][0] == {
+        "apiGroups": ["extensions"],
+        "verbs": ["use"],
+        "resources": ["podsecuritypolicies"],
+        "resourceNames": [uname],
+    }
+    assert r["rolebinding"][uname]["subjects"] == [
+        {"kind": "ServiceAccount", "namespace": "default", "name": uname}
+    ]
+    assert r["rolebinding"][uname]["roleRef"] == {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": uname,
+    }
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["serviceAccountName"]
+        == uname
+    )
+    psp_spec = r["podsecuritypolicy"][uname]["spec"]
+    assert psp_spec["privileged"] is True
 
 
 def test_external_pod_security_policy():
     ## Make sure we can use an externally defined pod security policy
-    config = '''
+    config = """
 rbac:
   create: true
   serviceAccountName: ""
@@ -1019,18 +1115,23 @@ rbac:
 podSecurityPolicy:
   create: false
   name: "customPodSecurityPolicy"
-'''
-    resources = ('role', 'rolebinding')
+"""
+    resources = ("role", "rolebinding")
     r = helm_template(config)
     for resource in resources:
         assert resource in r
 
-    assert r['role'][uname]['rules'][0] == {"apiGroups": ["extensions"], "verbs": ["use"], "resources": ["podsecuritypolicies"], "resourceNames": ["customPodSecurityPolicy"]}
+    assert r["role"][uname]["rules"][0] == {
+        "apiGroups": ["extensions"],
+        "verbs": ["use"],
+        "resources": ["podsecuritypolicies"],
+        "resourceNames": ["customPodSecurityPolicy"],
+    }
 
 
 def test_external_service_account():
     ## Make sure we can use an externally defined service account
-    config = '''
+    config = """
 rbac:
   create: false
   serviceAccountName: "customServiceAccountName"
@@ -1038,31 +1139,36 @@ rbac:
 podSecurityPolicy:
   create: false
   name: ""
-'''
-    resources = ('role', 'rolebinding', 'serviceaccount')
+"""
+    resources = ("role", "rolebinding", "serviceaccount")
     r = helm_template(config)
 
-    assert r['statefulset'][uname]['spec']['template']['spec']['serviceAccountName'] == "customServiceAccountName"
+    assert (
+        r["statefulset"][uname]["spec"]["template"]["spec"]["serviceAccountName"]
+        == "customServiceAccountName"
+    )
     # When referencing an external service account we do not want any resources to be created.
     for resource in resources:
         assert resource not in r
 
+
 def test_name_override():
     ## Make sure we can use a name override
-    config = '''
+    config = """
 nameOverride: "customName"
-'''
+"""
     r = helm_template(config)
 
-    assert "customName-master" in r['statefulset']
-    assert "customName-master" in r['service']
+    assert "customName-master" in r["statefulset"]
+    assert "customName-master" in r["service"]
+
 
 def test_full_name_override():
     ## Make sure we can use a full name override
-    config = '''
+    config = """
 fullnameOverride: "customfullName"
-'''
+"""
     r = helm_template(config)
 
-    assert "customfullName" in r['statefulset']
-    assert "customfullName" in r['service']
+    assert "customfullName" in r["statefulset"]
+    assert "customfullName" in r["service"]

--- a/filebeat/tests/filebeat_test.py
+++ b/filebeat/tests/filebeat_test.py
@@ -1,157 +1,180 @@
 import os
 import sys
-sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../helpers"))
 from helpers import helm_template
 
-project = 'filebeat'
-name = 'release-name-' + project
+project = "filebeat"
+name = "release-name-" + project
 
 
 def test_defaults():
-    config = '''
-    '''
+    config = """
+    """
 
     r = helm_template(config)
 
-    assert name in r['daemonset']
+    assert name in r["daemonset"]
 
-    c = r['daemonset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['name'] == project
-    assert c['image'].startswith('docker.elastic.co/beats/' + project + ':')
+    c = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["name"] == project
+    assert c["image"].startswith("docker.elastic.co/beats/" + project + ":")
 
-    assert c['env'][0]['name'] == 'POD_NAMESPACE'
-    assert c['env'][0]['valueFrom']['fieldRef']['fieldPath'] == 'metadata.namespace'
+    assert c["env"][0]["name"] == "POD_NAMESPACE"
+    assert c["env"][0]["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.namespace"
 
-    assert 'curl --fail 127.0.0.1:5066' in c['livenessProbe']['exec']['command'][-1]
+    assert "curl --fail 127.0.0.1:5066" in c["livenessProbe"]["exec"]["command"][-1]
 
-    assert 'filebeat test output' in c['readinessProbe']['exec']['command'][-1]
+    assert "filebeat test output" in c["readinessProbe"]["exec"]["command"][-1]
 
     # Empty customizable defaults
-    assert 'imagePullSecrets' not in r['daemonset'][name]['spec']['template']['spec']
-    assert 'tolerations' not in r['daemonset'][name]['spec']['template']['spec']
+    assert "imagePullSecrets" not in r["daemonset"][name]["spec"]["template"]["spec"]
+    assert "tolerations" not in r["daemonset"][name]["spec"]["template"]["spec"]
 
-    assert r['daemonset'][name]['spec']['updateStrategy']['type'] == 'RollingUpdate'
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "RollingUpdate"
 
-    assert r['daemonset'][name]['spec']['template']['spec']['serviceAccountName'] == name
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["serviceAccountName"] == name
+    )
 
-    volumes = r['daemonset'][name]['spec']['template']['spec']['volumes']
+    volumes = r["daemonset"][name]["spec"]["template"]["spec"]["volumes"]
     assert {
-            'name': 'data',
-                'hostPath': {
-                'path': '/var/lib/' + name + '-default-data',
-                'type': 'DirectoryOrCreate'
-                }
-           } in volumes
+        "name": "data",
+        "hostPath": {
+            "path": "/var/lib/" + name + "-default-data",
+            "type": "DirectoryOrCreate",
+        },
+    } in volumes
 
 
 def test_adding_envs():
-    config = '''
+    config = """
 extraEnvs:
 - name: LOG_LEVEL
   value: DEBUG
-'''
+"""
     r = helm_template(config)
-    envs = r['daemonset'][name]['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'LOG_LEVEL', 'value': 'DEBUG'} in envs
+    envs = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "LOG_LEVEL", "value": "DEBUG"} in envs
 
 
 def test_adding_a_extra_container():
-    config = '''
+    config = """
 extraContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraContainer = r['daemonset'][name]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainer
+    extraContainer = r["daemonset"][name]["spec"]["template"]["spec"]["containers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainer
 
 
 def test_adding_init_containers():
-    config = '''
+    config = """
 extraInitContainers:
 - name: dummy-init
   image: busybox
   command: ['echo', 'hey']
-'''
+"""
     r = helm_template(config)
-    initContainers = r['daemonset'][name]['spec']['template']['spec']['initContainers']
-    assert {'name': 'dummy-init', 'image': 'busybox', 'command': ['echo', 'hey']} in initContainers
+    initContainers = r["daemonset"][name]["spec"]["template"]["spec"]["initContainers"]
+    assert {
+        "name": "dummy-init",
+        "image": "busybox",
+        "command": ["echo", "hey"],
+    } in initContainers
 
 
 def test_adding_image_pull_secrets():
-    config = '''
+    config = """
 imagePullSecrets:
   - name: test-registry
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['imagePullSecrets'][0]['name'] == 'test-registry'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
+        == "test-registry"
+    )
 
 
 def test_adding_tolerations():
-    config = '''
+    config = """
 tolerations:
 - key: "key1"
   operator: "Equal"
   value: "value1"
   effect: "NoExecute"
   tolerationSeconds: 3600
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['tolerations'][0]['key'] == 'key1'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["tolerations"][0]["key"]
+        == "key1"
+    )
 
 
 def test_override_the_default_update_strategy():
-    config = '''
+    config = """
 updateStrategy: OnDelete
-'''
+"""
 
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['updateStrategy']['type'] == 'OnDelete'
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "OnDelete"
 
 
 def test_host_networking():
-    config = '''
+    config = """
 hostNetworking: true
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['hostNetwork'] is True
-    config = '''
+    assert r["daemonset"][name]["spec"]["template"]["spec"]["hostNetwork"] is True
+    config = """
 hostNetworking: false
-'''
+"""
     r = helm_template(config)
-    assert 'hostNetwork' not in r['daemonset'][name]['spec']['template']['spec']
+    assert "hostNetwork" not in r["daemonset"][name]["spec"]["template"]["spec"]
 
 
 def test_setting_a_custom_service_account():
-    config = '''
+    config = """
 serviceAccount: notdefault
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['serviceAccountName'] == 'notdefault'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["serviceAccountName"]
+        == "notdefault"
+    )
+
 
 def test_self_managing_rbac_resources():
-    config = '''
+    config = """
 managedServiceAccount: false
-'''
+"""
     r = helm_template(config)
-    assert 'serviceaccount' not in r
-    assert 'clusterrole' not in r
-    assert 'clusterrolebinding' not in r
+    assert "serviceaccount" not in r
+    assert "clusterrole" not in r
+    assert "clusterrolebinding" not in r
+
 
 def test_setting_pod_security_context():
-    config = '''
+    config = """
 podSecurityContext:
   runAsUser: 1001
   privileged: false
-'''
+"""
     r = helm_template(config)
-    c = r['daemonset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['runAsUser'] == 1001
-    assert c['securityContext']['privileged'] == False
+    c = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["runAsUser"] == 1001
+    assert c["securityContext"]["privileged"] == False
+
 
 def test_adding_in_filebeat_config():
-    config = '''
+    config = """
 filebeatConfig:
   filebeat.yml: |
     key:
@@ -160,50 +183,64 @@ filebeatConfig:
 
   other-config.yml: |
     hello = world
-'''
+"""
     r = helm_template(config)
-    c = r['configmap'][name + '-config']['data']
+    c = r["configmap"][name + "-config"]["data"]
 
-    assert 'filebeat.yml' in c
-    assert 'other-config.yml' in c
+    assert "filebeat.yml" in c
+    assert "other-config.yml" in c
 
-    assert 'nestedkey: value' in c['filebeat.yml']
-    assert 'dot.notation: test' in c['filebeat.yml']
+    assert "nestedkey: value" in c["filebeat.yml"]
+    assert "dot.notation: test" in c["filebeat.yml"]
 
-    assert 'hello = world' in c['other-config.yml']
+    assert "hello = world" in c["other-config.yml"]
 
-    d = r['daemonset'][name]['spec']['template']['spec']
+    d = r["daemonset"][name]["spec"]["template"]["spec"]
 
-    assert {'configMap': {'name': name + '-config', 'defaultMode': 0o600}, 'name': project + '-config'} in d['volumes']
-    assert {'mountPath': '/usr/share/filebeat/filebeat.yml', 'name': project + '-config', 'subPath': 'filebeat.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
-    assert {'mountPath': '/usr/share/filebeat/other-config.yml', 'name': project + '-config', 'subPath': 'other-config.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
+    assert {
+        "configMap": {"name": name + "-config", "defaultMode": 0o600},
+        "name": project + "-config",
+    } in d["volumes"]
+    assert {
+        "mountPath": "/usr/share/filebeat/filebeat.yml",
+        "name": project + "-config",
+        "subPath": "filebeat.yml",
+        "readOnly": True,
+    } in d["containers"][0]["volumeMounts"]
+    assert {
+        "mountPath": "/usr/share/filebeat/other-config.yml",
+        "name": project + "-config",
+        "subPath": "other-config.yml",
+        "readOnly": True,
+    } in d["containers"][0]["volumeMounts"]
 
-    assert 'configChecksum' in r['daemonset'][name]['spec']['template']['metadata']['annotations']
+    assert (
+        "configChecksum"
+        in r["daemonset"][name]["spec"]["template"]["metadata"]["annotations"]
+    )
 
 
 def test_adding_a_secret_mount():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/filebeat/config/certs
-'''
+"""
     r = helm_template(config)
-    s = r['daemonset'][name]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][0] == {
-        'mountPath': '/usr/share/filebeat/config/certs',
-        'name': 'elastic-certificates'
+    s = r["daemonset"][name]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][0] == {
+        "mountPath": "/usr/share/filebeat/config/certs",
+        "name": "elastic-certificates",
     }
-    assert s['volumes'][0] == {
-        'name': 'elastic-certificates',
-        'secret': {
-            'secretName': 'elastic-certs'
-        }
+    assert s["volumes"][0] == {
+        "name": "elastic-certificates",
+        "secret": {"secretName": "elastic-certs"},
     }
 
 
 def test_adding_a_extra_volume_with_volume_mount():
-    config = '''
+    config = """
 extraVolumes:
   - name: extras
     emptyDir: {}
@@ -211,34 +248,52 @@ extraVolumeMounts:
   - name: extras
     mountPath: /usr/share/extras
     readOnly: true
-'''
+"""
     r = helm_template(config)
-    extraVolume = r['daemonset'][name]['spec']['template']['spec']['volumes']
-    assert {'name': 'extras', 'emptyDir': {}} in extraVolume
-    extraVolumeMounts = r['daemonset'][name]['spec']['template']['spec']['containers'][0]['volumeMounts']
-    assert {'name': 'extras', 'mountPath': '/usr/share/extras', 'readOnly': True} in extraVolumeMounts
+    extraVolume = r["daemonset"][name]["spec"]["template"]["spec"]["volumes"]
+    assert {"name": "extras", "emptyDir": {}} in extraVolume
+    extraVolumeMounts = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["volumeMounts"]
+    assert {
+        "name": "extras",
+        "mountPath": "/usr/share/extras",
+        "readOnly": True,
+    } in extraVolumeMounts
+
 
 def test_adding_pod_labels():
-    config = '''
+    config = """
 labels:
   app.kubernetes.io/name: filebeat
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'filebeat'
-    assert r['daemonset'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'filebeat'
+    assert (
+        r["daemonset"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        == "filebeat"
+    )
+    assert (
+        r["daemonset"][name]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
+        == "filebeat"
+    )
 
 
 def test_adding_a_node_selector():
-    config = '''
+    config = """
 nodeSelector:
   disktype: ssd
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['nodeSelector']['disktype'] == 'ssd'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["nodeSelector"]["disktype"]
+        == "ssd"
+    )
 
 
 def test_adding_an_affinity_rule():
-    config = '''
+    config = """
 affinity:
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -249,52 +304,69 @@ affinity:
           values:
           - filebeat
       topologyKey: kubernetes.io/hostname
-'''
+"""
 
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['affinity']['podAntiAffinity'][
-        'requiredDuringSchedulingIgnoredDuringExecution'][0]['topologyKey'] == 'kubernetes.io/hostname'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"][
+            "requiredDuringSchedulingIgnoredDuringExecution"
+        ][0]["topologyKey"]
+        == "kubernetes.io/hostname"
+    )
+
 
 def test_priority_class_name():
-    config = '''
+    config = """
 priorityClassName: ""
-'''
+"""
     r = helm_template(config)
-    spec = r['daemonset'][name]['spec']['template']['spec']
-    assert 'priorityClassName' not in spec
+    spec = r["daemonset"][name]["spec"]["template"]["spec"]
+    assert "priorityClassName" not in spec
 
-    config = '''
+    config = """
 priorityClassName: "highest"
-'''
+"""
     r = helm_template(config)
-    priority_class_name = r['daemonset'][name]['spec']['template']['spec']['priorityClassName']
+    priority_class_name = r["daemonset"][name]["spec"]["template"]["spec"][
+        "priorityClassName"
+    ]
     assert priority_class_name == "highest"
 
+
 def test_adding_env_from():
-    config = '''
+    config = """
 envFrom:
 - configMapRef:
     name: configmap-name
-'''
+"""
     r = helm_template(config)
-    configMapRef = r['daemonset'][name]['spec']['template']['spec']['containers'][0]['envFrom'][0]['configMapRef']
-    assert configMapRef == {'name': 'configmap-name'}
+    configMapRef = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0][
+        "envFrom"
+    ][0]["configMapRef"]
+    assert configMapRef == {"name": "configmap-name"}
+
 
 def test_setting_fullnameOverride():
-    config = '''
+    config = """
 fullnameOverride: 'filebeat-custom'
-'''
+"""
     r = helm_template(config)
 
-    custom_name = 'filebeat-custom'
-    assert custom_name in r['daemonset']
-    assert r['daemonset'][custom_name]['spec']['template']['spec']['containers'][0]['name'] == project
-    assert r['daemonset'][custom_name]['spec']['template']['spec']['serviceAccountName'] == name
-    volumes = r['daemonset'][custom_name]['spec']['template']['spec']['volumes']
+    custom_name = "filebeat-custom"
+    assert custom_name in r["daemonset"]
+    assert (
+        r["daemonset"][custom_name]["spec"]["template"]["spec"]["containers"][0]["name"]
+        == project
+    )
+    assert (
+        r["daemonset"][custom_name]["spec"]["template"]["spec"]["serviceAccountName"]
+        == name
+    )
+    volumes = r["daemonset"][custom_name]["spec"]["template"]["spec"]["volumes"]
     assert {
-               'name': 'data',
-               'hostPath': {
-                   'path': '/var/lib/' + custom_name + '-default-data',
-                   'type': 'DirectoryOrCreate'
-               }
-           } in volumes
+        "name": "data",
+        "hostPath": {
+            "path": "/var/lib/" + custom_name + "-default-data",
+            "type": "DirectoryOrCreate",
+        },
+    } in volumes

--- a/helpers/bumper.py
+++ b/helpers/bumper.py
@@ -5,22 +5,22 @@ import glob
 import subprocess
 import fileinput
 
-os.chdir(os.path.join(os.path.dirname(__file__), '..'))
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
 
-chart_version = '7.5.2'
+chart_version = "7.5.2"
 
 versions = {
-    6: '6.8.6',
-    7: '7.5.2',
+    6: "6.8.6",
+    7: "7.5.2",
 }
 
 file_patterns = [
-    '*/examples/*/test/goss*.y*ml',
-    '*/examples/*/*.y*ml',
-    'helpers/examples.mk',
-    '*/README.md',
-    '*/values.y*ml',
-    '*/Chart.y*ml',
+    "*/examples/*/test/goss*.y*ml",
+    "*/examples/*/*.y*ml",
+    "helpers/examples.mk",
+    "*/README.md",
+    "*/values.y*ml",
+    "*/Chart.y*ml",
 ]
 
 # Anything matching this regex won't have version bumps changed
@@ -36,7 +36,7 @@ for major, version in versions.iteritems():
                 if re.match(blacklist, line):
                     print(line.rstrip())
                 else:
-                    if f.endswith('Chart.yaml') and line.startswith('version:'):
+                    if f.endswith("Chart.yaml") and line.startswith("version:"):
                         print(r.sub(chart_version, line.rstrip()))
                     else:
                         print(r.sub(version, line.rstrip()))

--- a/helpers/common.mk
+++ b/helpers/common.mk
@@ -29,3 +29,6 @@ helm:
 	kubectl get cs
 	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default || true
 	helm init --wait --upgrade
+
+lint-python:
+	black --diff --check .

--- a/helpers/common.mk
+++ b/helpers/common.mk
@@ -2,33 +2,46 @@ default: test
 
 .ONESHELL:
 
-lint:
-	grep 'charts/' ./.helmignore || echo 'charts/' >> ./.helmignore
-	helm lint --strict ./
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-template:
-	helm template ./
-
-build:
+.PHONY: build
+build: ## Build helm-tester docker image
 	cd ../helpers/helm-tester && \
 	for i in {1..5}; do docker build -t helm-tester . && break || sleep 15; done
 
-pytest:
-	pytest -sv --color=yes
-
-deps:
+.PHONY: deps
+deps: ## Update helm charts dependencies
 	sed --in-place '/charts\//d' ./.helmignore
 	helm dependency update
 
-test-all: lint deps template pytest
-
-test: build
-	docker run --rm -i --user "$$(id -u):$$(id -g)" -v $$(pwd)/../:/app -w /app/$$(basename $$(pwd)) helm-tester make test-all
-
-helm:
+.PHONY: helm
+helm: ## Deploy helm on k8s cluster
 	kubectl get cs
 	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default || true
 	helm init --wait --upgrade
 
-lint-python:
+.PHONY: lint
+lint: ## Lint helm templates
+	grep 'charts/' ./.helmignore || echo 'charts/' >> ./.helmignore
+	helm lint --strict ./
+
+.PHONY: lint-python
+lint-python: ## Lint python scripts
 	black --diff --check .
+
+.PHONY: pytest
+pytest: ## Run python tests
+	pytest -sv --color=yes
+
+.PHONY: template
+template: ## Render chart templates
+	helm template ./
+
+.PHONY: test
+test: build ## Run all tests in a docker container
+	docker run --rm -i --user "$$(id -u):$$(id -g)" -v $$(pwd)/../:/app -w /app/$$(basename $$(pwd)) helm-tester make test-all
+
+.PHONY: test-all ## Run all tests
+test-all: lint deps template pytest

--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -3,7 +3,12 @@ GOSS_FILE ?= goss.yaml
 GOSS_SELECTOR ?= release=$(RELEASE)
 STACK_VERSION := 7.5.2
 
-goss:
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.PHONY: goss
+goss: ## Run goss tests
 	GOSS_CONTAINER=$$(kubectl get --no-headers=true pods -l $(GOSS_SELECTOR) -o custom-columns=:metadata.name | sed -n 1p ) && \
 	echo Testing with pod: $$GOSS_CONTAINER && \
 	kubectl cp test/$(GOSS_FILE) $$GOSS_CONTAINER:/tmp/$(GOSS_FILE) && \

--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -4,21 +4,22 @@ import os
 import json
 from subprocess import check_output
 
+
 def helm_template(config):
     with tempfile.NamedTemporaryFile() as temp:
-        with open(temp.name, 'w') as values:
+        with open(temp.name, "w") as values:
             values.write(config)
-        helm_cmd = 'helm template -f {0} ./'.format(temp.name)
+        helm_cmd = "helm template -f {0} ./".format(temp.name)
         result = yaml.load_all(check_output(helm_cmd.split()))
 
         results = {}
         for r in result:
             if r:
-                kind = r['kind'].lower()
+                kind = r["kind"].lower()
                 if kind not in results:
                     results[kind] = {}
-                results[kind][r['metadata']['name']] = r
+                results[kind][r["metadata"]["name"]] = r
 
         if os.environ.get("DEBUG"):
             print(json.dumps(results, indent=4, sort_keys=True))
-        return(results)
+        return results

--- a/helpers/release.py
+++ b/helpers/release.py
@@ -10,52 +10,59 @@ try:
 except NameError:  # Python 3
     raw_input = input
 
-os.chdir(os.path.join(os.path.dirname(__file__), '..'))
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
 
-bucket = 'gs://' + os.environ['GCS_BUCKET']
+bucket = "gs://" + os.environ["GCS_BUCKET"]
 
 
 def run(cmd):
-    if 'DEBUG' in os.environ:
-        print(' '.join(cmd))
+    if "DEBUG" in os.environ:
+        print(" ".join(cmd))
     else:
         subprocess.check_call(cmd)
 
 
 # Cleanup existing releases
-for release in glob.glob('*/*.tgz'):
-    print('Removing: ' + release)
+for release in glob.glob("*/*.tgz"):
+    print("Removing: " + release)
     os.remove(release)
 
-for filepath in glob.iglob('*/Chart.yaml'):
+for filepath in glob.iglob("*/Chart.yaml"):
     chart = os.path.split(os.path.dirname(filepath))[-1]
 
     # Download dependencies
-    run(['helm', 'dependency', 'update', chart])
+    run(["helm", "dependency", "update", chart])
 
     # Package up the chart
-    run(['helm', 'package', chart, '--destination', chart])
+    run(["helm", "package", chart, "--destination", chart])
 
     # Upload it to the GCS bucket if it doesn't exist
-    source = '{chart}/{chart}-*.tgz'.format(**locals())
-    destination = '{bucket}/helm/{chart}/'.format(**locals())
-    run(['gsutil', 'cp', '-n', source, destination])
+    source = "{chart}/{chart}-*.tgz".format(**locals())
+    destination = "{bucket}/helm/{chart}/".format(**locals())
+    run(["gsutil", "cp", "-n", source, destination])
 
 # Grab the current index so we can merge it with the latest releases
-run(['gsutil', 'cp',
-     bucket + '/index.yaml', 'index.yaml.old'])
+run(["gsutil", "cp", bucket + "/index.yaml", "index.yaml.old"])
 
 # Merge it with the old index to include the older releases
-run(['helm', 'repo', 'index',
-     '--merge', 'index.yaml.old',
-     '--url', 'https://helm.elastic.co/helm/', '.'])
+run(
+    [
+        "helm",
+        "repo",
+        "index",
+        "--merge",
+        "index.yaml.old",
+        "--url",
+        "https://helm.elastic.co/helm/",
+        ".",
+    ]
+)
 
-with open('index.yaml', 'r') as index:
-    print('=' * 80)
+with open("index.yaml", "r") as index:
+    print("=" * 80)
     print(index.read())
-    print('=' * 80)
+    print("=" * 80)
 
 answer = raw_input('Upload new index.yaml? ("y" or "yes")\n')
-if answer in ['y', 'yes']:
-    run(['gsutil', 'cp',
-         'index.yaml', bucket + '/index.yaml'])
+if answer in ["y", "yes"]:
+    run(["gsutil", "cp", "index.yaml", bucket + "/index.yaml"])

--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -11,6 +11,10 @@ export TF_VAR_kubernetes_version=$(KUBERNETES_VERSION)
 
 .ONESHELL:
 
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
 credentials.json:
 	vault read -field=value \
 		"secret/devops-ci/helm-charts/gce/service-account" \
@@ -22,51 +26,57 @@ credentials.json:
 		-backend-config="prefix=$(CLUSTER_NAME)"
 
 .PHONY: init
-init: .terraform/terraform.tfstate
+init: .terraform/terraform.tfstate ## Initialize terraform working directory
 
 .PHONY: fmt
-fmt:
+fmt: ## Check terraform files format
 	terraform fmt -check=true -diff=true
 
-fmt-write:
+.PHONY: fmt-write
+fmt-write: ## Format terraform files
 	terraform fmt -write=true
 
 .PHONY: output
-output: init fmt
+output: init fmt ## Show terraform outputs
 	terraform output
 
 .PHONY: plan
-plan: init fmt
+plan: init fmt ## Show terraform execution plan
 	terraform plan -input=false
 
 .PHONY: apply
-apply: init fmt
+apply: init fmt ## Apply terraform execution plan
 	terraform apply -input=false -auto-approve
 
 .PHONY: destroy
-destroy: init credentials.json creds
+destroy: init credentials.json creds ## Destroy gke cluster
 	kubectl delete namespace $(NAMESPACE)
 	terraform destroy -input=false --force
 
-creds: credentials.json
+.PHONY: creds
+creds: credentials.json ## Get gke credentials
 	gcloud auth activate-service-account --key-file=${GOOGLE_CREDENTIALS}
 	gcloud --project=$(GOOGLE_PROJECT) container clusters get-credentials $(CLUSTER_NAME) --zone us-central1-a
 	kubectl create namespace $(NAMESPACE) || true
 	kubectl config set-context $$(kubectl config current-context) --namespace=$(NAMESPACE)
 
-k8s: apply creds
+.PHONY: k8s
+k8s: apply creds ## Configure gke cluster
 	kubectl get cs
 
-up: k8s
+.PHONY: up
+up: k8s ## Install helm on gke cluster
 	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default || true
 	for i in 1 2 3 4 5; do helm init --wait --upgrade && break || sleep 5; done
 
-integration: creds
+.PHONY: integration
+integration: creds ## Deploy helm chart and run integration tests
 	cd ../../$(CHART)/ && \
 	helm init --client-only && \
 	helm dependency update && \
 	cd ./examples/$(SUITE) && \
 	make
 
-build: 
+.PHONY: build
+build: ## Build helm-charts docker image
 	for i in 1 2 3 4 5; do docker build -t helm-charts . && break || sleep 5; done

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -1,124 +1,136 @@
 import os
 import sys
-sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../helpers"))
 from helpers import helm_template
 import yaml
 
-name = 'release-name-kibana'
-elasticsearchHosts = 'http://elasticsearch-master:9200'
+name = "release-name-kibana"
+elasticsearchHosts = "http://elasticsearch-master:9200"
 
 
 def test_defaults():
-    config = '''
-    '''
+    config = """
+    """
 
     r = helm_template(config)
 
-    assert name in r['deployment']
-    assert name in r['service']
+    assert name in r["deployment"]
+    assert name in r["service"]
 
-    s = r['service'][name]['spec']
-    assert s['ports'][0]['port'] == 5601
-    assert s['ports'][0]['name'] == 'http'
-    assert s['ports'][0]['protocol'] == 'TCP'
-    assert s['ports'][0]['targetPort'] == 5601
+    s = r["service"][name]["spec"]
+    assert s["ports"][0]["port"] == 5601
+    assert s["ports"][0]["name"] == "http"
+    assert s["ports"][0]["protocol"] == "TCP"
+    assert s["ports"][0]["targetPort"] == 5601
 
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['name'] == 'kibana'
-    assert c['image'].startswith('docker.elastic.co/kibana/kibana:')
-    assert c['ports'][0]['containerPort'] == 5601
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["name"] == "kibana"
+    assert c["image"].startswith("docker.elastic.co/kibana/kibana:")
+    assert c["ports"][0]["containerPort"] == 5601
 
-    assert c['env'][0]['name'] == 'ELASTICSEARCH_HOSTS'
-    assert c['env'][0]['value'] == elasticsearchHosts
+    assert c["env"][0]["name"] == "ELASTICSEARCH_HOSTS"
+    assert c["env"][0]["value"] == elasticsearchHosts
 
-    assert c['env'][1]['name'] == 'SERVER_HOST'
-    assert c['env'][1]['value'] == '0.0.0.0'
+    assert c["env"][1]["name"] == "SERVER_HOST"
+    assert c["env"][1]["value"] == "0.0.0.0"
 
-    assert 'http "/app/kibana"' in c['readinessProbe']['exec']['command'][-1]
+    assert 'http "/app/kibana"' in c["readinessProbe"]["exec"]["command"][-1]
 
     # Empty customizable defaults
-    assert 'imagePullSecrets' not in r['deployment'][name]['spec']['template']['spec']
-    assert 'tolerations' not in r['deployment'][name]['spec']['template']['spec']
-    assert 'nodeSelector' not in r['deployment'][name]['spec']['template']['spec']
-    assert 'ingress' not in r
+    assert "imagePullSecrets" not in r["deployment"][name]["spec"]["template"]["spec"]
+    assert "tolerations" not in r["deployment"][name]["spec"]["template"]["spec"]
+    assert "nodeSelector" not in r["deployment"][name]["spec"]["template"]["spec"]
+    assert "ingress" not in r
 
-    assert r['deployment'][name]['spec']['strategy']['type'] == 'Recreate'
+    assert r["deployment"][name]["spec"]["strategy"]["type"] == "Recreate"
 
     # Make sure that the default 'annotation' dictionary is empty
-    assert 'annotations' not in r['service'][name]['metadata']
+    assert "annotations" not in r["service"][name]["metadata"]
 
     # Make sure that the default 'loadBalancerSourceRanges' list is empty
-    assert 'loadBalancerSourceRanges' not in r['service'][name]['spec']
+    assert "loadBalancerSourceRanges" not in r["service"][name]["spec"]
+
 
 def test_overriding_the_elasticsearch_hosts():
-    config = '''
+    config = """
     elasticsearchHosts: 'http://hello.world'
-    '''
+    """
 
     r = helm_template(config)
 
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['env'][0]['name'] == 'ELASTICSEARCH_HOSTS'
-    assert c['env'][0]['value'] == 'http://hello.world'
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["env"][0]["name"] == "ELASTICSEARCH_HOSTS"
+    assert c["env"][0]["value"] == "http://hello.world"
+
 
 def test_overriding_the_elasticsearch_url():
-    config = '''
+    config = """
     elasticsearchURL: 'http://hello.world'
-    '''
+    """
 
     r = helm_template(config)
 
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['env'][0]['name'] == 'ELASTICSEARCH_URL'
-    assert c['env'][0]['value'] == 'http://hello.world'
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["env"][0]["name"] == "ELASTICSEARCH_URL"
+    assert c["env"][0]["value"] == "http://hello.world"
 
 
 def test_overriding_the_port():
-    config = '''
+    config = """
     httpPort: 5602
-    '''
+    """
 
     r = helm_template(config)
 
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['ports'][0]['containerPort'] == 5602
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["ports"][0]["containerPort"] == 5602
 
-    assert r['service'][name]['spec']['ports'][0]['targetPort'] == 5602
+    assert r["service"][name]["spec"]["ports"][0]["targetPort"] == 5602
 
 
 def test_adding_image_pull_secrets():
-    config = '''
+    config = """
 imagePullSecrets:
   - name: test-registry
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['imagePullSecrets'][0]['name'] == 'test-registry'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
+        == "test-registry"
+    )
 
 
 def test_adding_tolerations():
-    config = '''
+    config = """
 tolerations:
 - key: "key1"
   operator: "Equal"
   value: "value1"
   effect: "NoExecute"
   tolerationSeconds: 3600
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['tolerations'][0]['key'] == 'key1'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["tolerations"][0]["key"]
+        == "key1"
+    )
 
 
 def test_adding_a_node_selector():
-    config = '''
+    config = """
 nodeSelector:
   disktype: ssd
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['nodeSelector']['disktype'] == 'ssd'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["nodeSelector"]["disktype"]
+        == "ssd"
+    )
 
 
 def test_adding_an_affinity_rule():
-    config = '''
+    config = """
 affinity:
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -129,39 +141,53 @@ affinity:
           values:
           - kibana
       topologyKey: kubernetes.io/hostname
-'''
+"""
 
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['affinity']['podAntiAffinity'][
-        'requiredDuringSchedulingIgnoredDuringExecution'][0]['topologyKey'] == 'kubernetes.io/hostname'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["affinity"][
+            "podAntiAffinity"
+        ]["requiredDuringSchedulingIgnoredDuringExecution"][0]["topologyKey"]
+        == "kubernetes.io/hostname"
+    )
 
 
 def test_adding_a_extra_container():
-    config = '''
+    config = """
 extraContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraContainer = r['deployment'][name]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainer
+    extraContainer = r["deployment"][name]["spec"]["template"]["spec"]["containers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainer
 
 
 def test_adding_a_extra_init_container():
-    config = '''
+    config = """
 extraInitContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraInitContainer = r['deployment'][name]['spec']['template']['spec']['initContainers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraInitContainer
+    extraInitContainer = r["deployment"][name]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraInitContainer
 
 
 def test_adding_an_ingress_rule():
-    config = '''
+    config = """
 ingress:
   enabled: true
   annotations:
@@ -173,21 +199,22 @@ ingress:
   - secretName: elastic-co-wildcard
     hosts:
      - kibana.elastic.co
-'''
+"""
 
     r = helm_template(config)
-    assert name in r['ingress']
-    i = r['ingress'][name]['spec']
-    assert i['tls'][0]['hosts'][0] == 'kibana.elastic.co'
-    assert i['tls'][0]['secretName'] == 'elastic-co-wildcard'
+    assert name in r["ingress"]
+    i = r["ingress"][name]["spec"]
+    assert i["tls"][0]["hosts"][0] == "kibana.elastic.co"
+    assert i["tls"][0]["secretName"] == "elastic-co-wildcard"
 
-    assert i['rules'][0]['host'] == 'kibana.elastic.co'
-    assert i['rules'][0]['http']['paths'][0]['path'] == '/'
-    assert i['rules'][0]['http']['paths'][0]['backend']['serviceName'] == name
-    assert i['rules'][0]['http']['paths'][0]['backend']['servicePort'] == 5601
+    assert i["rules"][0]["host"] == "kibana.elastic.co"
+    assert i["rules"][0]["http"]["paths"][0]["path"] == "/"
+    assert i["rules"][0]["http"]["paths"][0]["backend"]["serviceName"] == name
+    assert i["rules"][0]["http"]["paths"][0]["backend"]["servicePort"] == 5601
+
 
 def test_adding_an_ingress_rule_wildcard():
-    config = '''
+    config = """
 ingress:
   enabled: true
   annotations:
@@ -199,60 +226,74 @@ ingress:
   - secretName: elastic-co-wildcard
     hosts:
      - "*.elastic.co"
-'''
+"""
 
     r = helm_template(config)
-    assert name in r['ingress']
-    i = r['ingress'][name]['spec']
-    assert i['tls'][0]['hosts'][0] == '*.elastic.co'
-    assert i['tls'][0]['secretName'] == 'elastic-co-wildcard'
+    assert name in r["ingress"]
+    i = r["ingress"][name]["spec"]
+    assert i["tls"][0]["hosts"][0] == "*.elastic.co"
+    assert i["tls"][0]["secretName"] == "elastic-co-wildcard"
 
-    assert i['rules'][0]['host'] == 'kibana.elastic.co'
-    assert i['rules'][0]['http']['paths'][0]['path'] == '/'
-    assert i['rules'][0]['http']['paths'][0]['backend']['serviceName'] == name
-    assert i['rules'][0]['http']['paths'][0]['backend']['servicePort'] == 5601
-
+    assert i["rules"][0]["host"] == "kibana.elastic.co"
+    assert i["rules"][0]["http"]["paths"][0]["path"] == "/"
+    assert i["rules"][0]["http"]["paths"][0]["backend"]["serviceName"] == name
+    assert i["rules"][0]["http"]["paths"][0]["backend"]["servicePort"] == 5601
 
 
 def test_override_the_default_update_strategy():
-    config = '''
+    config = """
 updateStrategy:
   type: "RollingUpdate"
   rollingUpdate:
     maxUnavailable: 1
     maxSurge: 1
-'''
+"""
 
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['strategy']['type'] == 'RollingUpdate'
-    assert r['deployment'][name]['spec']['strategy']['rollingUpdate']['maxUnavailable'] == 1
-    assert r['deployment'][name]['spec']['strategy']['rollingUpdate']['maxSurge'] == 1
+    assert r["deployment"][name]["spec"]["strategy"]["type"] == "RollingUpdate"
+    assert (
+        r["deployment"][name]["spec"]["strategy"]["rollingUpdate"]["maxUnavailable"]
+        == 1
+    )
+    assert r["deployment"][name]["spec"]["strategy"]["rollingUpdate"]["maxSurge"] == 1
+
 
 def test_using_a_name_override():
-    config = '''
+    config = """
 nameOverride: overrider
-'''
+"""
 
     r = helm_template(config)
-    assert 'overrider-kibana' in r['deployment']
+    assert "overrider-kibana" in r["deployment"]
+
 
 def test_setting_a_custom_service_account():
-    config = '''
+    config = """
 serviceAccount: notdefault
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['serviceAccount'] == 'notdefault'
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["serviceAccount"]
+        == "notdefault"
+    )
+
 
 def test_setting_pod_security_context():
-    config = '''
+    config = """
 podSecurityContext:
   runAsUser: 1001
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['spec']['securityContext']['runAsUser'] == 1001
+    assert (
+        r["deployment"][name]["spec"]["template"]["spec"]["securityContext"][
+            "runAsUser"
+        ]
+        == 1001
+    )
+
 
 def test_adding_in_kibana_config():
-    config = '''
+    config = """
 kibanaConfig:
   kibana.yml: |
     key:
@@ -261,229 +302,278 @@ kibanaConfig:
 
   other-config.yml: |
     hello = world
-'''
+"""
     r = helm_template(config)
-    c = r['configmap'][name + '-config']['data']
+    c = r["configmap"][name + "-config"]["data"]
 
-    assert 'kibana.yml' in c
-    assert 'other-config.yml' in c
+    assert "kibana.yml" in c
+    assert "other-config.yml" in c
 
-    assert 'nestedkey: value' in c['kibana.yml']
-    assert 'dot.notation: test' in c['kibana.yml']
+    assert "nestedkey: value" in c["kibana.yml"]
+    assert "dot.notation: test" in c["kibana.yml"]
 
-    assert 'hello = world' in c['other-config.yml']
+    assert "hello = world" in c["other-config.yml"]
 
-    d = r['deployment'][name]['spec']['template']['spec']
+    d = r["deployment"][name]["spec"]["template"]["spec"]
 
-    assert {'configMap': {'name': name + '-config'}, 'name': 'kibanaconfig'} in d['volumes']
-    assert {'mountPath': '/usr/share/kibana/config/kibana.yml', 'name': 'kibanaconfig', 'subPath': 'kibana.yml'} in d['containers'][0]['volumeMounts']
-    assert {'mountPath': '/usr/share/kibana/config/other-config.yml', 'name': 'kibanaconfig', 'subPath': 'other-config.yml'} in d['containers'][0]['volumeMounts']
+    assert {"configMap": {"name": name + "-config"}, "name": "kibanaconfig"} in d[
+        "volumes"
+    ]
+    assert {
+        "mountPath": "/usr/share/kibana/config/kibana.yml",
+        "name": "kibanaconfig",
+        "subPath": "kibana.yml",
+    } in d["containers"][0]["volumeMounts"]
+    assert {
+        "mountPath": "/usr/share/kibana/config/other-config.yml",
+        "name": "kibanaconfig",
+        "subPath": "other-config.yml",
+    } in d["containers"][0]["volumeMounts"]
 
-    assert 'configchecksum' in r['deployment'][name]['spec']['template']['metadata']['annotations']
+    assert (
+        "configchecksum"
+        in r["deployment"][name]["spec"]["template"]["metadata"]["annotations"]
+    )
+
 
 def test_changing_the_protocol():
-    config = '''
+    config = """
 protocol: https
-'''
+"""
     r = helm_template(config)
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert 'https://' in c['readinessProbe']['exec']['command'][-1]
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert "https://" in c["readinessProbe"]["exec"]["command"][-1]
+
 
 def test_changing_the_health_check_path():
-    config = '''
+    config = """
 healthCheckPath: "/kibana/app/kibana"
-'''
+"""
     r = helm_template(config)
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
 
-    assert 'http "/kibana/app/kibana"' in c['readinessProbe']['exec']['command'][-1]
+    assert 'http "/kibana/app/kibana"' in c["readinessProbe"]["exec"]["command"][-1]
 
 
 def test_priority_class_name():
-    config = '''
+    config = """
 priorityClassName: ""
-'''
+"""
     r = helm_template(config)
-    spec = r['deployment'][name]['spec']['template']['spec']
-    assert 'priorityClassName' not in spec
+    spec = r["deployment"][name]["spec"]["template"]["spec"]
+    assert "priorityClassName" not in spec
 
-    config = '''
+    config = """
 priorityClassName: "highest"
-'''
+"""
     r = helm_template(config)
-    priority_class_name = r['deployment'][name]['spec']['template']['spec']['priorityClassName']
+    priority_class_name = r["deployment"][name]["spec"]["template"]["spec"][
+        "priorityClassName"
+    ]
     assert priority_class_name == "highest"
 
+
 def test_service_labels():
-    config = ''
+    config = ""
 
     r = helm_template(config)
 
-    assert 'label1' not in r['service'][name]['metadata']['labels']
+    assert "label1" not in r["service"][name]["metadata"]["labels"]
 
-    config = '''
+    config = """
     service:
       labels:
         label1: value1
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['service'][name]['metadata']['labels']['label1'] == 'value1'
+    assert r["service"][name]["metadata"]["labels"]["label1"] == "value1"
+
 
 def test_service_annotations():
-    config = '''
+    config = """
 service:
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
-    '''
+    """
     r = helm_template(config)
-    s = r['service'][name]['metadata']['annotations']['cloud.google.com/load-balancer-type']
+    s = r["service"][name]["metadata"]["annotations"][
+        "cloud.google.com/load-balancer-type"
+    ]
     assert s == "Internal"
 
-    config = '''
+    config = """
 service:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-    '''
+    """
     r = helm_template(config)
-    s = r['service'][name]['metadata']['annotations']['service.beta.kubernetes.io/aws-load-balancer-internal']
+    s = r["service"][name]["metadata"]["annotations"][
+        "service.beta.kubernetes.io/aws-load-balancer-internal"
+    ]
     assert s == "0.0.0.0/0"
 
 
 def test_service_load_balancer_source_ranges():
-    config = '''
+    config = """
 service:
   loadBalancerSourceRanges:
     - 0.0.0.0/0
-    '''
+    """
     r = helm_template(config)
-    l = r['service'][name]['spec']['loadBalancerSourceRanges'][0]
+    l = r["service"][name]["spec"]["loadBalancerSourceRanges"][0]
     assert l == "0.0.0.0/0"
 
-    config = '''
+    config = """
 service:
   loadBalancerSourceRanges:
     - 192.168.0.0/24
     - 192.168.1.0/24
-    '''
+    """
     r = helm_template(config)
-    l = r['service'][name]['spec']['loadBalancerSourceRanges'][0]
+    l = r["service"][name]["spec"]["loadBalancerSourceRanges"][0]
     assert l == "192.168.0.0/24"
-    l = r['service'][name]['spec']['loadBalancerSourceRanges'][1]
+    l = r["service"][name]["spec"]["loadBalancerSourceRanges"][1]
     assert l == "192.168.1.0/24"
 
 
 def test_adding_a_nodePort():
-    config = ''
+    config = ""
 
     r = helm_template(config)
 
-    assert 'nodePort' not in r['service'][name]['spec']['ports'][0]
+    assert "nodePort" not in r["service"][name]["spec"]["ports"][0]
 
-    config = '''
+    config = """
     service:
       nodePort: 30001
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['service'][name]['spec']['ports'][0]['nodePort'] == 30001
+    assert r["service"][name]["spec"]["ports"][0]["nodePort"] == 30001
+
 
 def test_override_the_serverHost():
-    config = '''
+    config = """
     serverHost: "localhost"
-    '''
+    """
 
     r = helm_template(config)
 
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['env'][1]['name'] == 'SERVER_HOST'
-    assert c['env'][1]['value'] == 'localhost'
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["env"][1]["name"] == "SERVER_HOST"
+    assert c["env"][1]["value"] == "localhost"
+
 
 def test_adding_pod_annotations():
-    config = '''
+    config = """
 podAnnotations:
   iam.amazonaws.com/role: es-role
-'''
+"""
     r = helm_template(config)
-    assert r['deployment'][name]['spec']['template']['metadata']['annotations']['iam.amazonaws.com/role'] == 'es-role'
+    assert (
+        r["deployment"][name]["spec"]["template"]["metadata"]["annotations"][
+            "iam.amazonaws.com/role"
+        ]
+        == "es-role"
+    )
+
 
 def test_override_imagePullPolicy():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['imagePullPolicy'] == 'IfNotPresent'
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["imagePullPolicy"] == "IfNotPresent"
 
-    config = '''
+    config = """
     imagePullPolicy: Always
-    '''
+    """
 
     r = helm_template(config)
-    c = r['deployment'][name]['spec']['template']['spec']['containers'][0]
-    assert c['imagePullPolicy'] == 'Always'
+    c = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["imagePullPolicy"] == "Always"
+
 
 def test_adding_pod_labels():
-     config = '''
+    config = """
 labels:
   app.kubernetes.io/name: kibana
-'''
-     r = helm_template(config)
-     assert r['deployment'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'kibana'
-     assert r['deployment'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'kibana'
+"""
+    r = helm_template(config)
+    assert (
+        r["deployment"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        == "kibana"
+    )
+    assert (
+        r["deployment"][name]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
+        == "kibana"
+    )
+
 
 def test_adding_a_secret_mount_with_subpath():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/elasticsearch/config/certs
     subPath: cert.crt
-'''
+"""
     r = helm_template(config)
-    d = r['deployment'][name]['spec']['template']['spec']
-    assert d['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/elasticsearch/config/certs',
-        'subPath': 'cert.crt',
-        'name': 'elastic-certificates'
+    d = r["deployment"][name]["spec"]["template"]["spec"]
+    assert d["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/elasticsearch/config/certs",
+        "subPath": "cert.crt",
+        "name": "elastic-certificates",
     }
 
+
 def test_adding_a_secret_mount_without_subpath():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/elasticsearch/config/certs
-'''
+"""
     r = helm_template(config)
-    d = r['deployment'][name]['spec']['template']['spec']
-    assert d['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/elasticsearch/config/certs',
-        'name': 'elastic-certificates'
+    d = r["deployment"][name]["spec"]["template"]["spec"]
+    assert d["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/elasticsearch/config/certs",
+        "name": "elastic-certificates",
     }
 
+
 def test_adding_lifecycle_events():
-    config = '''
+    config = """
 lifecycle:
     postStart:
         exec:
             command: ['/bin/true']
-'''
+"""
     r = helm_template(config)
-    d = r['deployment'][name]['spec']['template']['spec']
-    p = d['containers'][0]['lifecycle']['postStart']
-    assert p['exec']['command'][0] == '/bin/true'
+    d = r["deployment"][name]["spec"]["template"]["spec"]
+    p = d["containers"][0]["lifecycle"]["postStart"]
+    assert p["exec"]["command"][0] == "/bin/true"
+
 
 def test_setting_fullnameOverride():
-    config = '''
+    config = """
 fullnameOverride: 'kibana-custom'
-'''
+"""
     r = helm_template(config)
 
-    custom_name = 'kibana-custom'
-    assert custom_name in r['deployment']
-    assert custom_name in r['service']
+    custom_name = "kibana-custom"
+    assert custom_name in r["deployment"]
+    assert custom_name in r["service"]
 
-    assert r['service'][custom_name]['spec']['ports'][0]['port'] == 5601
-    assert r['deployment'][custom_name]['spec']['template']['spec']['containers'][0]['name'] == 'kibana'
+    assert r["service"][custom_name]["spec"]["ports"][0]["port"] == 5601
+    assert (
+        r["deployment"][custom_name]["spec"]["template"]["spec"]["containers"][0][
+            "name"
+        ]
+        == "kibana"
+    )

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -1,153 +1,148 @@
 import os
 import sys
-sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../helpers"))
 from helpers import helm_template
 import yaml
 
 
-name="release-name-logstash"
+name = "release-name-logstash"
 
 
 def test_defaults():
-    config = '''
-'''
+    config = """
+"""
 
     r = helm_template(config)
 
     # Statefulset
-    assert r['statefulset'][name]['spec']['replicas'] == 1
-    assert r['statefulset'][name]['spec']['updateStrategy'] == {
-        'type': 'RollingUpdate'}
-    assert r['statefulset'][name]['spec']['podManagementPolicy'] == 'Parallel'
-    assert r['statefulset'][name]['spec']['template']['spec']['affinity']['podAntiAffinity']['requiredDuringSchedulingIgnoredDuringExecution'][0] == \
-        {
-            "labelSelector": {
-                "matchExpressions": [
-                    {
-                        "key": "app",
-                        "operator": "In",
-                        "values": [
-                            name
-                        ]
-                    }
-                ]
-            },
-            "topologyKey": "kubernetes.io/hostname"
+    assert r["statefulset"][name]["spec"]["replicas"] == 1
+    assert r["statefulset"][name]["spec"]["updateStrategy"] == {"type": "RollingUpdate"}
+    assert r["statefulset"][name]["spec"]["podManagementPolicy"] == "Parallel"
+    assert r["statefulset"][name]["spec"]["template"]["spec"]["affinity"][
+        "podAntiAffinity"
+    ]["requiredDuringSchedulingIgnoredDuringExecution"][0] == {
+        "labelSelector": {
+            "matchExpressions": [{"key": "app", "operator": "In", "values": [name]}]
+        },
+        "topologyKey": "kubernetes.io/hostname",
     }
 
     # Default environment variables
     env_vars = [
-        {
-            'name': 'LS_JAVA_OPTS',
-            'value': '-Xmx1g -Xms1g'
-        },
+        {"name": "LS_JAVA_OPTS", "value": "-Xmx1g -Xms1g"},
     ]
 
-    c = r['statefulset'][name]['spec']['template']['spec']['containers'][0]
+    c = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]
     for env in env_vars:
-        assert env in c['env']
+        assert env in c["env"]
 
     # Image
-    assert c['image'].startswith(
-        'docker.elastic.co/logstash/logstash:')
-    assert c['imagePullPolicy'] == 'IfNotPresent'
-    assert c['name'] == 'logstash'
+    assert c["image"].startswith("docker.elastic.co/logstash/logstash:")
+    assert c["imagePullPolicy"] == "IfNotPresent"
+    assert c["name"] == "logstash"
 
     # Ports
-    assert c['ports'][0] == {'name': 'http', 'containerPort': 9600}
+    assert c["ports"][0] == {"name": "http", "containerPort": 9600}
 
     # Health checks
-    assert c['livenessProbe']['failureThreshold'] == 3
-    assert c['livenessProbe']['initialDelaySeconds'] == 300
-    assert c['livenessProbe']['periodSeconds'] == 10
-    assert c['livenessProbe']['successThreshold'] == 1
-    assert c['livenessProbe']['timeoutSeconds'] == 5
-    assert '/' in c['livenessProbe']['httpGet']['path']
-    assert 'http' in c['livenessProbe']['httpGet']['port']
+    assert c["livenessProbe"]["failureThreshold"] == 3
+    assert c["livenessProbe"]["initialDelaySeconds"] == 300
+    assert c["livenessProbe"]["periodSeconds"] == 10
+    assert c["livenessProbe"]["successThreshold"] == 1
+    assert c["livenessProbe"]["timeoutSeconds"] == 5
+    assert "/" in c["livenessProbe"]["httpGet"]["path"]
+    assert "http" in c["livenessProbe"]["httpGet"]["port"]
 
-    assert c['readinessProbe']['failureThreshold'] == 3
-    assert c['readinessProbe']['initialDelaySeconds'] == 60
-    assert c['readinessProbe']['periodSeconds'] == 10
-    assert c['readinessProbe']['successThreshold'] == 3
-    assert c['readinessProbe']['timeoutSeconds'] == 5
-    assert '/' in c['readinessProbe']['httpGet']['path']
-    assert 'http' in c['readinessProbe']['httpGet']['port']
+    assert c["readinessProbe"]["failureThreshold"] == 3
+    assert c["readinessProbe"]["initialDelaySeconds"] == 60
+    assert c["readinessProbe"]["periodSeconds"] == 10
+    assert c["readinessProbe"]["successThreshold"] == 3
+    assert c["readinessProbe"]["timeoutSeconds"] == 5
+    assert "/" in c["readinessProbe"]["httpGet"]["path"]
+    assert "http" in c["readinessProbe"]["httpGet"]["port"]
 
     # Resources
-    assert c['resources'] == {
-        'requests': {
-            'cpu': '100m',
-            'memory': '1536Mi'
-        },
-        'limits': {
-            'cpu': '1000m',
-            'memory': '1536Mi'
-        }
+    assert c["resources"] == {
+        "requests": {"cpu": "100m", "memory": "1536Mi"},
+        "limits": {"cpu": "1000m", "memory": "1536Mi"},
     }
 
     # Persistence
-    assert 'volumeClaimTemplates' not in r['statefulset'][name]['spec']
-    assert r['statefulset'][name]['spec']['template']['spec']['containers'][0]['volumeMounts'] == None
+    assert "volumeClaimTemplates" not in r["statefulset"][name]["spec"]
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0][
+            "volumeMounts"
+        ]
+        == None
+    )
 
     # Service
-    assert 'serviceName' not in r['statefulset'][name]['spec']
-    assert 'service' not in r
-
+    assert "serviceName" not in r["statefulset"][name]["spec"]
+    assert "service" not in r
 
     # Other
-    assert r['statefulset'][name]['spec']['template']['spec']['securityContext'] == {
-        'fsGroup': 1000,
-        'runAsUser': 1000
+    assert r["statefulset"][name]["spec"]["template"]["spec"]["securityContext"] == {
+        "fsGroup": 1000,
+        "runAsUser": 1000,
     }
-    assert r['statefulset'][name]['spec']['template']['spec']['terminationGracePeriodSeconds'] == 120
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"][
+            "terminationGracePeriodSeconds"
+        ]
+        == 120
+    )
 
     # Pod disruption budget
-    assert r['poddisruptionbudget'][name + '-pdb']['spec']['maxUnavailable'] == 1
+    assert r["poddisruptionbudget"][name + "-pdb"]["spec"]["maxUnavailable"] == 1
 
     # Empty customizable defaults
-    assert 'imagePullSecrets' not in r['statefulset'][name]['spec']['template']['spec']
-    assert 'tolerations' not in r['statefulset'][name]['spec']['template']['spec']
-    assert 'nodeSelector' not in r['statefulset'][name]['spec']['template']['spec']
+    assert "imagePullSecrets" not in r["statefulset"][name]["spec"]["template"]["spec"]
+    assert "tolerations" not in r["statefulset"][name]["spec"]["template"]["spec"]
+    assert "nodeSelector" not in r["statefulset"][name]["spec"]["template"]["spec"]
 
 
 def test_increasing_the_replicas():
-    config = '''
+    config = """
 replicas: 5
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['replicas'] == 5
+    assert r["statefulset"][name]["spec"]["replicas"] == 5
 
 
 def test_disabling_pod_disruption_budget():
-    config = '''
+    config = """
 maxUnavailable: false
-'''
+"""
     r = helm_template(config)
-    assert 'poddisruptionbudget' not in r
+    assert "poddisruptionbudget" not in r
 
 
 def test_overriding_the_image_and_tag():
-    config = '''
+    config = """
 image: customImage
 imageTag: 6.2.4
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['spec']['containers'][0]['image'] == 'customImage:6.2.4'
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]["image"]
+        == "customImage:6.2.4"
+    )
 
 
 def test_adding_extra_env_vars():
-    config = '''
+    config = """
 extraEnvs:
   - name: hello
     value: world
-'''
+"""
     r = helm_template(config)
-    env = r['statefulset'][name]['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'hello', 'value': 'world'} in env
+    env = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "hello", "value": "world"} in env
 
 
 def test_adding_a_extra_volume_with_volume_mount():
-    config = '''
+    config = """
 extraVolumes: |
   - name: extras
     emptyDir: {}
@@ -155,161 +150,194 @@ extraVolumeMounts: |
   - name: extras
     mountPath: /usr/share/extras
     readOnly: true
-'''
+"""
     r = helm_template(config)
-    extraVolume = r['statefulset'][name]['spec']['template']['spec']['volumes']
-    assert {'name': 'extras', 'emptyDir': {}} in extraVolume
-    extraVolumeMounts = r['statefulset'][name]['spec']['template']['spec']['containers'][0]['volumeMounts']
-    assert {'name': 'extras', 'mountPath': '/usr/share/extras', 'readOnly': True} in extraVolumeMounts
+    extraVolume = r["statefulset"][name]["spec"]["template"]["spec"]["volumes"]
+    assert {"name": "extras", "emptyDir": {}} in extraVolume
+    extraVolumeMounts = r["statefulset"][name]["spec"]["template"]["spec"][
+        "containers"
+    ][0]["volumeMounts"]
+    assert {
+        "name": "extras",
+        "mountPath": "/usr/share/extras",
+        "readOnly": True,
+    } in extraVolumeMounts
 
 
 def test_adding_a_extra_container():
-    config = '''
+    config = """
 extraContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraContainer = r['statefulset'][name]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainer
+    extraContainer = r["statefulset"][name]["spec"]["template"]["spec"]["containers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainer
 
 
 def test_adding_a_extra_init_container():
-    config = '''
+    config = """
 extraInitContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraInitContainer = r['statefulset'][name]['spec']['template']['spec']['initContainers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraInitContainer
+    extraInitContainer = r["statefulset"][name]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraInitContainer
 
 
 def test_adding_persistence():
-    config = '''
+    config = """
 persistence:
   enabled: true
-'''
+"""
     r = helm_template(config)
-    c = r['statefulset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['volumeMounts'][0]['mountPath'] == '/usr/share/logstash/data'
-    assert c['volumeMounts'][0]['name'] == name
+    c = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["volumeMounts"][0]["mountPath"] == "/usr/share/logstash/data"
+    assert c["volumeMounts"][0]["name"] == name
 
-    v = r['statefulset']['release-name-logstash']['spec']['volumeClaimTemplates'][0]
-    assert v['metadata']['name'] == name
-    assert v['spec']['accessModes'] == ['ReadWriteOnce']
-    assert v['spec']['resources']['requests']['storage'] == '1Gi'
+    v = r["statefulset"]["release-name-logstash"]["spec"]["volumeClaimTemplates"][0]
+    assert v["metadata"]["name"] == name
+    assert v["spec"]["accessModes"] == ["ReadWriteOnce"]
+    assert v["spec"]["resources"]["requests"]["storage"] == "1Gi"
 
 
 def test_adding_storageclass_annotation_to_volumeclaimtemplate():
-    config = '''
+    config = """
 persistence:
   enabled: true
   annotations:
     volume.beta.kubernetes.io/storage-class: id
-'''
+"""
     r = helm_template(config)
-    annotations = r['statefulset'][name]['spec']['volumeClaimTemplates'][0]['metadata']['annotations']
-    assert annotations['volume.beta.kubernetes.io/storage-class'] == 'id'
+    annotations = r["statefulset"][name]["spec"]["volumeClaimTemplates"][0]["metadata"][
+        "annotations"
+    ]
+    assert annotations["volume.beta.kubernetes.io/storage-class"] == "id"
 
 
 def test_adding_multiple_persistence_annotations():
-    config = '''
+    config = """
     persistence:
       enabled: true
       annotations:
         hello: world
         world: hello
-'''
+"""
     r = helm_template(config)
-    annotations = r['statefulset'][name]['spec']['volumeClaimTemplates'][0]['metadata']['annotations']
+    annotations = r["statefulset"][name]["spec"]["volumeClaimTemplates"][0]["metadata"][
+        "annotations"
+    ]
 
-    assert annotations['hello'] == 'world'
-    assert annotations['world'] == 'hello'
+    assert annotations["hello"] == "world"
+    assert annotations["world"] == "hello"
 
 
 def test_adding_a_secret_mount():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/logstash/config/certs
-'''
+"""
     r = helm_template(config)
-    s = r['statefulset'][name]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/logstash/config/certs',
-        'name': 'elastic-certificates'
+    s = r["statefulset"][name]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/logstash/config/certs",
+        "name": "elastic-certificates",
     }
-    assert s['volumes'] == [{
-        'name': 'elastic-certificates',
-        'secret': {
-            'secretName': 'elastic-certs'
-        }
-    }]
+    assert s["volumes"] == [
+        {"name": "elastic-certificates", "secret": {"secretName": "elastic-certs"}}
+    ]
 
 
 def test_adding_a_secret_mount_with_subpath():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certs
     path: /usr/share/logstash/config/certs
     subPath: cert.crt
-'''
+"""
     r = helm_template(config)
-    s = r['statefulset'][name]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][-1] == {
-        'mountPath': '/usr/share/logstash/config/certs',
-        'subPath': 'cert.crt',
-        'name': 'elastic-certificates'
+    s = r["statefulset"][name]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/logstash/config/certs",
+        "subPath": "cert.crt",
+        "name": "elastic-certificates",
     }
 
 
 def test_adding_image_pull_secrets():
-    config = '''
+    config = """
 imagePullSecrets:
   - name: test-registry
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['spec']['imagePullSecrets'][0]['name'] == 'test-registry'
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["imagePullSecrets"][0][
+            "name"
+        ]
+        == "test-registry"
+    )
 
 
 def test_adding_tolerations():
-    config = '''
+    config = """
 tolerations:
 - key: "key1"
   operator: "Equal"
   value: "value1"
   effect: "NoExecute"
   tolerationSeconds: 3600
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['spec']['tolerations'][0]['key'] == 'key1'
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["tolerations"][0]["key"]
+        == "key1"
+    )
 
 
 def test_adding_pod_annotations():
-    config = '''
+    config = """
 podAnnotations:
   iam.amazonaws.com/role: logstash-role
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['metadata']['annotations']['iam.amazonaws.com/role'] == 'logstash-role'
+    assert (
+        r["statefulset"][name]["spec"]["template"]["metadata"]["annotations"][
+            "iam.amazonaws.com/role"
+        ]
+        == "logstash-role"
+    )
 
 
 def test_adding_a_node_selector():
-    config = '''
+    config = """
 nodeSelector:
   disktype: ssd
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['spec']['nodeSelector']['disktype'] == 'ssd'
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["nodeSelector"]["disktype"]
+        == "ssd"
+    )
 
 
 def test_adding_a_node_affinity():
-    config = '''
+    config = """
 nodeAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 100
@@ -319,26 +347,26 @@ nodeAffinity:
         operator: In
         values:
         - myvalue
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset']['release-name-logstash']['spec']['template']['spec']['affinity']['nodeAffinity'] == {
-        'preferredDuringSchedulingIgnoredDuringExecution': [{
-            'weight': 100,
-            'preference': {
-                'matchExpressions': [{
-                    'key': 'mylabel',
-                    'operator': 'In',
-                    'values': [
-                        'myvalue'
+    assert r["statefulset"]["release-name-logstash"]["spec"]["template"]["spec"][
+        "affinity"
+    ]["nodeAffinity"] == {
+        "preferredDuringSchedulingIgnoredDuringExecution": [
+            {
+                "weight": 100,
+                "preference": {
+                    "matchExpressions": [
+                        {"key": "mylabel", "operator": "In", "values": ["myvalue"]}
                     ]
-                }]
+                },
             }
-        }]
+        ]
     }
 
 
 def test_adding_in_logstash_config():
-    config = '''
+    config = """
 logstashConfig:
   logstash.yml: |
     key:
@@ -347,153 +375,198 @@ logstashConfig:
 
   log4j2.properties: |
     appender.rolling.name = rolling
-'''
+"""
     r = helm_template(config)
-    c = r['configmap'][name + '-config']['data']
+    c = r["configmap"][name + "-config"]["data"]
 
-    assert 'logstash.yml' in c
-    assert 'log4j2.properties' in c
+    assert "logstash.yml" in c
+    assert "log4j2.properties" in c
 
-    assert 'nestedkey: value' in c['logstash.yml']
-    assert 'dot.notation: test' in c['logstash.yml']
+    assert "nestedkey: value" in c["logstash.yml"]
+    assert "dot.notation: test" in c["logstash.yml"]
 
-    assert 'appender.rolling.name = rolling' in c['log4j2.properties']
+    assert "appender.rolling.name = rolling" in c["log4j2.properties"]
 
-    s = r['statefulset'][name]['spec']['template']['spec']
+    s = r["statefulset"][name]["spec"]["template"]["spec"]
 
-    assert {'configMap': {'name': 'release-name-logstash-config'}, 'name': 'logstashconfig'} in s['volumes']
-    assert {'mountPath': '/usr/share/logstash/config/logstash.yml', 'name': 'logstashconfig', 'subPath': 'logstash.yml'} in s['containers'][0]['volumeMounts']
-    assert {'mountPath': '/usr/share/logstash/config/log4j2.properties', 'name': 'logstashconfig', 'subPath': 'log4j2.properties'} in s['containers'][0]['volumeMounts']
+    assert {
+        "configMap": {"name": "release-name-logstash-config"},
+        "name": "logstashconfig",
+    } in s["volumes"]
+    assert {
+        "mountPath": "/usr/share/logstash/config/logstash.yml",
+        "name": "logstashconfig",
+        "subPath": "logstash.yml",
+    } in s["containers"][0]["volumeMounts"]
+    assert {
+        "mountPath": "/usr/share/logstash/config/log4j2.properties",
+        "name": "logstashconfig",
+        "subPath": "log4j2.properties",
+    } in s["containers"][0]["volumeMounts"]
 
-    assert 'configchecksum' in r['statefulset'][name]['spec']['template']['metadata']['annotations']
+    assert (
+        "configchecksum"
+        in r["statefulset"][name]["spec"]["template"]["metadata"]["annotations"]
+    )
 
 
 def test_adding_in_pipeline():
-    config = '''
+    config = """
 logstashPipeline:
   uptime.conf: |
     input { stdin { } } }
     output { stdout { { } } }
-'''
+"""
     r = helm_template(config)
-    c = r['configmap'][name + '-pipeline']['data']
+    c = r["configmap"][name + "-pipeline"]["data"]
 
-    assert 'uptime.conf' in c
+    assert "uptime.conf" in c
 
-    assert 'input { stdin { } } }' in c['uptime.conf']
-    assert 'output { stdout { { } } }' in c['uptime.conf']
+    assert "input { stdin { } } }" in c["uptime.conf"]
+    assert "output { stdout { { } } }" in c["uptime.conf"]
 
-    assert 'pipelinechecksum' in r['statefulset'][name]['spec']['template']['metadata']['annotations']
+    assert (
+        "pipelinechecksum"
+        in r["statefulset"][name]["spec"]["template"]["metadata"]["annotations"]
+    )
 
 
 def test_priority_class_name():
-    config = '''
+    config = """
 priorityClassName: ""
-'''
+"""
     r = helm_template(config)
-    spec = r['statefulset'][name]['spec']['template']['spec']
-    assert 'priorityClassName' not in spec
+    spec = r["statefulset"][name]["spec"]["template"]["spec"]
+    assert "priorityClassName" not in spec
 
-    config = '''
+    config = """
 priorityClassName: "highest"
-'''
+"""
     r = helm_template(config)
-    priority_class_name = r['statefulset'][name]['spec']['template']['spec']['priorityClassName']
+    priority_class_name = r["statefulset"][name]["spec"]["template"]["spec"][
+        "priorityClassName"
+    ]
     assert priority_class_name == "highest"
 
 
 def test_scheduler_name():
-    r = helm_template('')
-    spec = r['statefulset'][name]['spec']['template']['spec']
-    assert 'schedulerName' not in spec
+    r = helm_template("")
+    spec = r["statefulset"][name]["spec"]["template"]["spec"]
+    assert "schedulerName" not in spec
 
-    config = '''
+    config = """
 schedulerName: "stork"
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['spec']['schedulerName'] == "stork"
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["schedulerName"] == "stork"
+    )
 
 
 def test_lifecycle_hooks():
-    config = ''
+    config = ""
     r = helm_template(config)
-    c = r['statefulset'][name]['spec']['template']['spec']['containers'][0]
-    assert 'lifecycle' not in c
+    c = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert "lifecycle" not in c
 
-    config = '''
+    config = """
     lifecycle:
       preStop:
         exec:
           command: ["/bin/bash","/preStop"]
-    '''
+    """
     r = helm_template(config)
-    c = r['statefulset'][name]['spec']['template']['spec']['containers'][0]
+    c = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]
 
-    assert c['lifecycle']['preStop']['exec']['command'] == ["/bin/bash","/preStop"]
+    assert c["lifecycle"]["preStop"]["exec"]["command"] == ["/bin/bash", "/preStop"]
 
 
 def test_set_pod_security_context():
-    config = ''
+    config = ""
     r = helm_template(config)
-    assert r['statefulset'][name]['spec']['template']['spec']['securityContext']['fsGroup'] == 1000
-    assert r['statefulset'][name]['spec']['template']['spec']['securityContext']['runAsUser'] == 1000
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["securityContext"]["fsGroup"]
+        == 1000
+    )
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["securityContext"][
+            "runAsUser"
+        ]
+        == 1000
+    )
 
-    config = '''
+    config = """
     podSecurityContext:
       fsGroup: 1001
       other: test
-    '''
+    """
 
     r = helm_template(config)
 
-    assert r['statefulset'][name]['spec']['template']['spec']['securityContext']['fsGroup'] == 1001
-    assert r['statefulset'][name]['spec']['template']['spec']['securityContext']['other'] == 'test'
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["securityContext"]["fsGroup"]
+        == 1001
+    )
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["securityContext"]["other"]
+        == "test"
+    )
 
 
 def test_set_container_security_context():
-    config = ''
+    config = ""
 
     r = helm_template(config)
-    c = r['statefulset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['capabilities']['drop'] == ['ALL']
-    assert c['securityContext']['runAsNonRoot'] == True
-    assert c['securityContext']['runAsUser'] == 1000
+    c = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+    assert c["securityContext"]["runAsNonRoot"] == True
+    assert c["securityContext"]["runAsUser"] == 1000
 
-    config = '''
+    config = """
     securityContext:
       runAsUser: 1001
       other: test
-'''
+"""
 
     r = helm_template(config)
-    c = r['statefulset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['capabilities']['drop'] == ['ALL']
-    assert c['securityContext']['runAsNonRoot'] == True
-    assert c['securityContext']['runAsUser'] == 1001
-    assert c['securityContext']['other'] == 'test'
+    c = r["statefulset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+    assert c["securityContext"]["runAsNonRoot"] == True
+    assert c["securityContext"]["runAsUser"] == 1001
+    assert c["securityContext"]["other"] == "test"
 
 
 def test_adding_pod_labels():
-    config = '''
+    config = """
 labels:
   app.kubernetes.io/name: logstash
-'''
+"""
     r = helm_template(config)
-    assert r['statefulset'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'logstash'
-    assert r['statefulset'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'logstash'
+    assert (
+        r["statefulset"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        == "logstash"
+    )
+    assert (
+        r["statefulset"][name]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
+        == "logstash"
+    )
 
 
 def test_pod_security_policy():
     ## Make sure the default config is not creating any resources
-    config = ''
-    resources = ('role', 'rolebinding', 'serviceaccount', 'podsecuritypolicy')
+    config = ""
+    resources = ("role", "rolebinding", "serviceaccount", "podsecuritypolicy")
     r = helm_template(config)
     for resource in resources:
         assert resource not in r
-    assert 'serviceAccountName' not in r['statefulset'][name]['spec']['template']['spec']
+    assert (
+        "serviceAccountName" not in r["statefulset"][name]["spec"]["template"]["spec"]
+    )
 
     ## Make sure all the resources are created with default values
-    config = '''
+    config = """
 rbac:
   create: true
   serviceAccountName: ""
@@ -501,21 +574,34 @@ rbac:
 podSecurityPolicy:
   create: true
   name: ""
-'''
+"""
     r = helm_template(config)
     for resource in resources:
         assert resource in r
-    assert r['role'][name]['rules'][0] == {"apiGroups": ["extensions"], "verbs": ["use"], "resources": ["podsecuritypolicies"], "resourceNames": [name]}
-    assert r['rolebinding'][name]['subjects'] == [{"kind": "ServiceAccount", "namespace": "default", "name": name}]
-    assert r['rolebinding'][name]['roleRef'] == {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": name}
-    assert r['statefulset'][name]['spec']['template']['spec']['serviceAccountName'] == name
-    psp_spec = r['podsecuritypolicy'][name]['spec']
-    assert psp_spec['privileged'] is True
+    assert r["role"][name]["rules"][0] == {
+        "apiGroups": ["extensions"],
+        "verbs": ["use"],
+        "resources": ["podsecuritypolicies"],
+        "resourceNames": [name],
+    }
+    assert r["rolebinding"][name]["subjects"] == [
+        {"kind": "ServiceAccount", "namespace": "default", "name": name}
+    ]
+    assert r["rolebinding"][name]["roleRef"] == {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": name,
+    }
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["serviceAccountName"] == name
+    )
+    psp_spec = r["podsecuritypolicy"][name]["spec"]
+    assert psp_spec["privileged"] is True
 
 
 def test_external_pod_security_policy():
     ## Make sure we can use an externally defined pod security policy
-    config = '''
+    config = """
 rbac:
   create: true
   serviceAccountName: ""
@@ -523,18 +609,23 @@ rbac:
 podSecurityPolicy:
   create: false
   name: "customPodSecurityPolicy"
-'''
-    resources = ('role', 'rolebinding')
+"""
+    resources = ("role", "rolebinding")
     r = helm_template(config)
     for resource in resources:
         assert resource in r
 
-    assert r['role'][name]['rules'][0] == {"apiGroups": ["extensions"], "verbs": ["use"], "resources": ["podsecuritypolicies"], "resourceNames": ["customPodSecurityPolicy"]}
+    assert r["role"][name]["rules"][0] == {
+        "apiGroups": ["extensions"],
+        "verbs": ["use"],
+        "resources": ["podsecuritypolicies"],
+        "resourceNames": ["customPodSecurityPolicy"],
+    }
 
 
 def test_external_service_account():
     ## Make sure we can use an externally defined service account
-    config = '''
+    config = """
 rbac:
   create: false
   serviceAccountName: "customServiceAccountName"
@@ -542,18 +633,21 @@ rbac:
 podSecurityPolicy:
   create: false
   name: ""
-'''
-    resources = ('role', 'rolebinding', 'serviceaccount')
+"""
+    resources = ("role", "rolebinding", "serviceaccount")
     r = helm_template(config)
 
-    assert r['statefulset'][name]['spec']['template']['spec']['serviceAccountName'] == "customServiceAccountName"
+    assert (
+        r["statefulset"][name]["spec"]["template"]["spec"]["serviceAccountName"]
+        == "customServiceAccountName"
+    )
     # When referencing an external service account we do not want any resources to be created.
     for resource in resources:
         assert resource not in r
 
 
 def test_adding_a_service():
-    config = '''
+    config = """
 service:
   annotations: {}
   type: ClusterIP
@@ -562,22 +656,32 @@ service:
       port: 5044
       protocol: TCP
       targetPort: 5044
-'''
+"""
     r = helm_template(config)
-    s = r['service'][name]
-    assert s['metadata']['name'] == name
-    assert s['metadata']['annotations'] == {}
-    assert s['spec']['type'] == 'ClusterIP'
-    assert len(s['spec']['ports']) == 1
-    assert s['spec']['ports'][0] == {
-        'name': 'beats', 'port': 5044, 'protocol': 'TCP', 'targetPort': 5044}
+    s = r["service"][name]
+    assert s["metadata"]["name"] == name
+    assert s["metadata"]["annotations"] == {}
+    assert s["spec"]["type"] == "ClusterIP"
+    assert len(s["spec"]["ports"]) == 1
+    assert s["spec"]["ports"][0] == {
+        "name": "beats",
+        "port": 5044,
+        "protocol": "TCP",
+        "targetPort": 5044,
+    }
+
 
 def test_setting_fullnameOverride():
-    config = '''
+    config = """
 fullnameOverride: 'logstash-custom'
-'''
+"""
     r = helm_template(config)
 
-    custom_name = 'logstash-custom'
-    assert custom_name in r['statefulset']
-    assert r['statefulset'][custom_name]['spec']['template']['spec']['containers'][0]['name'] == 'logstash'
+    custom_name = "logstash-custom"
+    assert custom_name in r["statefulset"]
+    assert (
+        r["statefulset"][custom_name]["spec"]["template"]["spec"]["containers"][0][
+            "name"
+        ]
+        == "logstash"
+    )

--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -1,148 +1,189 @@
 import os
 import sys
-sys.path.insert(1, os.path.join(sys.path[0], '../../helpers'))
+
+sys.path.insert(1, os.path.join(sys.path[0], "../../helpers"))
 from helpers import helm_template
 
-project = 'metricbeat'
-name = 'release-name-' + project
+project = "metricbeat"
+name = "release-name-" + project
+
 
 def test_defaults():
-    config = '''
-    '''
+    config = """
+    """
 
     r = helm_template(config)
 
-    assert name in r['daemonset']
+    assert name in r["daemonset"]
 
-    c = r['daemonset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['name'] == project
-    assert c['image'].startswith('docker.elastic.co/beats/' + project + ':')
+    c = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["name"] == project
+    assert c["image"].startswith("docker.elastic.co/beats/" + project + ":")
 
-    assert c['env'][0]['name'] == 'POD_NAMESPACE'
-    assert c['env'][0]['valueFrom']['fieldRef']['fieldPath'] == 'metadata.namespace'
+    assert c["env"][0]["name"] == "POD_NAMESPACE"
+    assert c["env"][0]["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.namespace"
 
-    assert 'curl --fail 127.0.0.1:5066' in c['livenessProbe']['exec']['command'][-1]
+    assert "curl --fail 127.0.0.1:5066" in c["livenessProbe"]["exec"]["command"][-1]
 
-    assert 'metricbeat test output' in c['readinessProbe']['exec']['command'][-1]
+    assert "metricbeat test output" in c["readinessProbe"]["exec"]["command"][-1]
 
     # Empty customizable defaults
-    assert 'imagePullSecrets' not in r['daemonset'][name]['spec']['template']['spec']
-    assert 'tolerations' not in r['daemonset'][name]['spec']['template']['spec']
+    assert "imagePullSecrets" not in r["daemonset"][name]["spec"]["template"]["spec"]
+    assert "tolerations" not in r["daemonset"][name]["spec"]["template"]["spec"]
 
-    assert r['daemonset'][name]['spec']['updateStrategy']['type'] == 'RollingUpdate'
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "RollingUpdate"
 
-    assert r['daemonset'][name]['spec']['template']['spec']['serviceAccountName'] == name
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["serviceAccountName"] == name
+    )
 
-    volumes = r['daemonset'][name]['spec']['template']['spec']['volumes']
+    volumes = r["daemonset"][name]["spec"]["template"]["spec"]["volumes"]
     assert {
-            'name': 'data',
-                'hostPath': {
-                'path': '/var/lib/' + name + '-default-data',
-                'type': 'DirectoryOrCreate'
-                }
-           } in volumes
+        "name": "data",
+        "hostPath": {
+            "path": "/var/lib/" + name + "-default-data",
+            "type": "DirectoryOrCreate",
+        },
+    } in volumes
 
 
 def test_adding_a_extra_container():
-    config = '''
+    config = """
 extraContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraContainerDaemonset = r['daemonset'][name]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainerDaemonset
-    deployment_name = name + '-metrics'
-    extraContainerDeployment = r['deployment'][deployment_name]['spec']['template']['spec']['containers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraContainerDeployment
+    extraContainerDaemonset = r["daemonset"][name]["spec"]["template"]["spec"][
+        "containers"
+    ]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainerDaemonset
+    deployment_name = name + "-metrics"
+    extraContainerDeployment = r["deployment"][deployment_name]["spec"]["template"][
+        "spec"
+    ]["containers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraContainerDeployment
 
 
 def test_adding_a_extra_init_container():
-    config = '''
+    config = """
 extraInitContainers: |
   - name: do-something
     image: busybox
     command: ['do', 'something']
-'''
+"""
     r = helm_template(config)
-    extraInitContainerDaemonset = r['daemonset'][name]['spec']['template']['spec']['initContainers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraInitContainerDaemonset
-    deployment_name = name + '-metrics'
-    extraInitContainerDeployment = r['deployment'][deployment_name]['spec']['template']['spec']['initContainers']
-    assert {'name': 'do-something', 'image': 'busybox', 'command': ['do', 'something'], } in extraInitContainerDeployment
+    extraInitContainerDaemonset = r["daemonset"][name]["spec"]["template"]["spec"][
+        "initContainers"
+    ]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraInitContainerDaemonset
+    deployment_name = name + "-metrics"
+    extraInitContainerDeployment = r["deployment"][deployment_name]["spec"]["template"][
+        "spec"
+    ]["initContainers"]
+    assert {
+        "name": "do-something",
+        "image": "busybox",
+        "command": ["do", "something"],
+    } in extraInitContainerDeployment
 
 
 def test_adding_envs():
-    config = '''
+    config = """
 extraEnvs:
 - name: LOG_LEVEL
   value: DEBUG
-'''
+"""
     r = helm_template(config)
-    envs = r['daemonset'][name]['spec']['template']['spec']['containers'][0]['env']
-    assert {'name': 'LOG_LEVEL', 'value': 'DEBUG'} in envs
+    envs = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "LOG_LEVEL", "value": "DEBUG"} in envs
 
 
 def test_adding_image_pull_secrets():
-    config = '''
+    config = """
 imagePullSecrets:
   - name: test-registry
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['imagePullSecrets'][0]['name'] == 'test-registry'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"]
+        == "test-registry"
+    )
 
 
 def test_adding_tolerations():
-    config = '''
+    config = """
 tolerations:
 - key: "key1"
   operator: "Equal"
   value: "value1"
   effect: "NoExecute"
   tolerationSeconds: 3600
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['tolerations'][0]['key'] == 'key1'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["tolerations"][0]["key"]
+        == "key1"
+    )
 
 
 def test_override_the_default_update_strategy():
-    config = '''
+    config = """
 updateStrategy: OnDelete
-'''
+"""
 
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['updateStrategy']['type'] == 'OnDelete'
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "OnDelete"
+
 
 def test_setting_a_custom_service_account():
-    config = '''
+    config = """
 serviceAccount: notdefault
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['serviceAccountName'] == 'notdefault'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["serviceAccountName"]
+        == "notdefault"
+    )
+
 
 def test_self_managing_rbac_resources():
-    config = '''
+    config = """
 managedServiceAccount: false
-'''
+"""
     r = helm_template(config)
-    assert name not in r['serviceaccount']
-    assert name not in r['clusterrole']
-    assert name not in r['clusterrolebinding']
+    assert name not in r["serviceaccount"]
+    assert name not in r["clusterrole"]
+    assert name not in r["clusterrolebinding"]
+
 
 def test_setting_pod_security_context():
-    config = '''
+    config = """
 podSecurityContext:
   runAsUser: 1001
   privileged: false
-'''
+"""
     r = helm_template(config)
-    c = r['daemonset'][name]['spec']['template']['spec']['containers'][0]
-    assert c['securityContext']['runAsUser'] == 1001
-    assert c['securityContext']['privileged'] == False
+    c = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0]
+    assert c["securityContext"]["runAsUser"] == 1001
+    assert c["securityContext"]["privileged"] == False
+
 
 def test_adding_in_metricbeat_config():
-    config = '''
+    config = """
 metricbeatConfig:
   metricbeat.yml: |
     key:
@@ -151,50 +192,64 @@ metricbeatConfig:
 
   other-config.yml: |
     hello = world
-'''
+"""
     r = helm_template(config)
-    c = r['configmap'][name + '-config']['data']
+    c = r["configmap"][name + "-config"]["data"]
 
-    assert 'metricbeat.yml' in c
-    assert 'other-config.yml' in c
+    assert "metricbeat.yml" in c
+    assert "other-config.yml" in c
 
-    assert 'nestedkey: value' in c['metricbeat.yml']
-    assert 'dot.notation: test' in c['metricbeat.yml']
+    assert "nestedkey: value" in c["metricbeat.yml"]
+    assert "dot.notation: test" in c["metricbeat.yml"]
 
-    assert 'hello = world' in c['other-config.yml']
+    assert "hello = world" in c["other-config.yml"]
 
-    d = r['daemonset'][name]['spec']['template']['spec']
+    d = r["daemonset"][name]["spec"]["template"]["spec"]
 
-    assert {'configMap': {'name': name + '-config', 'defaultMode': 0o600}, 'name': project + '-config'} in d['volumes']
-    assert {'mountPath': '/usr/share/metricbeat/metricbeat.yml', 'name': project + '-config', 'subPath': 'metricbeat.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
-    assert {'mountPath': '/usr/share/metricbeat/other-config.yml', 'name': project + '-config', 'subPath': 'other-config.yml', 'readOnly': True} in d['containers'][0]['volumeMounts']
+    assert {
+        "configMap": {"name": name + "-config", "defaultMode": 0o600},
+        "name": project + "-config",
+    } in d["volumes"]
+    assert {
+        "mountPath": "/usr/share/metricbeat/metricbeat.yml",
+        "name": project + "-config",
+        "subPath": "metricbeat.yml",
+        "readOnly": True,
+    } in d["containers"][0]["volumeMounts"]
+    assert {
+        "mountPath": "/usr/share/metricbeat/other-config.yml",
+        "name": project + "-config",
+        "subPath": "other-config.yml",
+        "readOnly": True,
+    } in d["containers"][0]["volumeMounts"]
 
-    assert 'configChecksum' in r['daemonset'][name]['spec']['template']['metadata']['annotations']
+    assert (
+        "configChecksum"
+        in r["daemonset"][name]["spec"]["template"]["metadata"]["annotations"]
+    )
 
 
 def test_adding_a_secret_mount():
-    config = '''
+    config = """
 secretMounts:
   - name: elastic-certificates
     secretName: elastic-certificates-name
     path: /usr/share/metricbeat/config/certs
-'''
+"""
     r = helm_template(config)
-    s = r['daemonset'][name]['spec']['template']['spec']
-    assert s['containers'][0]['volumeMounts'][0] == {
-        'mountPath': '/usr/share/metricbeat/config/certs',
-        'name': 'elastic-certificates'
+    s = r["daemonset"][name]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][0] == {
+        "mountPath": "/usr/share/metricbeat/config/certs",
+        "name": "elastic-certificates",
     }
-    assert s['volumes'][0] == {
-        'name': 'elastic-certificates',
-        'secret': {
-            'secretName': 'elastic-certificates-name'
-        }
+    assert s["volumes"][0] == {
+        "name": "elastic-certificates",
+        "secret": {"secretName": "elastic-certificates-name"},
     }
 
 
 def test_adding_a_extra_volume_with_volume_mount():
-    config = '''
+    config = """
 extraVolumes:
   - name: extras
     emptyDir: {}
@@ -202,25 +257,34 @@ extraVolumeMounts:
   - name: extras
     mountPath: /usr/share/extras
     readOnly: true
-'''
+"""
     r = helm_template(config)
-    extraVolume = r['daemonset'][name]['spec']['template']['spec']['volumes']
-    assert {'name': 'extras', 'emptyDir': {}} in extraVolume
-    extraVolumeMounts = r['daemonset'][name]['spec']['template']['spec']['containers'][0]['volumeMounts']
-    assert {'name': 'extras', 'mountPath': '/usr/share/extras', 'readOnly': True} in extraVolumeMounts
+    extraVolume = r["daemonset"][name]["spec"]["template"]["spec"]["volumes"]
+    assert {"name": "extras", "emptyDir": {}} in extraVolume
+    extraVolumeMounts = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["volumeMounts"]
+    assert {
+        "name": "extras",
+        "mountPath": "/usr/share/extras",
+        "readOnly": True,
+    } in extraVolumeMounts
 
 
 def test_adding_a_node_selector():
-    config = '''
+    config = """
 nodeSelector:
   disktype: ssd
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['nodeSelector']['disktype'] == 'ssd'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["nodeSelector"]["disktype"]
+        == "ssd"
+    )
 
 
 def test_adding_an_affinity_rule():
-    config = '''
+    config = """
 affinity:
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -231,42 +295,50 @@ affinity:
           values:
           - metricbeat
       topologyKey: kubernetes.io/hostname
-'''
+"""
 
     r = helm_template(config)
-    assert r['daemonset'][name]['spec']['template']['spec']['affinity']['podAntiAffinity'][
-        'requiredDuringSchedulingIgnoredDuringExecution'][0]['topologyKey'] == 'kubernetes.io/hostname'
+    assert (
+        r["daemonset"][name]["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"][
+            "requiredDuringSchedulingIgnoredDuringExecution"
+        ][0]["topologyKey"]
+        == "kubernetes.io/hostname"
+    )
 
 
 def test_priority_class_name():
-    config = '''
+    config = """
 priorityClassName: ""
-'''
+"""
     r = helm_template(config)
-    daemonset_spec = r['daemonset'][name]['spec']['template']['spec']
-    deployment_spec = r['deployment'][name + '-metrics']['spec']['template']['spec']
-    assert 'priorityClassName' not in daemonset_spec
-    assert 'priorityClassName' not in deployment_spec
+    daemonset_spec = r["daemonset"][name]["spec"]["template"]["spec"]
+    deployment_spec = r["deployment"][name + "-metrics"]["spec"]["template"]["spec"]
+    assert "priorityClassName" not in daemonset_spec
+    assert "priorityClassName" not in deployment_spec
 
-    config = '''
+    config = """
 priorityClassName: "highest"
-'''
+"""
     r = helm_template(config)
-    daemonset_priority_class_name = r['daemonset'][name]['spec']['template']['spec']['priorityClassName']
-    deployment_priority_class_name = r['deployment'][name + '-metrics']['spec']['template']['spec']['priorityClassName']
+    daemonset_priority_class_name = r["daemonset"][name]["spec"]["template"]["spec"][
+        "priorityClassName"
+    ]
+    deployment_priority_class_name = r["deployment"][name + "-metrics"]["spec"][
+        "template"
+    ]["spec"]["priorityClassName"]
     assert daemonset_priority_class_name == "highest"
     assert deployment_priority_class_name == "highest"
 
 
 def test_cluster_role_rules():
-    config = ''
+    config = ""
     r = helm_template(config)
-    rules = r['clusterrole']['release-name-metricbeat-cluster-role']['rules'][0]
-    assert rules['apiGroups'][0] == 'extensions'
-    assert rules['verbs'][0]     == 'get'
-    assert rules['resources'][0] == 'namespaces'
+    rules = r["clusterrole"]["release-name-metricbeat-cluster-role"]["rules"][0]
+    assert rules["apiGroups"][0] == "extensions"
+    assert rules["verbs"][0] == "get"
+    assert rules["resources"][0] == "namespaces"
 
-    config = '''
+    config = """
 clusterRoleRules:
   - apiGroups:
     - "someone"
@@ -274,48 +346,66 @@ clusterRoleRules:
     - "or"
     resources:
     - "something"
-'''
+"""
     r = helm_template(config)
-    rules = r['clusterrole']['release-name-metricbeat-cluster-role']['rules'][0]
-    assert rules['apiGroups'][0] == 'someone'
-    assert rules['verbs'][0]     == 'or'
-    assert rules['resources'][0] == 'something'
+    rules = r["clusterrole"]["release-name-metricbeat-cluster-role"]["rules"][0]
+    assert rules["apiGroups"][0] == "someone"
+    assert rules["verbs"][0] == "or"
+    assert rules["resources"][0] == "something"
 
 
 def test_adding_pod_labels():
-    config = '''
+    config = """
 labels:
   app.kubernetes.io/name: metricbeat
-'''
+"""
     r = helm_template(config)
-    assert r['daemonset'][name]['metadata']['labels']['app.kubernetes.io/name'] == 'metricbeat'
-    assert r['daemonset'][name]['spec']['template']['metadata']['labels']['app.kubernetes.io/name'] == 'metricbeat'
+    assert (
+        r["daemonset"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        == "metricbeat"
+    )
+    assert (
+        r["daemonset"][name]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
+        == "metricbeat"
+    )
+
 
 def test_adding_env_from():
-    config = '''
+    config = """
 envFrom:
 - configMapRef:
     name: configmap-name
-'''
+"""
     r = helm_template(config)
-    configMapRef = r['daemonset'][name]['spec']['template']['spec']['containers'][0]['envFrom'][0]['configMapRef']
-    assert configMapRef == {'name': 'configmap-name'}
+    configMapRef = r["daemonset"][name]["spec"]["template"]["spec"]["containers"][0][
+        "envFrom"
+    ][0]["configMapRef"]
+    assert configMapRef == {"name": "configmap-name"}
+
 
 def test_setting_fullnameOverride():
-    config = '''
+    config = """
 fullnameOverride: 'metricbeat-custom'
-'''
+"""
     r = helm_template(config)
 
-    custom_name = 'metricbeat-custom'
-    assert custom_name in r['daemonset']
-    assert r['daemonset'][custom_name]['spec']['template']['spec']['containers'][0]['name'] == project
-    assert r['daemonset'][custom_name]['spec']['template']['spec']['serviceAccountName'] == name
-    volumes = r['daemonset'][custom_name]['spec']['template']['spec']['volumes']
+    custom_name = "metricbeat-custom"
+    assert custom_name in r["daemonset"]
+    assert (
+        r["daemonset"][custom_name]["spec"]["template"]["spec"]["containers"][0]["name"]
+        == project
+    )
+    assert (
+        r["daemonset"][custom_name]["spec"]["template"]["spec"]["serviceAccountName"]
+        == name
+    )
+    volumes = r["daemonset"][custom_name]["spec"]["template"]["spec"]["volumes"]
     assert {
-               'name': 'data',
-               'hostPath': {
-                   'path': '/var/lib/' + custom_name + '-default-data',
-                   'type': 'DirectoryOrCreate'
-               }
-           } in volumes
+        "name": "data",
+        "hostPath": {
+            "path": "/var/lib/" + custom_name + "-default-data",
+            "type": "DirectoryOrCreate",
+        },
+    } in volumes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 atomicwrites==1.3.0
 attrs==19.1.0
+black==19.10b0
 importlib-metadata==0.23
 more-itertools==7.2.0
 pluggy==0.13.0


### PR DESCRIPTION
This PR is reformatting all python scripts using [black](https://black.readthedocs.io/en/stable/) and add black formating to CI.

Also add [phony targets](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) and help to Makefiles.