### PR TITLE
[testing] Ensure that the 'namespace' is specified in Helm command

### DIFF
--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -9,7 +9,7 @@ def helm_template(config):
     with tempfile.NamedTemporaryFile() as temp:
         with open(temp.name, "w") as values:
             values.write(config)
-        helm_cmd = "helm template -f {0} ./".format(temp.name)
+        helm_cmd = "helm template -f {0} --namespace default ./".format(temp.name)
         result = yaml.load_all(check_output(helm_cmd.split()))
 
         results = {}


### PR DESCRIPTION
If the `--namespace` flag isn't provided to Helm, then it will use whatever the local configured namespace is, which could be different.

This can lead to tests failing that expect the `.Release.Namespace` to resolve to `default`
