### PR TITLE
Add extensible label support on Kibana

### DIFF
--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -29,3 +29,15 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kibana.labels" -}}
+app: {{ .Chart.Name }}
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end -}}

--- a/kibana/templates/configmap.yaml
+++ b/kibana/templates/configmap.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kibana.fullname" . }}-config
-  labels:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name | quote }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.kibanaConfig }}
   {{ $path }}: |

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -2,12 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kibana.fullname" . }}
-  labels:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name | quote }}
-    {{- range $key, $value := .Values.labels }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:

--- a/kibana/templates/ingress.yaml
+++ b/kibana/templates/ingress.yaml
@@ -6,10 +6,7 @@ apiVersion: {{ template "kibana.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/kibana/templates/service.yaml
+++ b/kibana/templates/service.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kibana.fullname" . }}
-  labels:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4}}
 {{- end }}


### PR DESCRIPTION
Common labels were moved to helpers template to have only one source of truth of common/added labels shared between all Kibana resources.

Also, this extends the capability to add a custom label and this will be common between all the resources.

This is useful in many ways because it allows querying all the Kibana resources that match a common label and be used in a whole service backup with other resources outside of its chart's responsibility.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] ~~Updated template tests in `${CHART}/tests/*.py`~~
- [ ] ~~Updated integration tests in `${CHART}/examples/*/test/goss.yaml`~~
