### PR TITLE
Elasticsearch: set PVC labels through setting all StatefulSet labels to its volumeClaimTemplate

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -26,6 +26,16 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: {{ template "elasticsearch.uname" . }}
+    {{- if .Values.persistence.labels.enabled }}
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}"
+        app: "{{ template "elasticsearch.uname" . }}"
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     {{- with .Values.persistence.annotations  }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -84,8 +84,10 @@ def test_defaults():
     assert c["volumeMounts"][0]["mountPath"] == "/usr/share/elasticsearch/data"
     assert c["volumeMounts"][0]["name"] == uname
 
+    # volumeClaimTemplates
     v = r["statefulset"][uname]["spec"]["volumeClaimTemplates"][0]
     assert v["metadata"]["name"] == uname
+    assert "labels" not in v["metadata"]
     assert v["spec"]["accessModes"] == ["ReadWriteOnce"]
     assert v["spec"]["resources"]["requests"]["storage"] == "30Gi"
 
@@ -477,6 +479,20 @@ def test_adding_multiple_persistence_annotations():
 
     assert annotations["hello"] == "world"
     assert annotations["world"] == "hello"
+
+
+def test_enabling_persistence_label_in_volumeclaimtemplate():
+    config = """
+persistence:
+  labels:
+    enabled: true
+"""
+    r = helm_template(config)
+    volume_claim_template_labels = r["statefulset"][uname]["spec"][
+        "volumeClaimTemplates"
+    ][0]["metadata"]["labels"]
+    statefulset_labels = r["statefulset"][uname]["metadata"]["labels"]
+    assert volume_claim_template_labels == statefulset_labels
 
 
 def test_adding_a_secret_mount():

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -119,6 +119,9 @@ podSecurityPolicy:
 
 persistence:
   enabled: true
+  labels:
+    # Add default labels for the volumeClaimTemplate fo the StatefulSet
+    enabled: false
   annotations: {}
 
 extraVolumes: []


### PR DESCRIPTION
Elasticsearch: set PVC labels through setting all StatefulSet labels to its volumeClaimTemplate.

Allows to track created PVCs (example: delete all PVCs from this recently deleted Release).

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
