### PR TITLE
podSecurityContext.runAsUser needs to be nulled as well for Openshift

### DIFF
--- a/elasticsearch/examples/openshift/values.yaml
+++ b/elasticsearch/examples/openshift/values.yaml
@@ -5,6 +5,7 @@ securityContext:
 
 podSecurityContext:
   fsGroup: null
+  runAsUser: null
 
 sysctlInitContainer:
   enabled: false


### PR DESCRIPTION
Currently, the Openshift example does not remove `runAsUser` completely. When deploying the chart in Openshift, this results in the error:
```
unable to validate against any security context constraint: [spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000630000, 1000639999]]
```
To verify without Openshift, you see that
```
$ helm template -f elasticsearch/examples/openshift/values.yaml elasticsearch elasticsearch/ | grep runAsUser
```
sets the UID, which is not allowed by the default Openshift security context.

This pull request fixes the example so that runAsUser is not set at all.