### PR TITLE
[elasticsearch] remove initial_master_nodes test

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -43,14 +43,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{- define "elasticsearch.endpoints" -}}
-{{- $replicas := int (toString (.Values.replicas)) }}
-{{- $uname := (include "elasticsearch.uname" .) }}
-  {{- range $i, $e := untilStep 0 $replicas 1 -}}
-{{ $uname }}-{{ $i }},
-  {{- end -}}
-{{- end -}}
-
 {{- define "elasticsearch.esMajorVersion" -}}
 {{- if .Values.esMajorVersion -}}
 {{ .Values.esMajorVersion }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -291,13 +291,8 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           {{- if eq .Values.roles.master "true" }}
-          {{- if ge (int (include "elasticsearch.esMajorVersion" .)) 7 }}
-          - name: cluster.initial_master_nodes
-            value: "{{ template "elasticsearch.endpoints" . }}"
-          {{- else }}
           - name: discovery.zen.minimum_master_nodes
             value: "{{ .Values.minimumMasterNodes }}"
-          {{- end }}
           {{- end }}
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -1268,17 +1268,3 @@ fullnameOverride: "customfullName"
 
     assert "customfullName" in r["statefulset"]
     assert "customfullName" in r["service"]
-
-
-def test_initial_master_nodes_when_using_full_name_override():
-    config = """
-fullnameOverride: "customfullName"
-"""
-    r = helm_template(config)
-    env = r["statefulset"]["customfullName"]["spec"]["template"]["spec"]["containers"][
-        0
-    ]["env"]
-    assert {
-        "name": "cluster.initial_master_nodes",
-        "value": "customfullName-0," + "customfullName-1," + "customfullName-2,",
-    } in env


### PR DESCRIPTION
`test_initial_master_nodes_when_using_full_name_override` has been added in af288a9 but is not valid with 6.x version.

This commit remove from 6.8 branch the test and `elasticsearch.endpoints` template which are only used with 7.x version.

Fixes [elastic+helm-charts+6.8+template-testing](https://devops-ci.elastic.co/job/elastic+helm-charts+6.8+template-testing/130/CHART=elasticsearch,label=docker&&virtual) job.