### PR TITLE
[elasticsearch] _helpers.tpl - elasticsearch.endpoints to use elasticsearch.uname

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -45,7 +45,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "elasticsearch.endpoints" -}}
 {{- $replicas := int (toString (.Values.replicas)) }}
-{{- $uname := printf "%s-%s" .Values.clusterName .Values.nodeGroup }}
+{{- $uname := (include "elasticsearch.uname" .) }}
   {{- range $i, $e := untilStep 0 $replicas 1 -}}
 {{ $uname }}-{{ $i }},
   {{- end -}}

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -1299,15 +1299,16 @@ fullnameOverride: "customfullName"
     assert "customfullName" in r["statefulset"]
     assert "customfullName" in r["service"]
 
+
 def test_initial_master_nodes_when_using_full_name_override():
     config = """
 fullnameOverride: "customfullName"
 """
     r = helm_template(config)
-    env = r["statefulset"]["customfullName"]["spec"]["template"]["spec"]["containers"][0]["env"]
+    env = r["statefulset"]["customfullName"]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["env"]
     assert {
-       "name": "cluster.initial_master_nodes",
-       "value": "customfullName-0,"
-                + "customfullName-1,"
-                + "customfullName-2,",
+        "name": "cluster.initial_master_nodes",
+        "value": "customfullName-0," + "customfullName-1," + "customfullName-2,",
     } in env

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -1298,3 +1298,16 @@ fullnameOverride: "customfullName"
 
     assert "customfullName" in r["statefulset"]
     assert "customfullName" in r["service"]
+
+def test_initial_master_nodes_when_using_full_name_override():
+    config = """
+fullnameOverride: "customfullName"
+"""
+    r = helm_template(config)
+    env = r["statefulset"]["customfullName"]["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {
+       "name": "cluster.initial_master_nodes",
+       "value": "customfullName-0,"
+                + "customfullName-1,"
+                + "customfullName-2,",
+    } in env


### PR DESCRIPTION
This addressing an issue where nodes are unable to locate the masters when `fullnameOverride` is used, due to the `cluster.initial_master_nodes` having the wrong name of the nodes.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
