### PR TITLE
[meta] run lint-python job on ubuntu 18.04

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+master+template-lint-python.yml
@@ -11,7 +11,7 @@
         type: slave
         name: label
         values:
-        - docker&&virtual
+        - docker&&virtual&&ubuntu-18.04
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
@@ -11,7 +11,7 @@
         type: slave
         name: label
         values:
-        - docker&&virtual
+        - docker&&virtual&&ubuntu-18.04
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/helpers/common.mk
+++ b/helpers/common.mk
@@ -29,7 +29,7 @@ lint: ## Lint helm templates
 
 .PHONY: lint-python
 lint-python: ## Lint python scripts
-	black --diff --check .
+	black --diff --check --exclude='ve/|venv/' .
 
 .PHONY: pytest
 pytest: ## Run python tests


### PR DESCRIPTION
[black](https://black.readthedocs.io/en/stable/) requires python >= 3.6 which is not available on ubuntu 16.04

Fix #477 
