### PR TITLE
[apm-server] Add to test matrix

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -4,6 +4,7 @@ CHART:
   - filebeat
   - metricbeat
   - logstash
+  - apm-server
 ES_SUITE:
   - default
   - config


### PR DESCRIPTION
Spotted that the `apm-server` chart isn't being tested by PR suite.

So add it to the `CHART` matrix.
