### PR TITLE
Allow projected volumes for elasticsearch, logstash and metricbeat

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -114,6 +114,7 @@ podSecurityPolicy:
       - secret
       - configMap
       - persistentVolumeClaim
+      - projected
 
 persistence:
   enabled: true

--- a/logstash/values.yaml
+++ b/logstash/values.yaml
@@ -89,6 +89,7 @@ podSecurityPolicy:
       - secret
       - configMap
       - persistentVolumeClaim
+      - projected
 
 persistence:
   enabled: false

--- a/metricbeat/templates/podsecuritypolicy.yaml
+++ b/metricbeat/templates/podsecuritypolicy.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podSecurityPolicy.create -}}
+{{- $fullName := include "metricbeat.fullname" . -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+spec:
+{{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
+{{- end -}}

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -218,6 +218,25 @@ clusterRoleRules:
   - nodes/stats
   verbs: ["get"]
 
+podSecurityPolicy:
+  create: false
+  name: ""
+  spec:
+    privileged: true
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - secret
+      - configMap
+      - persistentVolumeClaim
+      - projected
+
 podAnnotations: {}
   # iam.amazonaws.com/role: es-cluster
 


### PR DESCRIPTION
Projected volumes are the default volume type on Google Kubernetes Engine (GKE) with cluster >= 1.16. This PR allows to use them out-of-the-box more easily if pod security policy is enabled. This is only relevant for clusters with pod security policy enabled. By default >= 1.16 clusters should work with this PR.

Furthermore, it adds a missing pod security policy for metricbeat for this case.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
