### PR TITLE
[script] Update bumper script to handle SNAPSHOT versions

### DIFF
--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -22,7 +22,7 @@ easily be overridden in the config value `apmConfig.apm-server.yml`.
 
 ## Installing
 
-This chart is tested with the latest 7.7.x versions.
+This chart is tested with the latest 7.7.0-SNAPSHOT versions.
 
 * Add the elastic helm charts repo
 
@@ -46,7 +46,7 @@ This chart is tested with the latest 7.7.x versions.
   git checkout -b 7.7 origin/7.7
   ```
 
-* Install the latest 7.7.x-SNAPSHOT
+* Install the latest 7.7.0-SNAPSHOT
 
   ```bash
   helm install --name apm-server ./helm-charts/apm-server

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -48,7 +48,7 @@ If you currently have a cluster deployed with the [helm/charts stable](https://g
 
 ## Installing
 
-This chart is tested with the latest 7.7.x versions.
+This chart is tested with the latest 7.7.0-SNAPSHOT versions.
 
 * Add the elastic helm charts repo
 
@@ -72,7 +72,7 @@ This chart is tested with the latest 7.7.x versions.
   git checkout -b 7.7 origin/7.7
   ```
 
-* Install the latest 7.7.x-SNAPSHOT
+* Install the latest 7.7.0-SNAPSHOT
 
   ```bash
   helm install --name elasticsearch ./helm-charts/elasticsearch

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -16,7 +16,7 @@ This helm chart is a lightweight way to configure and run our official [Filebeat
 
 ## Installing
 
-This chart is tested with the latest 7.7.x versions.
+This chart is tested with the latest 7.7.0-SNAPSHOT versions.
 
 * Add the elastic helm charts repo
 
@@ -40,7 +40,7 @@ This chart is tested with the latest 7.7.x versions.
   git checkout -b 7.7 origin/7.7
   ```
 
-* Install the latest 7.7.x-SNAPSHOT
+* Install the latest 7.7.0-SNAPSHOT
 
   ```bash
   helm install --name filebeat ./helm-charts/filebeat

--- a/helpers/bumper.py
+++ b/helpers/bumper.py
@@ -28,7 +28,6 @@ chart_version = versions[7]
 file_patterns = [
     "*/examples/*/*.y*ml",
     "helpers/examples.mk",
-    "*/README.md",
     "*/values.y*ml",
     "*/Chart.y*ml",
 ]
@@ -43,7 +42,7 @@ blacklist = re.compile(r".*127.0.0.1.*")
 print("Updating versions...")
 
 for major, version in versions.iteritems():
-    r = re.compile(r"{0}\.[0-9]*\.[0-9]*-?[0-9]?".format(major))
+    r = re.compile(r"{0}\.[0-9]*\.[0-9]*-?(SNAPSHOT)?".format(major))
     for pattern in file_patterns:
         for f in glob.glob(pattern):
             print(f)

--- a/helpers/bumper.py
+++ b/helpers/bumper.py
@@ -28,6 +28,7 @@ chart_version = versions[7]
 file_patterns = [
     "*/examples/*/*.y*ml",
     "helpers/examples.mk",
+    "*/README.md",
     "*/values.y*ml",
     "*/Chart.y*ml",
 ]

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -11,7 +11,7 @@ This helm chart is a lightweight way to configure and run our official [Kibana d
 
 ## Installing
 
-This chart is tested with the latest 7.7.x versions.
+This chart is tested with the latest 7.7.0-SNAPSHOT versions.
 
 * Add the elastic helm charts repo
 
@@ -35,7 +35,7 @@ This chart is tested with the latest 7.7.x versions.
   git checkout -b 7.7 origin/7.7
   ```
 
-* Install the latest 7.7.x-SNAPSHOT
+* Install the latest 7.7.0-SNAPSHOT
 
   ```bash
   helm install --name kibana ./helm-charts/kibana

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -20,7 +20,7 @@ This helm chart is a lightweight way to configure and run our official [Logstash
 
 ## Installing
 
-This chart is tested with the latest 7.7.x versions.
+This chart is tested with the latest 7.7.0-SNAPSHOT versions.
 
 * Add the elastic helm charts repo
 
@@ -44,7 +44,7 @@ This chart is tested with the latest 7.7.x versions.
   git checkout -b 7.7 origin/7.7
   ```
 
-* Install the latest 7.7.x-SNAPSHOT
+* Install the latest 7.7.0-SNAPSHOT
 
   ```bash
   helm install --name logstash ./helm-charts/logstash

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -25,7 +25,7 @@ The workaround is to use `--force` argument for `helm upgrade` command which wil
 
 ## Installing
 
-This chart is tested with the latest 7.7.x versions.
+This chart is tested with the latest 7.7.0-SNAPSHOT versions.
 
 * Add the elastic helm charts repo
 
@@ -49,7 +49,7 @@ This chart is tested with the latest 7.7.x versions.
   git checkout -b 7.7 origin/7.7
   ```
 
-* Install the latest 7.7.x-SNAPSHOT
+* Install the latest 7.7.0-SNAPSHOT
 
   ```bash
   helm install --name metricbeat ./helm-charts/metricbeat


### PR DESCRIPTION
This commit updates the `bumper.py` script to handle the
workflows for updating the versions to test staging artifacts
and before a release, for example:

- update 7.7.0-SNAPSHOT to 7.7.0 before tagging a release, by running
  `env BUMPER_VERSION_7="7.7.0" ./helpers/bumper.py`
- update 7.7.0-SNAPHSHOT to 7.7.0-abcdefgh for testing staging artifacts
by running:
  `env BUMPER_VERSION_7="7.7.0-abcdefgh" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py`

For now, this script does not handle the bump from 7.7.0 to 7.7.1-SNAPSHOT
for the next development iteration after a release. In the meantime,
this update should be done manually.


