### PR TITLE
fix: allow redirection on the readinessProbe

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
                 #!/usr/bin/env bash -e
                 http () {
                     local path="${1}"
-                    set -- -XGET -s --fail
+                    set -- -XGET -s --fail -L
 
                     if [ -n "${ELASTICSEARCH_USERNAME}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
                       set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"


### PR DESCRIPTION
## What does this PR do?

It adds the `-L` flag to `curl` to allow redirections.

## Why is it important?

It fixes the readinessProbe for kibana 8.0.0-SNAPSHOT version.

## Related issues
Closes #548
