### PR TITLE
fixup! [meta] install pip dependencies before lint-python

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
@@ -17,6 +17,6 @@
         #!/usr/local/bin/runbld
         set -euo pipefail
 
-        virtualenv venv && source venv/bin/activate
+        virtualenv -p python3 venv && source venv/bin/activate
         pip install -r requirements.txt
         make lint-python

--- a/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
@@ -17,6 +17,6 @@
         #!/usr/local/bin/runbld
         set -euo pipefail
 
-        virtualenv venv && source venv/bin/activate
+        virtualenv -p python3 venv && source venv/bin/activate
         pip install -r requirements.txt
         make lint-python


### PR DESCRIPTION
[Black](https://black.readthedocs.io/en/stable/) is only compatible with Python 3

