### PR TITLE
Filebeat improvements

### DIFF
--- a/filebeat/examples/6.x/values.yaml
+++ b/filebeat/examples/6.x/values.yaml
@@ -3,3 +3,16 @@ imageTag: 6.8.8
 extraEnvs:
   - name: ELASTICSEARCH_HOSTS
     value: six-master:9200
+
+filebeatConfig:
+  filebeat.yml: |
+    filebeat.inputs:
+    - type: docker
+      containers.ids:
+        - '*'
+      processors:
+      - add_kubernetes_metadata:
+          in_cluster: true
+    output.elasticsearch:
+      host: '${NODE_NAME}'
+      hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'

--- a/filebeat/examples/security/values.yaml
+++ b/filebeat/examples/security/values.yaml
@@ -5,8 +5,7 @@ filebeatConfig:
       containers.ids:
       - '*'
       processors:
-      - add_kubernetes_metadata:
-          in_cluster: true
+      - add_kubernetes_metadata: ~
 
     output.elasticsearch:
       username: '${ELASTICSEARCH_USERNAME}'

--- a/filebeat/examples/security/values.yaml
+++ b/filebeat/examples/security/values.yaml
@@ -5,7 +5,11 @@ filebeatConfig:
       paths:
         - /var/log/containers/*.log
       processors:
-      - add_kubernetes_metadata: ~
+      - add_kubernetes_metadata: 
+          host: ${NODE_NAME}
+          matchers:
+          - logs_path:
+              logs_path: "/var/log/containers/"
 
     output.elasticsearch:
       username: '${ELASTICSEARCH_USERNAME}'

--- a/filebeat/examples/security/values.yaml
+++ b/filebeat/examples/security/values.yaml
@@ -1,9 +1,9 @@
 filebeatConfig:
   filebeat.yml: |
     filebeat.inputs:
-    - type: docker
-      containers.ids:
-      - '*'
+    - type: container
+      paths:
+        - /var/log/containers/*.log
       processors:
       - add_kubernetes_metadata: ~
 

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -75,6 +75,9 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: varlog
+        hostPath:
+          path: /var/log
       - name: varrundockersock
         hostPath:
           path: /var/run/docker.sock
@@ -151,6 +154,9 @@ spec:
           mountPath: /usr/share/filebeat/data
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
           readOnly: true
         # Necessary when using autodiscovery; avoid mounting it otherwise
         # See: https://www.elastic.co/guide/en/beats/filebeat/master/configuration-autodiscover.html

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -4,9 +4,9 @@
 filebeatConfig:
   filebeat.yml: |
     filebeat.inputs:
-    - type: docker
-      containers.ids:
-      - '*'
+    - type: container
+      paths:
+        - /var/log/containers/*.log
       processors:
       - add_kubernetes_metadata: ~
 

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -8,7 +8,11 @@ filebeatConfig:
       paths:
         - /var/log/containers/*.log
       processors:
-      - add_kubernetes_metadata: ~
+      - add_kubernetes_metadata: 
+          host: ${NODE_NAME}
+          matchers:
+          - logs_path:
+              logs_path: "/var/log/containers/"
 
     output.elasticsearch:
       host: '${NODE_NAME}'


### PR DESCRIPTION
- Remove `in_cluster` config from `add_kubernetes_metadata
- Use `container` input instead of `docker` input
- Use recommended values for `add_kubernetes_metadata`

Fixes #558 

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] ~README.md updated with any new values or changes~
- [ ] ~Updated template tests in `${CHART}/tests/*.py`~
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`