### PR TITLE
[ci] Fix triggering upstream cleanup job

### DIFF
--- a/.ci/jobs.t/elastic+helm-charts+{branch}.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}.yml
@@ -44,5 +44,5 @@
     publishers:
     - trigger-parameterized-builds:
       - project: elastic+helm-charts+%BRANCH%+cluster-cleanup
-        current-parameters: true
-        trigger-with-no-params: false
+        current-parameters: false
+        trigger-with-no-params: true


### PR DESCRIPTION
For doing the integration tests some GKE clusters are created. There is
a dedicated job to clean up these clusters at the end of the tests.
This commit fixes the Jenkins configuration to make sure this upstream
job (which does not need parameter) is triggered.


