### PR TITLE
[jenkins] Fix Google cluster name

### DIFF
--- a/.ci/jobs.t/elastic+helm-charts+{branch}+cluster-cleanup.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+cluster-cleanup.yml
@@ -29,7 +29,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+cluster-creation.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+cluster-creation.yml
@@ -29,7 +29,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+integration-apm-server.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+integration-apm-server.yml
@@ -33,7 +33,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+integration-elasticsearch.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+integration-elasticsearch.yml
@@ -33,7 +33,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+integration-filebeat.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+integration-filebeat.yml
@@ -33,7 +33,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+integration-kibana.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+integration-kibana.yml
@@ -33,7 +33,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+integration-logstash.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+integration-logstash.yml
@@ -33,7 +33,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash

--- a/.ci/jobs.t/elastic+helm-charts+{branch}+integration-metricbeat.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+integration-metricbeat.yml
@@ -33,7 +33,8 @@
         unset VAULT_ROLE_ID VAULT_SECRET_ID
         set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-%BRANCH%"
+        BRANCH_NAME="%BRANCH%"
+        cluster_name="helm-${KUBERNETES_VERSION//./}-${BRANCH_NAME//./}"
 
         cd helpers/terraform/
         ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat


### PR DESCRIPTION
The cluster names created for running tests can't contain the character
 `.` which is part of the branch name.
