### PR TITLE
[metricbeat] Fix configchecksum not being set

### DIFF
--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{/* This forces a restart if the configmap has changed */}}
-        {{- if .Values.metricbeatConfig }}
+        {{- if or  .Values.metricbeatConfig .Values.daemonset.metricbeatConfig }}
         configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
       name: "{{ template "metricbeat.fullname" . }}"

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{/* This forces a restart if the configmap has changed */}}
-        {{- if .Values.metricbeatConfig }}
+        {{- if or  .Values.metricbeatConfig .Values.deployment.metricbeatConfig }}
         configChecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
       labels:


### PR DESCRIPTION
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [X] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

This tackles https://github.com/elastic/helm-charts/issues/632

Downside: leads to avoidable reloads of daemonset if deployment changes and vice versa