### PR TITLE
Add namespace parameter to the test function to NOTES.txt

### DIFF
--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Watch all cluster members come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "elasticsearch.uname" . }} -w
 2. Test cluster health using Helm test.
-  $ helm test {{ .Release.Name }}
+  $ helm test {{ .Release.Name }} --namespace={{ .Release.Namespace }}


### PR DESCRIPTION
If the user copies the second command from the notes, he will get an error "Error: release: not found". This PR adds a namespace parameter to the test function.

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [X] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
