### PR TITLE
[kibana] Make curl redo the request on redirect

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
                       set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
                     fi
 
-                    STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}")
+                    STATUS=$(curl --output /dev/null --write-out "%{http_code}" -L -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}")
                     if [[ "${STATUS}" -eq 200 ]]; then
                       exit 0
                     fi


### PR DESCRIPTION
If xpack.security is enabled kibana pod fails because curl returns 302 with location header to login page. To prevent this behaviour I added -L param which make curl redo the request on the login page.

- [x] Chart version not bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in ${CHART}/tests/*.py
- [ ] Updated integration tests in ${CHART}/examples/*/test/goss.yaml