### PR TITLE
Remove .Values.service check before setting serviceName

### DIFF
--- a/logstash/examples/6.x/test/goss.yaml
+++ b/logstash/examples/6.x/test/goss.yaml
@@ -12,7 +12,7 @@ http:
       - '"host" : "helm-logstash-six-logstash-0"'
       - '"version" : "6.8.7"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-six-logstash-0"'
+      - '"name" : "helm-logstash-six-logstash-0.svc.cluster.local"'
 
 file:
   /usr/share/logstash/config/logstash.yml:

--- a/logstash/templates/statefulset.yaml
+++ b/logstash/templates/statefulset.yaml
@@ -12,9 +12,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  {{- if .Values.service }}
   serviceName: {{ template "logstash.fullname" . }}
-  {{- end }}
   selector:
     matchLabels:
       app: "{{ template "logstash.fullname" . }}"

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -78,7 +78,7 @@ def test_defaults():
     )
 
     # Service
-    assert "serviceName" not in r["statefulset"][name]["spec"]
+    assert "serviceName" in r["statefulset"][name]["spec"]
     assert "service" not in r
 
     # Other


### PR DESCRIPTION
It appears that {{-if .Values.service }} is evaluating falsely here, preventing a required value in Helm 3 from being set (serviceName), and making this change resolves https://github.com/elastic/helm-charts/issues/497 without any other modifications to the template. Other StatefulSet definitions that are known to work (at a basic level) with Helm 3, such as elasticsearch/templates/statefulset.yaml#L16, do not implement this check.

It seems that making this change allows for additional Helm 3 compatibility without breaking anything in Helm 2, though correct me if I'm wrong there - I don't have anything running Helm 2.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

^ Checked off all of the above as this change impacts none of them.