### PR TITLE
[elasticsearch] update kind example for version >= 0.7.0

### DIFF
--- a/elasticsearch/examples/kubernetes-kind/Makefile
+++ b/elasticsearch/examples/kubernetes-kind/Makefile
@@ -3,8 +3,11 @@ default: test
 RELEASE := helm-es-kind
 
 install:
-	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
+
+install-local-path:
+	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+	helm upgrade --wait --timeout=900 --install --values values-local-path.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)

--- a/elasticsearch/examples/kubernetes-kind/README.md
+++ b/elasticsearch/examples/kubernetes-kind/README.md
@@ -6,21 +6,19 @@ using [custom values][].
 Note that this configuration should be used for test only and isn't recommended
 for production.
 
+Note that Kind < 0.7.0 are affected by a [kind issue][] with mount points
+created from PVCs not writable by non-root users. [kubernetes-sigs/kind#1157][]
+fix it in Kind 0.7.0.
 
-## Requirements
-
-There is currently an [kind issue][] with mount points created from PVCs not
-writable by non-root users. [kubernetes-sigs/kind#1157][] should fix it in a
-future release.
-
-Meanwhile, the workaround is to install manually
+The workaround for Kind < 0.7.0 is to install manually
 [Rancher Local Path Provisioner][] and use `local-path` storage class for
 Elasticsearch volumes (see [Makefile][] instructions).
 
 
 ## Usage
 
-* Deploy Elasticsearch chart with the default values: `make install`
+* For Kind >= 0.7.0: Deploy Elasticsearch chart with the default values: `make install`
+* For Kind < 0.7.0: Deploy Elasticsearch chart with `local-path` storage class: `make install-local-path`
 
 * You can now setup a port forward to query Elasticsearch API:
 

--- a/elasticsearch/examples/kubernetes-kind/values-local-path.yaml
+++ b/elasticsearch/examples/kubernetes-kind/values-local-path.yaml
@@ -1,0 +1,23 @@
+---
+# Permit co-located instances for solitary minikube virtual machines.
+antiAffinity: "soft"
+
+# Shrink default JVM heap.
+esJavaOpts: "-Xmx128m -Xms128m"
+
+# Allocate smaller chunks of memory per pod.
+resources:
+  requests:
+    cpu: "100m"
+    memory: "512M"
+  limits:
+    cpu: "1000m"
+    memory: "512M"
+
+# Request smaller persistent volumes.
+volumeClaimTemplate:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "local-path"
+  resources:
+    requests:
+      storage: 100M


### PR DESCRIPTION
This PR update the [kubernetes-kind](https://kind.sigs.k8s.io/) example to use new `standard` `StorageClass` instead of the `local-path` `StorageClass` which was added as a workaround for kind < 0.7.0 in #434.