### PR TITLE
[elasticsearch] Set securityContext for test pod

### DIFF
--- a/elasticsearch/templates/test/test-elasticsearch-health.yaml
+++ b/elasticsearch/templates/test/test-elasticsearch-health.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  securityContext:
+{{ toYaml .Values.podSecurityContext | indent 4 }}
   containers:
   - name: "{{ .Release.Name }}-{{ randAlpha 5 | lower }}-test"
     image: "{{ .Values.image }}:{{ .Values.imageTag }}"


### PR DESCRIPTION
Apply the the security context from the values file to the test pod: this will allow the `helm test` pod to run without root and work with more restrictive pod security policies.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes (nothing new to say)
- [ ] Updated template tests in `${CHART}/tests/*.py` (nothing new to test)
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml` (nothing new to test)
