### PR TITLE
[metricbeat] fix deployment upgrade by removing chart label from .spec.selector.matchLabels

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -7,7 +7,9 @@
   - [GA support](#ga-support)
   - [New branching model](#new-branching-model)
   - [Filebeat container inputs](#filebeat-container-inputs)
+  - [Metricbeat upgrade issue](#metricbeat-upgrade-issue)
   - [Metricbeat split values for daemonset and deployment](#metricbeat-split-values-for-daemonset-and-deployment)
+- [6.8.9 - 2020/05/13](#689---20200513)
 - [7.6.2 - 2020/03/31](#762---20200331)
   - [Kibana default resources](#kibana-default-resources)
 - [7.6.0 - 2020/02/11](#760---20200211)
@@ -47,6 +49,14 @@ Docker images
 
 Filebeat chart default config is now using [container input][] instead of
 [docker input][] in [#568][].
+
+### Metricbeat upgrade issue
+
+Metricbeat upgrade are failing with
+`spec.selector: Invalid value: ... field is immutable` error. This is related to
+Metricbeat deployment selector including chart version which is not immutable.
+You should use `helm upgrade --force` to upgrade Metricbeat. See [#621][] for
+more details.
 
 ### Metricbeat split values for daemonset and deployment
 
@@ -153,6 +163,7 @@ volumeClaimTemplate:
 [#540]: https://github.com/elastic/helm-charts/pull/540
 [#568]: https://github.com/elastic/helm-charts/pull/568
 [#572]: https://github.com/elastic/helm-charts/pull/572
+[#621]: https://github.com/elastic/helm-charts/pull/621
 [container input]: https://www.elastic.co/guide/en/beats/filebeat/7.7/filebeat-input-container.html
 [docker input]: https://www.elastic.co/guide/en/beats/filebeat/7.7/filebeat-input-docker.html
 [elastic helm repo]: https://helm.elastic.co

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app: '{{ template "metricbeat.fullname" . }}-metrics'
-      chart: '{{ .Chart.Name }}'
       heritage: '{{ .Release.Service }}'
       release: '{{ .Release.Name }}'
   template:

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       app: '{{ template "metricbeat.fullname" . }}-metrics'
-      chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+      chart: '{{ .Chart.Name }}'
       heritage: '{{ .Release.Service }}'
       release: '{{ .Release.Name }}'
   template:


### PR DESCRIPTION
This fix metricbeat chart upgrades when `.Chart.Version` change.
Fix #621 

```
UPGRADE FAILED
Error: Deployment.apps "metricbeat-metricbeat-metrics" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"metricbeat-metricbeat-metrics", "chart":"metricbeat-7.7.0", "heritage":"Tiller", "release":"metricbeat"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
Error: UPGRADE FAILED: Deployment.apps "metricbeat-metricbeat-metrics" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"metricbeat-metricbeat-metrics", "chart":"metricbeat-7.7.0", "heritage":"Tiller", "release":"metricbeat"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

See https://github.com/helm/charts/issues/7680 for more details.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
