### PR TITLE
Giving more control on the kubeStateMetrics subchart for Metricbeat

### DIFF
--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -97,6 +97,8 @@ helm install --name metricbeat elastic/metricbeat --set imageTag=7.6.2
 | `priorityClassName`      | The [name of the PriorityClass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass). No default is supplied as the PriorityClass must be created first.                                                                                                                            | `""`                                                                                                                      |
 | `replicas`               | The replica count for the metricbeat deployment talking to kube-state-metrics                                                                                                                                                                                                                                            | `1`                                                                                                                       |
 | `fullnameOverride`       | Overrides the full name of the resources. If not set the name will default to "`.Release.Name`-`.Values.nameOverride or .Chart.Name`"                                                                                                                                                                                    | `""`                                                                                                                      |
+| `kubeStateMetrics`       | Control the kube-state-metrics sub-chart                                                                                                                                                                                                                                                                                 | `enabled: true`                                                                                                           |
+| `exports`                | Values for all sub-charts                                                                                                                                                                                                                                                                                                | `kubestateMetrics: {}`                                                                                                    |
 
 ## Examples
 
@@ -146,3 +148,4 @@ To run the goss tests against the default example:
 cd examples/default
 make goss
 ```
+

--- a/metricbeat/requirements.lock
+++ b/metricbeat/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.4.1
-digest: sha256:89fdea6b5f048652fc2d562ff59338a8cbf25f9053dc28976a1271b4387692b1
-generated: "2019-11-01T10:31:40.002896+01:00"
+digest: sha256:e1fa927c66914bd01036d6ed762684932688228ef50bdf0a46dd4803f5ab565e
+generated: "2020-04-04T11:25:44.500343-07:00"

--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -2,3 +2,7 @@ dependencies:
   - name: 'kube-state-metrics'
     version: '2.4.1'
     repository: '@stable'
+    condition: kubeStateMetrics.enabled
+    import-values:
+      - kubeStateMetrics
+

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -207,3 +207,11 @@ updateStrategy: RollingUpdate
 # Only edit these if you know what you're doing
 nameOverride: ""
 fullnameOverride: ""
+
+# Control the behavior of kube-state-metrics
+kubeStateMetrics:
+  enabled: true
+
+exports:
+  kubeStateMetrics: {}
+


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [-] Updated template tests in `${CHART}/tests/*.py` 
- [-] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Hello Elastic Team!

Thanks for contributing these charts to open source! We appreciate it :)

I'm hoping this could get added. We're having issues in our Prometheus instance seeing double metrics due to the kube-state-metrics chart defaulting to include the Prometheus annotations. We're running in Rancher, which also provisions kube-state-metrics so having some more control would be appreciated!

How much testing should be added here due to the nature of this change? I tried adding and running some pytests but looks like all tests are failing for a multitude of reasons.