### PR TITLE
Missing deletion of "elastic-certificate-crt"

### DIFF
--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -9,7 +9,7 @@ install:
 	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../
 
 purge:
-	kubectl delete secrets elastic-credentials elastic-certificates elastic-certificate-pem || true
+	kubectl delete secrets elastic-credentials elastic-certificates elastic-certificate-pem elastic-certificate-crt|| true
 	helm del --purge $(RELEASE)
 
 test: secrets install goss


### PR DESCRIPTION
Purge is missing the "elastic-certificate-crt" secret deletion.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
