### PR TITLE
Include pre-releases in the semver range.

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -154,7 +154,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if semverCompare ">1.13" .Capabilities.KubeVersion.GitVersion }}
+      {{- if semverCompare ">1.13-0" .Capabilities.KubeVersion.GitVersion }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- end }}
       initContainers:


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

The new parameter `enableServiceLinks` added in https://github.com/elastic/helm-charts/pull/542 is only rendered with kubernetes >1.13. However the notation for the parameter to `semverCompare` requires a `-0` suffix to also take into account versions like `v1.15.12-gke.6.12`. Because of that, the `enableServiceLinks` parameter currently nothing on GKE. 

Note that the `helm template` and `helm install` will generate different values for `.Capabilities.KubeVersion.GitVersion`, something I was previously not aware of. 