### PR TITLE
[doc] fix ga support mentions for 6.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,8 @@
 
 * First 6.x release
 * 6.8.9 as the default stack version
-* See [7.7.0 CHANGELOG](#770---20200513) for other changes
+* See [7.7.0 CHANGELOG](#770---20200513) except GA support (charts are
+  staying in Beta for 6.8).
 
 
 ## 7.6.2 - 2020/03/31

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Note that only the released charts coming from [Elastic Helm repo][] or
 
 |     | Elasticsearch | Kibana | Logstash | Filebeat | Metricbeat | APM Server |
 |-----|---------------|--------|----------|----------|------------|------------|
+| 6.8 | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
 | 7.0 | Alpha         | Alpha  | /        | /        | /          | /          |
 | 7.1 | Beta          | Beta   | /        | Beta     | /          | /          |
 | 7.2 | Beta          | Beta   | /        | Beta     | Beta       | /          |


### PR DESCRIPTION
This PR remove the GA support mentions for 6.8.9 release. Only releases >= 7.7.0 are GA and eligible to support.