### PR TITLE
[apm-server] allow customizing probes

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -88,15 +88,9 @@ spec:
 {{ toYaml .Values.podSecurityContext | indent 10 }}
 {{- end }}
         livenessProbe:
-          httpGet:
-            path: /
-            port: http
-          initialDelaySeconds: 30
+{{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          httpGet:
-            path: /
-            port: http
-          initialDelaySeconds: 30
+{{ toYaml .Values.readinessProbe | indent 10 }}
         ports:
           - containerPort: {{ .Values.service.port }}
             name: http

--- a/apm-server/values.yaml
+++ b/apm-server/values.yaml
@@ -80,12 +80,20 @@ podSecurityContext:
   privileged: false
 
 livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
 
 readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
   failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10


### PR DESCRIPTION
This commit makes probes customizable using values.
The values where already partly existing but weren't used in the deployment template.

Fixes #488 
