### PR TITLE
[meta] use same staging job for all branches

### DIFF
--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -20,6 +25,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -20,6 +25,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -24,6 +29,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -24,6 +29,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -24,6 +29,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -24,6 +29,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -24,6 +29,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
@@ -6,9 +6,14 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'True'
     axes:
     - axis:
@@ -24,6 +29,9 @@
         type: yaml
         name: KUBERNETES_VERSION
         filename: helpers/matrix.yml
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging.yml
+++ b/.ci/jobs/elastic+helm-charts+staging.yml
@@ -7,11 +7,19 @@
     parameters:
       - string:
           name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.6.1-abcdabcd)"
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BRANCH
+          description: "The helm-charts repo branch to use. (Example: 7.8)"
     project-type: multijob
     scm:
     - git:
+        branches:
+        - $BRANCH
         wipe-workspace: 'False'
+    wrappers:
+    - build-name:
+        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
     builders:
     - multijob:
         name: template testing and kubernetes cluster creation


### PR DESCRIPTION
We currently have staging jobs for every branch (6.8, 7.8, 7.x & master). However, we should only test staging from the minor release branches (ie: 6.8 & 7.8). In addition, staging jobs are only triggered manually after a BC, so staging job for a specific branch should rarely have more than 10 builds. This commit will rationalize and help having a cleaner Helm charts Jenkins view by using the same staging jobs for every branches. 

Note that staging jobs templates should be removed from the other branches.
