### PR TITLE
[logstash] remove expected logstash host and name assertion

### DIFF
--- a/logstash/examples/default/test/goss.yaml
+++ b/logstash/examples/default/test/goss.yaml
@@ -9,10 +9,10 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-default-logstash-0"'
+      - '"host" : "helm-logstash-default-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-default-logstash-0"'
+      - '"name" : "helm-logstash-default-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
 
 file:
   /usr/share/logstash/config/logstash.yml:

--- a/logstash/examples/default/test/goss.yaml
+++ b/logstash/examples/default/test/goss.yaml
@@ -9,10 +9,8 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-default-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-default-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
 
 file:
   /usr/share/logstash/config/logstash.yml:

--- a/logstash/examples/elasticsearch/test/goss.yaml
+++ b/logstash/examples/elasticsearch/test/goss.yaml
@@ -21,10 +21,8 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-elasticsearch-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-elasticsearch-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
   http://elasticsearch-master:9200/_cat/indices:
     status: 200
     timeout: 2000

--- a/logstash/examples/elasticsearch/test/goss.yaml
+++ b/logstash/examples/elasticsearch/test/goss.yaml
@@ -21,10 +21,10 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-elasticsearch-logstash-0"'
+      - '"host" : "helm-logstash-elasticsearch-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-elasticsearch-logstash-0"'
+      - '"name" : "helm-logstash-elasticsearch-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
   http://elasticsearch-master:9200/_cat/indices:
     status: 200
     timeout: 2000

--- a/logstash/examples/oss/test/goss.yaml
+++ b/logstash/examples/oss/test/goss.yaml
@@ -9,10 +9,10 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-oss-logstash-0"'
+      - '"host" : "helm-logstash-oss-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-oss-logstash-0"'
+      - '"name" : "helm-logstash-oss-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
 
 file:
   /usr/share/logstash/config/logstash.yml:

--- a/logstash/examples/oss/test/goss.yaml
+++ b/logstash/examples/oss/test/goss.yaml
@@ -9,10 +9,8 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-oss-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-oss-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
 
 file:
   /usr/share/logstash/config/logstash.yml:

--- a/logstash/examples/security/test/goss.yaml
+++ b/logstash/examples/security/test/goss.yaml
@@ -21,10 +21,10 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-security-logstash-0"'
+      - '"host" : "helm-logstash-security-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-security-logstash-0"'
+      - '"name" : "helm-logstash-security-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
   https://security-master:9200/_cat/indices:
     status: 200
     timeout: 2000

--- a/logstash/examples/security/test/goss.yaml
+++ b/logstash/examples/security/test/goss.yaml
@@ -21,10 +21,8 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"host" : "helm-logstash-security-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
       - '"version" : "6.8.11"'
       - '"http_address" : "0.0.0.0:9600"'
-      - '"name" : "helm-logstash-security-logstash-0.helm-logstash-default-logstash-headless.default.svc.cluster.local"'
   https://security-master:9200/_cat/indices:
     status: 200
     timeout: 2000


### PR DESCRIPTION
This commit remove expected Logstash host and name in Logstash tests with 6.x.

When using a headless service (4a6067e), Logstash 6.x use the full name of the service related to the namespace (ie: `helm-logstash-default-logstash-0.helm-logstash-oss-logstash-headless.helm-charts-testing.svc.cluster.local`). Keeping this test would require a hard coupling between the test and the namespace where it is running.