### PR TITLE
[ci] Fix multijob configuration for testing staging artifacts

### DIFF
--- a/.ci/jobs.t/elastic+helm-charts+{branch}+staging.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+staging.yml
@@ -1,13 +1,13 @@
 ---
 - job:
     name: elastic+helm-charts+%BRANCH%+staging
-    display-name: elastic / helm-charts - staging
+    display-name: elastic / helm-charts +%BRANCH%+ - staging tests
     description: Staging image testing
     concurrent: true
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.7.0-abcdabcd)"
     project-type: multijob
     scm:
     - git:
@@ -17,30 +17,30 @@
         name: template testing and kubernetes cluster creation
         condition: SUCCESSFUL
         projects:
-        - name: elastic+helm-charts+staging+cluster-creation
+        - name: elastic+helm-charts+%BRANCH%+staging+cluster-creation
           current-parameters: true
     - multijob:
         name: elasticsearch integration testing
         condition: ALWAYS
         projects:
-        - name: elastic+helm-charts+staging+integration-elasticsearch
+        - name: elastic+helm-charts+%BRANCH%+staging+integration-elasticsearch
           current-parameters: true
     - multijob:
         name: integration testing
         condition: ALWAYS
         projects:
-        - name: elastic+helm-charts+staging+integration-kibana
+        - name: elastic+helm-charts+%BRANCH%+staging+integration-kibana
           current-parameters: true
-        - name: elastic+helm-charts+staging+integration-filebeat
+        - name: elastic+helm-charts+%BRANCH%+staging+integration-filebeat
           current-parameters: true
-        - name: elastic+helm-charts+staging+integration-metricbeat
+        - name: elastic+helm-charts+%BRANCH%+staging+integration-metricbeat
           current-parameters: true
-        - name: elastic+helm-charts+staging+integration-logstash
+        - name: elastic+helm-charts+%BRANCH%+staging+integration-logstash
           current-parameters: true
-        - name: elastic+helm-charts+staging+integration-apm-server
+        - name: elastic+helm-charts+%BRANCH%+staging+integration-apm-server
           current-parameters: true
     publishers:
     - trigger-parameterized-builds:
-      - project: elastic+helm-charts+staging+cluster-cleanup
+      - project: elastic+helm-charts+%BRANCH%+staging+cluster-cleanup
         current-parameters: true
         trigger-with-no-params: false


### PR DESCRIPTION
The multi-job configuration for testing staging artifacts was
referencing jobs from another branch. This commit makes sure the
configured jobs are all from the same git branch.

