### PR TITLE
[meta] add slack token to ci jobs

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -51,3 +51,4 @@
         notify-every-failure: True
         room: infra-release-notify
         team-domain: elastic
+        auth-token-id: release-slack-integration-token

--- a/.ci/jobs/elastic+helm-charts+staging.yml
+++ b/.ci/jobs/elastic+helm-charts+staging.yml
@@ -52,3 +52,4 @@
         notify-every-failure: True
         room: infra-release-notify
         team-domain: elastic
+        auth-token-id: release-slack-integration-token


### PR DESCRIPTION
This PR is a follow up of https://github.com/elastic/helm-charts/pull/718 to add the Slack token to CI jobs configuration