### PR TITLE
[kibana] Add pod security policy to template

### DIFF
--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -41,3 +41,16 @@ heritage: {{ .Release.Service }}
 {{ toYaml .Values.labels }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Use the fullname if the serviceAccount value is not set
+*/}}
+{{- define "kibana.serviceAccount" -}}
+{{- if and .Values.rbac.serviceAccountName ( not ( eq .Values.podSecurityPolicy.name "" ) ) -}}
+{{- .Values.rbac.serviceAccountName -}}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+

--- a/kibana/templates/clusterrole.yaml
+++ b/kibana/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "kibana.serviceAccount" . }}-cluster-role
+  labels:
+    app: "{{ template "kibana.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/kibana/templates/clusterrolebinding.yaml
+++ b/kibana/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kibana.serviceAccount" . }}-cluster-role-binding
+  labels:
+    app: "{{ template "kibana.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "kibana.serviceAccount" . }}-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kibana.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
 {{- end }}
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
-      {{- if .Values.serviceAccount }}
-      serviceAccount: {{ .Values.serviceAccount }}
+      {{- if .Values.rbac.serviceAccountName }}
+      serviceAccount: {{ .Values.rbac.serviceAccountName }}
       {{- end }}
       volumes:
         {{- range .Values.secretMounts }}

--- a/kibana/templates/podsecuritypolicy.yaml
+++ b/kibana/templates/podsecuritypolicy.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podSecurityPolicy.create -}}
+{{- $fullName := include "kibana.fullname" . -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+spec:
+{{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
+{{- end -}}

--- a/kibana/templates/serviceaccount.yaml
+++ b/kibana/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kibana.serviceAccount" . }}
+  labels:
+    app: "{{ template "kibana.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+{{- end -}}

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -282,7 +282,8 @@ nameOverride: overrider
 
 def test_setting_a_custom_service_account():
     config = """
-serviceAccount: notdefault
+rbac:
+  serviceAccountName: notdefault
 """
     r = helm_template(config)
     assert (

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -72,7 +72,32 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-serviceAccount: ""
+# Whether this chart should self-manage its service account, role, and associated role binding.
+managedServiceAccount: true
+
+rbac:
+  create: false
+  serviceAccountName: ""
+
+podSecurityPolicy:
+  create: false
+  name: ""
+  spec:
+    privileged: true
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - secret
+      - configMap
+      - persistentVolumeClaim
+      - projected
+      - emptyDir
 
 # This is the PriorityClass settings as defined in
 # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
This is necessary in order to be able to make the chart work on a cluster with pod security policy enabled.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
