### PR TITLE
[meta] add slack notifications to CI jobs

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -43,6 +43,3 @@
         timeout: 360
         fail: true
     - timestamps
-    publishers:
-    - email:
-        recipients: infra-root+build@elastic.co

--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -46,3 +46,8 @@
       - project: elastic+helm-charts+master+cluster-cleanup
         current-parameters: true
         trigger-with-no-params: false
+    - slack:
+        notify-back-to-normal: True
+        notify-every-failure: True
+        room: infra-release-notify
+        team-domain: elastic

--- a/.ci/jobs/elastic+helm-charts+staging.yml
+++ b/.ci/jobs/elastic+helm-charts+staging.yml
@@ -44,8 +44,8 @@
       - project: elastic+helm-charts+staging+cluster-cleanup
         current-parameters: true
         trigger-with-no-params: false
-      - slack:
-        notify-back-to-normal: True
-        notify-every-failure: True
-        room: infra-release-notify
-        team-domain: elastic
+    - slack:
+      notify-back-to-normal: True
+      notify-every-failure: True
+      room: infra-release-notify
+      team-domain: elastic

--- a/.ci/jobs/elastic+helm-charts+staging.yml
+++ b/.ci/jobs/elastic+helm-charts+staging.yml
@@ -44,3 +44,8 @@
       - project: elastic+helm-charts+staging+cluster-cleanup
         current-parameters: true
         trigger-with-no-params: false
+      - slack:
+        notify-back-to-normal: True
+        notify-every-failure: True
+        room: infra-release-notify
+        team-domain: elastic


### PR DESCRIPTION
This PR add Slack notifications to Elastic Release team Slack channel for [elastic+helm-charts+master](https://devops-ci.elastic.co/view/Helm%20Charts/job/elastic+helm-charts+master/) and [elastic+helm-charts+staging](https://devops-ci.elastic.co/view/Helm%20Charts/job/elastic+helm-charts+staging/) test jobs.