### PR TITLE
[meta] allow concurrency for staging jobs

### DIFF
--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+cluster-cleanup
     display-name: elastic / helm-charts - staging - cluster cleanup
     description: staging - cluster cleanup
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+cluster-creation
     display-name: elastic / helm-charts - staging - cluster creation
     description: staging - cluster creation
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+integration-apm-server
     display-name: elastic / helm-charts - staging - integration apm-server
     description: staging - integration apm-server
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+integration-elasticsearch
     display-name: elastic / helm-charts - staging - integration elasticsearch
     description: staging - integration elasticsearch
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+integration-filebeat
     display-name: elastic / helm-charts - staging - integration filebeat
     description: staging - integration filebeat
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+integration-kibana
     display-name: elastic / helm-charts - staging - integration kibana
     description: staging - integration kibana
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+integration-logstash
     display-name: elastic / helm-charts - staging - integration logstash
     description: staging - integration logstash
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID

--- a/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
@@ -3,6 +3,7 @@
     name: elastic+helm-charts+staging+integration-metricbeat
     display-name: elastic / helm-charts - staging - integration metricbeat
     description: staging - integration metricbeat
+    concurrent: true
     parameters:
     - string:
         name: BUILD_ID


### PR DESCRIPTION
This commit allow concurrency for staging jobs.
The upstream matrix job does already have concurrency enabled but not the downstream jobs.

This is required so we can test staging for multiple releases in // (example when we have a 6.x and 7.x release planned for the same day).