### PR TITLE
[elasticsearch] fix helm test command

### DIFF
--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Watch all cluster members come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "elasticsearch.uname" . }} -w
 2. Test cluster health using Helm test.
-  $ helm test {{ .Release.Name }} --namespace={{ .Release.Namespace }}
+  $ helm test {{ .Release.Name }} --cleanup


### PR DESCRIPTION
* remove wrong `--namespace` argument
* add `--cleanup` to clean test pod

```shell
$ helm upgrade --wait --timeout=900 --install --values values.yaml helm-es-docker-for-mac ../../
Release "helm-es-docker-for-mac" does not exist. Installing it now.
NAME:   helm-es-docker-for-mac
LAST DEPLOYED: Mon Apr  6 15:57:23 2020
NAMESPACE: default
STATUS: DEPLOYED

...

NOTES:
1. Watch all cluster members come up.
  $ kubectl get pods --namespace=default -l app=elasticsearch-master -w
2. Test cluster health using Helm test.
  $ helm test helm-es-docker-for-mac --namespace=default

$ helm test helm-es-docker-for-mac --namespace=default
Error: unknown flag: --namespace
```
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] ~README.md updated with any new values or changes~
- [ ] ~Updated template tests in `${CHART}/tests/*.py`~
- [ ] ~Updated integration tests in `${CHART}/examples/*/test/goss.yaml`~
