### PR TITLE
[meta] use branch_specifier param instead of BRANCH

### DIFF
--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - cluster cleanup
     description: staging - cluster cleanup
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -27,7 +19,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - cluster creation
     description: staging - cluster creation
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -27,7 +19,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - integration apm-server
     description: staging - integration apm-server
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -31,7 +23,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - integration elasticsearch
     description: staging - integration elasticsearch
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -31,7 +23,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - integration filebeat
     description: staging - integration filebeat
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -31,7 +23,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - integration kibana
     description: staging - integration kibana
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -31,7 +23,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - integration logstash
     description: staging - integration logstash
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -31,7 +23,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
@@ -4,17 +4,9 @@
     display-name: elastic / helm-charts - staging - integration metricbeat
     description: staging - integration metricbeat
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    scm:
-    - git:
-        branches:
-        - $BRANCH
-        wipe-workspace: 'True'
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
     - axis:
         type: slave
@@ -31,7 +23,7 @@
         filename: helpers/matrix.yml
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - shell: |-
         #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+helm-charts+staging.yml
+++ b/.ci/jobs/elastic+helm-charts+staging.yml
@@ -5,21 +5,16 @@
     description: Staging image testing
     concurrent: true
     parameters:
-      - string:
-          name: BUILD_ID
-          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
-      - string:
-          name: BRANCH
-          description: "The helm-charts repo branch to use. (Example: 7.8)"
-    project-type: multijob
+    - string:
+        name: BUILD_ID
+        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+    project-type:
     scm:
     - git:
-        branches:
-        - $BRANCH
         wipe-workspace: 'False'
     wrappers:
     - build-name:
-        name: "${BUILD_NUMBER} - ${BRANCH} - ${BUILD_ID}"
+        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
     - multijob:
         name: template testing and kubernetes cluster creation


### PR DESCRIPTION
This commit remove the `BRANCH` CI job parameter introduced in 47a45cf because there is already a
`branch_specifier` parameter existing in [.ci/jobs/defaults.yml](https://github.com/elastic/helm-charts/blob/8f2025f82adc9598597a8790e767f46d40e782c1/.ci/jobs/defaults.yml).
