### PR TITLE
Elasticsearch secret mountmode

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -113,6 +113,9 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
         {{- end }}
         {{- if .Values.esConfig }}
         - name: esconfig

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -514,6 +514,24 @@ secretMounts:
     }
 
 
+def test_adding_a_secret_mount_with_default_mode():
+    config = """
+secretMounts:
+  - name: elastic-certificates
+    secretName: elastic-certs
+    path: /usr/share/elasticsearch/config/certs
+    subPath: cert.crt
+    defaultMode: 0755
+"""
+    r = helm_template(config)
+    s = r["statefulset"][uname]["spec"]["template"]["spec"]
+    assert s["containers"][0]["volumeMounts"][-1] == {
+        "mountPath": "/usr/share/elasticsearch/config/certs",
+        "subPath": "cert.crt",
+        "name": "elastic-certificates",
+    }
+
+
 def test_adding_image_pull_secrets():
     config = """
 imagePullSecrets:

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -48,6 +48,7 @@ secretMounts: []
 #  - name: elastic-certificates
 #    secretName: elastic-certificates
 #    path: /usr/share/elasticsearch/config/certs
+#    defaultMode: 0755
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
 imageTag: "7.6.2"


### PR DESCRIPTION
Add ability to set the file permissions when mounting a secret
https://kubernetes.io/docs/concepts/configuration/secret/#secret-files-permissions

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
