### PR TITLE
follow redirects for kibana health check

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
                       set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
                     fi
 
-                    STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}")
+                    STATUS=$(curl --output /dev/null --write-out "%{http_code}" -kL "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}")
                     if [[ "${STATUS}" -eq 200 ]]; then
                       exit 0
                     fi


### PR DESCRIPTION
If you're cluster has authentication enabled the kibana server automatically forwards your traffic to _/login_ via a HTTP 302 redirect which the health check thinks is an error unless you specifically tell it to use the /login path. By using the curl _-L_ flag it will follow the redirect and return the correct code saving the user some debugging

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py`
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
