### PR TITLE
[meta] drop gke 1.13 tests

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -38,6 +38,5 @@ APM_SERVER_SUITE:
   - security
   - 6.x
 KUBERNETES_VERSION:
-  - '1.13'
   - '1.14'
   - '1.15'


### PR DESCRIPTION
GKE 1.13 is no more available regarding [GKE release-notes] and [elastic+helm-charts+master+cluster-creation/KUBERNETES_VERSION=1.13]

[GKE release-notes]: https://cloud.google.com/kubernetes-engine/docs/release-notes#version_updates
[elastic+helm-charts+master+cluster-creation/KUBERNETES_VERSION=1.13]: https://devops-ci.elastic.co/view/Helm%20Charts/job/elastic+helm-charts+master+cluster-creation/KUBERNETES_VERSION=1.13,label=docker&&virtual/457/console

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
