### PR TITLE
Staging image testing

### DIFF
--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -1,8 +1,8 @@
 ---
 - job:
-    name: elastic+helm-charts+master+cluster-cleanup
-    display-name: elastic / helm-charts - master - cluster cleanup
-    description: Master - cluster cleanup
+    name: elastic+helm-charts+staging+cluster-cleanup
+    display-name: elastic / helm-charts - staging - cluster cleanup
+    description: staging - cluster cleanup
     parameters:
       - string:
           name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -33,8 +33,6 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
-
         cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
         cd helpers/terraform/

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -1,0 +1,41 @@
+---
+- job:
+    name: elastic+helm-charts+master+cluster-cleanup
+    display-name: elastic / helm-charts - master - cluster cleanup
+    description: Master - cluster cleanup
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
@@ -1,0 +1,42 @@
+---
+- job:
+    name: elastic+helm-charts+staging+cluster-creation
+    display-name: elastic / helm-charts - staging - cluster creation
+    description: staging - cluster creation
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+        ./in-docker make k8s-staging-registry KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
@@ -33,8 +33,6 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
-
         cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
         cd helpers/terraform/

--- a/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: elastic+helm-charts+master+integration-apm-server
+    display-name: elastic / helm-charts - master - integration apm-server
+    description: Master - integration apm-server
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: APM_SERVER_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
@@ -1,8 +1,8 @@
 ---
 - job:
-    name: elastic+helm-charts+master+integration-apm-server
-    display-name: elastic / helm-charts - master - integration apm-server
-    description: Master - integration apm-server
+    name: elastic+helm-charts+staging+integration-apm-server
+    display-name: elastic / helm-charts - staging - integration apm-server
+    description: staging - integration apm-server
     parameters:
       - string:
           name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: elastic+helm-charts+staging+integration-elasticsearch
+    display-name: elastic / helm-charts - staging - integration elasticsearch
+    description: staging - integration elasticsearch
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: ES_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: elastic+helm-charts+staging+integration-filebeat
+    display-name: elastic / helm-charts - staging - integration filebeat
+    description: staging - integration filebeat
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: FILEBEAT_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: elastic+helm-charts+staging+integration-kibana
+    display-name: elastic / helm-charts - staging - integration kibana
+    description: staging - integration kibana
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: KIBANA_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: elastic+helm-charts+staging+integration-logstash
+    display-name: elastic / helm-charts - staging - integration logstash
+    description: staging - integration logstash
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: LOGSTASH_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash

--- a/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: elastic+helm-charts+staging+integration-metricbeat
+    display-name: elastic / helm-charts - staging - integration metricbeat
+    description: staging - integration metricbeat
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    scm:
+    - git:
+        wipe-workspace: 'True'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - docker&&virtual
+    - axis:
+        type: yaml
+        name: METRICBEAT_SUITE
+        filename: helpers/matrix.yml
+    - axis:
+        type: yaml
+        name: KUBERNETES_VERSION
+        filename: helpers/matrix.yml
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        source /usr/local/bin/bash_standard_lib.sh
+
+        set +x
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+        set -x
+
+        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+
+        cd helpers/terraform/
+        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat

--- a/.ci/jobs/elastic+helm-charts+staging.yml
+++ b/.ci/jobs/elastic+helm-charts+staging.yml
@@ -1,0 +1,49 @@
+---
+- job:
+    name: elastic+helm-charts+staging
+    display-name: elastic / helm-charts - staging
+    description: Staging image testing
+    concurrent: true
+    parameters:
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+    project-type: multijob
+    scm:
+    - git:
+        wipe-workspace: 'False'
+    triggers:
+    - timed: H H(02-04) * * *
+    - github
+    builders:
+    - multijob:
+        name: template testing and kubernetes cluster creation
+        condition: SUCCESSFUL
+        projects:
+        - name: elastic+helm-charts+staging+cluster-creation
+          current-parameters: true
+    - multijob:
+        name: elasticsearch integration testing
+        condition: ALWAYS
+        projects:
+        - name: elastic+helm-charts+staging+integration-elasticsearch
+          current-parameters: true
+    - multijob:
+        name: integration testing
+        condition: ALWAYS
+        projects:
+        - name: elastic+helm-charts+staging+integration-kibana
+          current-parameters: true
+        - name: elastic+helm-charts+staging+integration-filebeat
+          current-parameters: true
+        - name: elastic+helm-charts+staging+integration-metricbeat
+          current-parameters: true
+        - name: elastic+helm-charts+staging+integration-logstash
+          current-parameters: true
+        - name: elastic+helm-charts+staging+integration-apm-server
+          current-parameters: true
+    publishers:
+    - trigger-parameterized-builds:
+      - project: elastic+helm-charts+staging+cluster-cleanup
+        current-parameters: true
+        trigger-with-no-params: false

--- a/helpers/common.mk
+++ b/helpers/common.mk
@@ -4,7 +4,7 @@ default: test
 
 .PHONY: help
 help: ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 .PHONY: build
 build: ## Build helm-tester docker image

--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -5,7 +5,7 @@ STACK_VERSION := 7.6.1
 
 .PHONY: help
 help: ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 .PHONY: goss
 goss: ## Run goss tests

--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -13,7 +13,7 @@ export TF_VAR_kubernetes_version=$(KUBERNETES_VERSION)
 
 .PHONY: help
 help: ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 .PHONY: clean
 clean: ## Delete terraform working directory and local state files
@@ -68,6 +68,14 @@ creds: credentials.json ## Get gke credentials
 .PHONY: k8s
 k8s: apply creds ## Configure gke cluster
 	kubectl get cs
+
+.PHONY: k8s-staging-registry
+k8s-staging-registry: creds ## Create the staging registry auth secret in k8s
+	@DOCKER_PASSWORD="$$(vault read -field=password secret/devops-ci/docker.elastic.co/devops-ci)" && \
+		kubectl create secret docker-registry registry-staging \
+		--docker-server="docker.elastic.co" \
+		--docker-username="devops-ci" \
+		--docker-password="$$DOCKER_PASSWORD"
 
 .PHONY: up
 up: k8s ## Install helm on gke cluster


### PR DESCRIPTION
Add a multijob for performing tests with staging images based on a
BUILD_ID.

The terraform helper now can create a docker registry secret in
kubernetes.

The bumper scripts now adds an `imagePullSecrets` entry to support
pulling from the private registry, and additionally handling to ensure
goss tests work when using BUILD_ID values as a bumped version.

Allow the makefile help generator to support goals that include
numbers.

~- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)~
~- [ ] README.md updated with any new values or changes~
~- [ ] Updated template tests in `${CHART}/tests/*.py`~
~- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`~
