### PR TITLE
[release] Initiate 7.9 branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,12 +261,12 @@ make goss
 [elastic helm repository]: https://helm.elastic.co
 [github forking model]: https://help.github.com/articles/fork-a-repo/
 [goss]: https://github.com/aelsabbahy/goss/blob/master/docs/manual.md
-[integration test example]: https://github.com/elastic/helm-charts/blob/7.x/elasticsearch/examples/default/test/goss.yaml
+[integration test example]: https://github.com/elastic/helm-charts/blob/7.9/elasticsearch/examples/default/test/goss.yaml
 [integration tests section]: #integration-tests
 [pytest]: https://docs.pytest.org/en/latest/
 [serverspec]: https://serverspec.org
-[templating test example]: https://github.com/elastic/helm-charts/blob/7.x/elasticsearch/tests/elasticsearch_test.py
+[templating test example]: https://github.com/elastic/helm-charts/blob/7.9/elasticsearch/tests/elasticsearch_test.py
 [templating tests section]: #templating-tests
 [release.md]: https://github.com/elastic/helm-charts/blob/master/helpers/release.md
 [releases section]: #releases
-[requirements.txt]: https://github.com/elastic/helm-charts/blob/7.x/requirements.txt
+[requirements.txt]: https://github.com/elastic/helm-charts/blob/7.9/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elastic Stack Kubernetes Helm Charts
 
-[![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+helm-charts+7.x.svg)](https://devops-ci.elastic.co/job/elastic+helm-charts+7.x/)
+[![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+helm-charts+7.9.svg)](https://devops-ci.elastic.co/job/elastic+helm-charts+7.9/)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -64,7 +64,8 @@ Note that only the released charts coming from [Elastic Helm repo][] or
 | 7.5 | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
 | 7.6 | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
 | 7.7 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.x | GA            | GA     | Beta     | GA       | GA         | Beta       |
+| 7.8 | GA            | GA     | Beta     | GA       | GA         | Beta       |
+| 7.9 | GA            | GA     | Beta     | GA       | GA         | Beta       |
 
 ### Kubernetes Versions
 
@@ -86,13 +87,13 @@ Elastic recommended way to deploy Elasticsearch, Kibana and APM Server on
 Kubernetes.
 
 
-[currently tested]: https://devops-ci.elastic.co/job/elastic+helm-charts+7.x/
+[currently tested]: https://devops-ci.elastic.co/job/elastic+helm-charts+7.9/
 [elastic cloud on kubernetes]: https://github.com/elastic/cloud-on-k8s
 [elastic helm repo]: https://helm.elastic.co
 [github releases]: https://github.com/elastic/helm-charts/releases
 [helm 3]: https://v3.helm.sh
-[helm-tester Dockerfile]: https://github.com/elastic/helm-charts/blob/7.x/helpers/helm-tester/Dockerfile
-[helpers/matrix.yml]: https://github.com/elastic/helm-charts/blob/7.x/helpers/matrix.yml
+[helm-tester Dockerfile]: https://github.com/elastic/helm-charts/blob/7.9/helpers/helm-tester/Dockerfile
+[helpers/matrix.yml]: https://github.com/elastic/helm-charts/blob/7.9/helpers/matrix.yml
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -19,7 +19,7 @@ for released version.
 - [Requirements](#requirements)
 - [Installing](#installing)
   - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using 7.x branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-7x-branch-and-790-snapshot-versions)
+  - [Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-79-branch-and-790-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
@@ -53,7 +53,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Install the latest 7.7 release:
 `helm install --name apm-server elastic/apm-server`
 
-### Install development version using 7.x branch and 7.9.0-SNAPSHOT versions
+### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
@@ -152,12 +152,12 @@ about our development and testing process.
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [apm server docker image]: https://www.elastic.co/guide/en/apm/server/7.8/running-on-docker.html
 [apm server oss docker image]: https://www.docker.elastic.co/r/apm/apm-server-oss
-[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#default
+[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#default
 [environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 [environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
-[examples]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples
-[examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/oss
-[examples/security]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/security
+[examples]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples/oss
+[examples/security]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples/security
 [helm]: https://helm.sh
 [horizontal pod autoscaler]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
@@ -173,7 +173,7 @@ about our development and testing process.
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [serviceAccount]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-[supported configurations]: https://github.com/elastic/helm-charts/tree/7.x/README.md#supported-configurations
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.9/README.md#supported-configurations
 [tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 [updateStrategy]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment
-[values.yaml]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/values.yaml
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/values.yaml

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -8,7 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Alpha features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [7.7.1][] release
+**Warning**: This branch is used for development, please use [7.8.1][] release
 for released version.
 
 
@@ -50,7 +50,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install the latest 7.7 release:
+* Install the latest 7.8 release:
 `helm install --name apm-server elastic/apm-server`
 
 ### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
@@ -144,7 +144,7 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/apm-server/README.md
+[7.8.1]: https://github.com/elastic/helm-charts/blob/7.8.1/apm-server/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/apm-server/examples/default/README.md
+++ b/apm-server/examples/default/README.md
@@ -22,6 +22,6 @@ This example deploy APM Server 7.9.0-SNAPSHOT using [default values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/default/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/default/test/goss.yaml
-[default values]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/default/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples/default/test/goss.yaml
+[default values]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/values.yaml

--- a/apm-server/examples/oss/README.md
+++ b/apm-server/examples/oss/README.md
@@ -23,5 +23,5 @@ You can also run [goss integration tests][] using `make test`
 
 
 [apm server oss]: https://www.elastic.co/downloads/apm-oss
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/oss/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/oss/test/goss.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/oss/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples/oss/test/goss.yaml

--- a/apm-server/examples/security/README.md
+++ b/apm-server/examples/security/README.md
@@ -23,6 +23,6 @@ Elasticsearch (see [values][]).
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/security/test/goss.yaml
-[values]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/security/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples/security/test/goss.yaml
+[values]: https://github.com/elastic/helm-charts/tree/7.9/apm-server/examples/security/values.yaml

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -3,7 +3,7 @@
 This Helm chart is a lightweight way to configure and run our official
 [Elasticsearch Docker image][].
 
-**Warning**: This branch is used for development, please use [7.7.1][] release
+**Warning**: This branch is used for development, please use [7.8.1][] release
 for released version.
 
 
@@ -60,7 +60,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install the latest 7.7 release:
+* Install the latest 7.8 release:
 `helm install --name elasticsearch elastic/elasticsearch`
 
 ### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
@@ -385,7 +385,7 @@ about our development and testing process.
 
 
 [#63]: https://github.com/elastic/helm-charts/issues/63
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/elasticsearch/README.md
+[7.8.1]: https://github.com/elastic/helm-charts/blob/7.8.1/elasticsearch/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -14,7 +14,7 @@ for released version.
 - [Requirements](#requirements)
 - [Installing](#installing)
   - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using 7.x branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-7x-branch-and-790-snapshot-versions)
+  - [Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-79-branch-and-790-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
@@ -63,7 +63,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Install the latest 7.7 release:
 `helm install --name elasticsearch elastic/elasticsearch`
 
-### Install development version using 7.x branch and 7.9.0-SNAPSHOT versions
+### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
@@ -392,67 +392,67 @@ about our development and testing process.
 [alternate scheduler]: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/#specify-schedulers-for-pods
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [anti-affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-[cluster.name]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/cluster.name.html
-[clustering and node discovery]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#clustering-and-node-discovery
-[config example]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/config/values.yaml
+[cluster.name]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster.name.html
+[clustering and node discovery]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#clustering-and-node-discovery
+[config example]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/config/values.yaml
 [curator]: https://www.elastic.co/guide/en/elasticsearch/client/curator/7.8/snapshot.html
-[custom docker image]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docker.html#_c_customized_image
+[custom docker image]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docker.html#_c_customized_image
 [deploys statefulsets serially]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
-[discovery.zen.minimum_master_nodes]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/discovery-settings.html#minimum_master_nodes
-[docker for mac]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/docker-for-mac
-[elasticsearch cluster health status params]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/cluster-health.html#request-params
-[elasticsearch docker image]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docker.html
+[discovery.zen.minimum_master_nodes]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/discovery-settings.html#minimum_master_nodes
+[docker for mac]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/docker-for-mac
+[elasticsearch cluster health status params]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster-health.html#request-params
+[elasticsearch docker image]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docker.html
 [elasticsearch oss docker image]: https://www.docker.elastic.co/r/elasticsearch/elasticsearch-oss
 [environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 [environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
-[examples]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/
-[examples/multi]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/multi
-[examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/oss
-[examples/security]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security
+[examples]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/
+[examples/multi]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/multi
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/oss
+[examples/security]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
 [helm/charts stable]: https://github.com/helm/charts/tree/master/stable/elasticsearch/
-[how to install plugins guide]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#how-to-install-plugins
-[how to use the keystore]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#how-to-use-the-keystore
-[http.port]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings
+[how to install plugins guide]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#how-to-install-plugins
+[how to use the keystore]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#how-to-use-the-keystore
+[http.port]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-http.html#_settings
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[java options]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/jvm-options.html
-[jvm heap size]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/heap-size.html
-[kind]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/kubernetes-kind
+[java options]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/jvm-options.html
+[jvm heap size]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/heap-size.html
+[kind]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/kubernetes-kind
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [lifecycle hooks]: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 [loadBalancer annotations]: https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
 [loadBalancer]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
 [maxUnavailable]: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
-[migration guide]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/migration/README.md
-[minikube]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/minikube
-[microk8s]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/microk8s
-[multi]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/multi/
-[network.host elasticsearch setting]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/network.host.html
+[migration guide]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/migration/README.md
+[minikube]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/minikube
+[microk8s]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/microk8s
+[multi]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/multi/
+[network.host elasticsearch setting]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/network.host.html
 [node affinity settings]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-[node-certificates]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/configuring-tls.html#node-certificates
+[node-certificates]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/configuring-tls.html#node-certificates
 [nodePort]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
-[nodes types]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-node.html
+[nodes types]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-node.html
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-[openshift]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/openshift
+[openshift]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/openshift
 [priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 [probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-[roles]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-node.html
+[roles]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-node.html
 [secret]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets
 [securityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 [service types]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [snapshot lifecycle management]: https://github.com/elastic/elasticsearch/issues/38461
-[snapshot plugin]: https://www.elastic.co/guide/en/elasticsearch/plugins/7.x/repository.html
-[snapshot repository]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-snapshots.html
-[supported configurations]: https://github.com/elastic/helm-charts/tree/7.x/README.md#supported-configurations
-[sysctl vm.max_map_count]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/vm-max-map-count.html#vm-max-map-count
+[snapshot plugin]: https://www.elastic.co/guide/en/elasticsearch/plugins/7.9/repository.html
+[snapshot repository]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-snapshots.html
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.9/README.md#supported-configurations
+[sysctl vm.max_map_count]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/vm-max-map-count.html#vm-max-map-count
 [terminationGracePeriod]: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 [tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-[transport port configuration]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_transport_settings
+[transport port configuration]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/modules-transport.html#_transport_settings
 [updateStrategy]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
-[values.yaml]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/values.yaml
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/values.yaml
 [volumeClaimTemplate for statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-storage

--- a/elasticsearch/examples/config/README.md
+++ b/elasticsearch/examples/config/README.md
@@ -23,5 +23,5 @@ custom [values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/config/test/goss.yaml
-[values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/config/values.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/config/test/goss.yaml
+[values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/config/values.yaml

--- a/elasticsearch/examples/default/README.md
+++ b/elasticsearch/examples/default/README.md
@@ -21,5 +21,5 @@ This example deploy a 3 nodes Elasticsearch 7.9.0-SNAPSHOT cluster using
 You can also run [goss integration tests][] using `make test`
 
 
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/default/test/goss.yaml
-[default values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/values.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/default/test/goss.yaml
+[default values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/values.yaml

--- a/elasticsearch/examples/docker-for-mac/README.md
+++ b/elasticsearch/examples/docker-for-mac/README.md
@@ -19,5 +19,5 @@ for production.
   ```
 
 
-[custom values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/docker-for-mac/values.yaml
+[custom values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/docker-for-mac/values.yaml
 [docker for mac]: https://docs.docker.com/docker-for-mac/kubernetes/

--- a/elasticsearch/examples/kubernetes-kind/README.md
+++ b/elasticsearch/examples/kubernetes-kind/README.md
@@ -28,9 +28,9 @@ Elasticsearch volumes (see [Makefile][] instructions).
   ```
 
 
-[custom values]: https://github.com/elastic/helm-charts/blob/7.x/elasticsearch/examples/kubernetes-kind/values.yaml
+[custom values]: https://github.com/elastic/helm-charts/blob/7.9/elasticsearch/examples/kubernetes-kind/values.yaml
 [kind]: https://kind.sigs.k8s.io/
 [kind issue]: https://github.com/kubernetes-sigs/kind/issues/830
 [kubernetes-sigs/kind#1157]: https://github.com/kubernetes-sigs/kind/pull/1157
 [rancher local path provisioner]: https://github.com/rancher/local-path-provisioner
-[Makefile]: https://github.com/elastic/helm-charts/blob/7.x/elasticsearch/examples/kubernetes-kind/Makefile#L5
+[Makefile]: https://github.com/elastic/helm-charts/blob/7.9/elasticsearch/examples/kubernetes-kind/Makefile#L5

--- a/elasticsearch/examples/microk8s/README.md
+++ b/elasticsearch/examples/microk8s/README.md
@@ -28,5 +28,5 @@ The following MicroK8S [addons][] need to be enabled:
 
 
 [addons]: https://microk8s.io/docs/addons
-[custom values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/microk8s/values.yaml
+[custom values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/microk8s/values.yaml
 [MicroK8S]: https://microk8s.io

--- a/elasticsearch/examples/migration/README.md
+++ b/elasticsearch/examples/migration/README.md
@@ -160,8 +160,8 @@ client nodes:
 working correctly you can cleanup leftover resources from your old cluster.
 
 [basic license]: https://www.elastic.co/subscriptions
-[data.yml]: https://github.com/elastic/helm-charts/blob/7.x/elasticsearch/examples/migration/data.yml
+[data.yml]: https://github.com/elastic/helm-charts/blob/7.9/elasticsearch/examples/migration/data.yml
 [helm/charts]: https://github.com/helm/charts/tree/master/stable/elasticsearch
-[master.yml]: https://github.com/elastic/helm-charts/blob/7.x/elasticsearch/examples/migration/master.yml
+[master.yml]: https://github.com/elastic/helm-charts/blob/7.9/elasticsearch/examples/migration/master.yml
 [restoring to a different cluster guide]: https://www.elastic.co/guide/en/elasticsearch/reference/6.6/modules-snapshots.html#_restoring_to_a_different_cluster
 [rolling upgrades guide]: https://www.elastic.co/guide/en/elasticsearch/reference/6.6/rolling-upgrades.html

--- a/elasticsearch/examples/minikube/README.md
+++ b/elasticsearch/examples/minikube/README.md
@@ -34,5 +34,5 @@ minikube addons enable storage-provisioner
   ```
 
 
-[custom values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/minikube/values.yaml
+[custom values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/minikube/values.yaml
 [minikube]: https://minikube.sigs.k8s.io/docs/

--- a/elasticsearch/examples/multi/README.md
+++ b/elasticsearch/examples/multi/README.md
@@ -22,6 +22,6 @@ releases:
 You can also run [goss integration tests][] using `make test`
 
 
-[data values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/multi/data.yml
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/multi/test/goss.yaml
-[master values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/multi/master.yml
+[data values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/multi/data.yml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/multi/test/goss.yaml
+[master values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/multi/master.yml

--- a/elasticsearch/examples/openshift/README.md
+++ b/elasticsearch/examples/openshift/README.md
@@ -19,6 +19,6 @@ using [custom values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[custom values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/openshift/values.yaml
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/openshift/test/goss.yaml
+[custom values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/openshift/values.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/openshift/test/goss.yaml
 [openshift]: https://www.openshift.com/

--- a/elasticsearch/examples/oss/README.md
+++ b/elasticsearch/examples/oss/README.md
@@ -20,4 +20,4 @@ You can also run [goss integration tests][] using `make test`
 
 
 [elasticsearch oss]: https://www.elastic.co/downloads/elasticsearch-oss
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/oss/test/goss.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/oss/test/goss.yaml

--- a/elasticsearch/examples/security/README.md
+++ b/elasticsearch/examples/security/README.md
@@ -24,6 +24,6 @@ deployment you should generate SSL certificates following the [official docs][].
 You can also run [goss integration tests][] using `make test`
 
 
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security/test/goss.yaml
-[official docs]: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/configuring-tls.html#node-certificates
-[values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security/security.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security/test/goss.yaml
+[official docs]: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/configuring-tls.html#node-certificates
+[values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security/security.yaml

--- a/elasticsearch/examples/upgrade/README.md
+++ b/elasticsearch/examples/upgrade/README.md
@@ -23,5 +23,5 @@ You can also run [goss integration tests][] using `make test`.
 
 [7.0.0-alpha1]: https://github.com/elastic/helm-charts/releases/tag/7.0.0-alpha1
 [7.4.0]: https://github.com/elastic/helm-charts/releases/tag/7.4.0
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/upgrade/test/goss.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/upgrade/test/goss.yaml
 [jq]: https://stedolan.github.io/jq/

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -214,7 +214,7 @@ readinessProbe:
   successThreshold: 3
   timeoutSeconds: 5
 
-# https://www.elastic.co/guide/en/elasticsearch/reference/7.x/cluster-health.html#request-params wait_for_status
+# https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster-health.html#request-params wait_for_status
 clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
 
 ## Use an alternate scheduler.

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -3,7 +3,7 @@
 This Helm chart is a lightweight way to configure and run our official
 [Filebeat Docker image][].
 
-**Warning**: This branch is used for development, please use [7.7.1][] release
+**Warning**: This branch is used for development, please use [7.8.1][] release
 for released version.
 
 
@@ -47,7 +47,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install the latest 7.7 release:
+* Install the latest 7.8 release:
 `helm install --name filebeat elastic/filebeat`
 
 ### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
@@ -182,7 +182,7 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/filebeat/README.md
+[7.8.1]: https://github.com/elastic/helm-charts/blob/7.8.1/filebeat/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -14,7 +14,7 @@ for released version.
 - [Requirements](#requirements)
 - [Installing](#installing)
   - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using 7.x branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-7x-branch-and-790-snapshot-versions)
+  - [Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-79-branch-and-790-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
@@ -50,7 +50,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Install the latest 7.7 release:
 `helm install --name filebeat elastic/filebeat`
 
-### Install development version using 7.x branch and 7.9.0-SNAPSHOT versions
+### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
@@ -188,21 +188,21 @@ about our development and testing process.
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-[default Filebeat Helm chart]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/README.md#default
+[default Filebeat Helm chart]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/README.md#default
 [environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 [environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
-[examples]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples
-[examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples/oss
-[examples/security]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples/security
-[filebeat docker image]: https://www.elastic.co/guide/en/beats/filebeat/7.x/running-on-docker.html
+[examples]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples/oss
+[examples/security]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples/security
+[filebeat docker image]: https://www.elastic.co/guide/en/beats/filebeat/7.9/running-on-docker.html
 [filebeat oss docker image]: https://www.docker.elastic.co/r/beats/filebeat-oss
-[filebeat outputs]: https://www.elastic.co/guide/en/beats/filebeat/7.x/configuring-output.html
+[filebeat outputs]: https://www.elastic.co/guide/en/beats/filebeat/7.9/configuring-output.html
 [helm]: https://helm.sh
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
-[kafka output]: https://www.elastic.co/guide/en/beats/filebeat/7.x/kafka-output.html
+[kafka output]: https://www.elastic.co/guide/en/beats/filebeat/7.9/kafka-output.html
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -210,8 +210,8 @@ about our development and testing process.
 [priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 [probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-[supported configurations]: https://github.com/elastic/helm-charts/tree/7.x/README.md#supported-configurations
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.9/README.md#supported-configurations
 [serviceAccount]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 [tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 [updateStrategy]: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
-[values.yaml]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/values.yaml
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/values.yaml

--- a/filebeat/examples/default/README.md
+++ b/filebeat/examples/default/README.md
@@ -22,6 +22,6 @@ This example deploy Filebeat 7.9.0-SNAPSHOT using [default values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/default/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples/default/test/goss.yaml
-[default values]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/default/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples/default/test/goss.yaml
+[default values]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/values.yaml

--- a/filebeat/examples/oss/README.md
+++ b/filebeat/examples/oss/README.md
@@ -23,5 +23,5 @@ You can also run [goss integration tests][] using `make test`
 
 
 [filebeat oss]: https://www.elastic.co/downloads/beats/filebeat-oss
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/oss/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples/oss/test/goss.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/oss/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples/oss/test/goss.yaml

--- a/filebeat/examples/security/README.md
+++ b/filebeat/examples/security/README.md
@@ -23,6 +23,6 @@ Elasticsearch (see [values][]).
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples/security/test/goss.yaml
-[values]: https://github.com/elastic/helm-charts/tree/7.x/filebeat/examples/security/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples/security/test/goss.yaml
+[values]: https://github.com/elastic/helm-charts/tree/7.9/filebeat/examples/security/values.yaml

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -159,7 +159,7 @@ spec:
           mountPath: /var/log
           readOnly: true
         # Necessary when using autodiscovery; avoid mounting it otherwise
-        # See: https://www.elastic.co/guide/en/beats/filebeat/7.x/configuration-autodiscover.html
+        # See: https://www.elastic.co/guide/en/beats/filebeat/7.9/configuration-autodiscover.html
         - name: varrundockersock
           mountPath: /var/run/docker.sock
           readOnly: true

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -14,7 +14,7 @@ for released version.
 - [Requirements](#requirements)
 - [Installing](#installing)
   - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using 7.x branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-7x-branch-and-790-snapshot-versions)
+  - [Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-79-branch-and-790-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
@@ -51,7 +51,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Install the latest 7.7 release:
 `helm install --name kibana elastic/kibana`
 
-### Install development version using 7.x branch and 7.9.0-SNAPSHOT versions
+### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
@@ -206,34 +206,34 @@ about our development and testing process.
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#default
+[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#default
 [environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 [environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
-[examples]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples
-[examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/oss
-[examples/security]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/security
+[examples]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/oss
+[examples/security]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[kibana docker image]: https://www.elastic.co/guide/en/kibana/7.x/docker.html
+[kibana docker image]: https://www.elastic.co/guide/en/kibana/7.9/docker.html
 [kibana oss docker image]: https://www.docker.elastic.co/r/kibana/kibana-oss
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [lifecycle hooks]: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-[openshift]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/openshift
+[openshift]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/openshift
 [priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 [probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-[security enabled elasticsearch cluster]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#security
+[security enabled elasticsearch cluster]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#security
 [securityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-[server.host]: https://www.elastic.co/guide/en/kibana/7.x/settings.html
+[server.host]: https://www.elastic.co/guide/en/kibana/7.9/settings.html
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [serviceAccount]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-[standard upgrade]: https://www.elastic.co/guide/en/kibana/7.x/upgrade-standard.html
-[supported configurations]: https://github.com/elastic/helm-charts/tree/7.x/README.md#supported-configurations
+[standard upgrade]: https://www.elastic.co/guide/en/kibana/7.9/upgrade-standard.html
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.9/README.md#supported-configurations
 [tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 [updateStrategy]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment
-[values.yaml]: https://github.com/elastic/helm-charts/tree/7.x/kibana/values.yaml
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.9/kibana/values.yaml

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -3,7 +3,7 @@
 This Helm chart is a lightweight way to configure and run our official
 [Kibana Docker image][].
 
-**Warning**: This branch is used for development, please use [7.7.1][] release
+**Warning**: This branch is used for development, please use [7.8.1][] release
 for released version.
 
 
@@ -48,7 +48,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install the latest 7.7 release:
+* Install the latest 7.8 release:
 `helm install --name kibana elastic/kibana`
 
 ### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
@@ -200,7 +200,7 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/kibana/README.md
+[7.8.1]: https://github.com/elastic/helm-charts/blob/7.8.1/kibana/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/kibana/examples/default/README.md
+++ b/kibana/examples/default/README.md
@@ -22,6 +22,6 @@ This example deploy Kibana 7.9.0-SNAPSHOT using [default values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/default/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/default/test/goss.yaml
-[default values]: https://github.com/elastic/helm-charts/tree/7.x/kibana/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/default/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/default/test/goss.yaml
+[default values]: https://github.com/elastic/helm-charts/tree/7.9/kibana/values.yaml

--- a/kibana/examples/openshift/README.md
+++ b/kibana/examples/openshift/README.md
@@ -20,7 +20,7 @@ This example deploy Kibana 7.9.0-SNAPSHOT on [OpenShift][] using [custom values]
 You can also run [goss integration tests][] using `make test`
 
 
-[custom values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/openshift/values.yaml
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/openshift/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/openshift/test/goss.yaml
+[custom values]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/openshift/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/openshift/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/openshift/test/goss.yaml
 [openshift]: https://www.openshift.com/

--- a/kibana/examples/oss/README.md
+++ b/kibana/examples/oss/README.md
@@ -23,5 +23,5 @@ You can also run [goss integration tests][] using `make test`
 
 
 [kibana oss]: https://www.elastic.co/downloads/kibana-oss
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/oss/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/oss/test/goss.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/oss/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/oss/test/goss.yaml

--- a/kibana/examples/security/README.md
+++ b/kibana/examples/security/README.md
@@ -23,6 +23,6 @@ Elasticsearch (see [values][]).
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/security/test/goss.yaml
-[values]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/security/security.yml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/security/test/goss.yaml
+[values]: https://github.com/elastic/helm-charts/tree/7.9/kibana/examples/security/security.yml

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -19,7 +19,7 @@ for released version.
 - [Requirements](#requirements)
 - [Installing](#installing)
   - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using 7.x branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-7x-branch-and-790-snapshot-versions)
+  - [Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-79-branch-and-790-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
@@ -53,7 +53,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Install the latest 7.7 release:
 `helm install --name logstash elastic/logstash`
 
-### Install development version using 7.x branch and 7.9.0-SNAPSHOT versions
+### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
@@ -193,30 +193,30 @@ about our development and testing process.
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [anti-affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 [deploys statefulsets serially]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
-[custom docker image]: https://www.elastic.co/guide/en/logstash/7.x/docker-config.html#_custom_images
+[custom docker image]: https://www.elastic.co/guide/en/logstash/7.9/docker-config.html#_custom_images
 [environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 [environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
-[examples]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples
-[examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples/oss
+[examples]: https://github.com/elastic/helm-charts/tree/7.9/logstash/examples
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.9/logstash/examples/oss
 [helm]: https://helm.sh
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-[logstash docker image]: https://www.elastic.co/guide/en/logstash/7.x/docker.html
+[logstash docker image]: https://www.elastic.co/guide/en/logstash/7.9/docker.html
 [logstash oss docker image]: https://www.docker.elastic.co/r/logstash/logstash-oss
 [maxUnavailable]: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
 [node affinity settings]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-[note]: https://www.elastic.co/guide/en/logstash/7.x/docker-config.html#docker-env-config
+[note]: https://www.elastic.co/guide/en/logstash/7.9/docker-config.html#docker-env-config
 [priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 [probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 [updateStrategy]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [securityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
-[supported configurations]: https://github.com/elastic/helm-charts/tree/7.x/README.md#supported-configurations
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.9/README.md#supported-configurations
 [terminationGracePeriod]: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 [tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-[values.yaml]: https://github.com/elastic/helm-charts/tree/7.x/logstash/values.yaml
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.9/logstash/values.yaml
 [volumeClaimTemplate for statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-storage

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -8,7 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Alpha features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [7.7.1][] release
+**Warning**: This branch is used for development, please use [7.8.1][] release
 for released version.
 
 
@@ -50,7 +50,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install the latest 7.7 release:
+* Install the latest 7.8 release:
 `helm install --name logstash elastic/logstash`
 
 ### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
@@ -185,7 +185,7 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/logstash/README.md
+[7.8.1]: https://github.com/elastic/helm-charts/blob/7.8.1/logstash/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/logstash/examples/default/README.md
+++ b/logstash/examples/default/README.md
@@ -13,5 +13,5 @@ This example deploy Logstash 7.9.0-SNAPSHOT using [default values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples/default/test/goss.yaml
-[default values]: https://github.com/elastic/helm-charts/tree/7.x/logstash/values.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/logstash/examples/default/test/goss.yaml
+[default values]: https://github.com/elastic/helm-charts/tree/7.9/logstash/values.yaml

--- a/logstash/examples/elasticsearch/README.md
+++ b/logstash/examples/elasticsearch/README.md
@@ -23,6 +23,6 @@ This example deploy Logstash 7.9.0-SNAPSHOT which connects to Elasticsearch (see
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/default/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples/elasticsearch/test/goss.yaml
-[values]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples/elasticsearch/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/default/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/logstash/examples/elasticsearch/test/goss.yaml
+[values]: https://github.com/elastic/helm-charts/tree/7.9/logstash/examples/elasticsearch/values.yaml

--- a/logstash/examples/oss/README.md
+++ b/logstash/examples/oss/README.md
@@ -14,4 +14,4 @@ You can also run [goss integration tests][] using `make test`
 
 
 [logstash oss]: https://www.elastic.co/downloads/logstash-oss
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples/oss/test/goss.yaml
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/logstash/examples/oss/test/goss.yaml

--- a/logstash/examples/security/README.md
+++ b/logstash/examples/security/README.md
@@ -1,6 +1,6 @@
 # Security
 
-This example deploy Logstash 7.7.1 which connects to Elasticsearch using TLS
+This example deploy Logstash 7.9.0-SNAPSHOT which connects to Elasticsearch using TLS
 (see [values][]).
 
 

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -3,7 +3,7 @@
 This Helm chart is a lightweight way to configure and run our official
 [Metricbeat Docker image][].
 
-**Warning**: This branch is used for development, please use [7.7.1][] release
+**Warning**: This branch is used for development, please use [7.8.1][] release
 for released version.
 
 
@@ -47,7 +47,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install the latest 7.7 release:
+* Install the latest 7.8 release:
 `helm install --name metricbeat elastic/metricbeat`
 
 ### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
@@ -205,7 +205,7 @@ about our development and testing process.
 
 
 [#471]: https://github.com/elastic/helm-charts/pull/471
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/metricbeat/README.md
+[7.8.1]: https://github.com/elastic/helm-charts/blob/7.8.1/metricbeat/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -14,7 +14,7 @@ for released version.
 - [Requirements](#requirements)
 - [Installing](#installing)
   - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using 7.x branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-7x-branch-and-790-snapshot-versions)
+  - [Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions](#install-development-version-using-79-branch-and-790-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
@@ -50,7 +50,7 @@ This chart is tested with the latest 7.9.0-SNAPSHOT versions.
 * Install the latest 7.7 release:
 `helm install --name metricbeat elastic/metricbeat`
 
-### Install development version using 7.x branch and 7.9.0-SNAPSHOT versions
+### Install development version using 7.9 branch and 7.9.0-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
@@ -211,22 +211,22 @@ about our development and testing process.
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#default
+[default elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/README.md#default
 [cluster role rules]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
 [environment variables]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 [environment from variables]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
-[examples]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples
-[examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/oss
-[examples/security]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/security
+[examples]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples
+[examples/oss]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples/oss
+[examples/security]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples/security
 [helm]: https://helm.sh
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
-[kube-state-metrics]: https://github.com/helm/charts/tree/7.x/stable/kube-state-metrics
+[kube-state-metrics]: https://github.com/helm/charts/tree/7.9/stable/kube-state-metrics
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-[metricbeat docker image]: https://www.elastic.co/guide/en/beats/metricbeat/7.x/running-on-docker.html
+[metricbeat docker image]: https://www.elastic.co/guide/en/beats/metricbeat/7.9/running-on-docker.html
 [metricbeat oss docker image]: https://www.docker.elastic.co/r/beats/metricbeat-oss
 [priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -234,7 +234,7 @@ about our development and testing process.
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 [securityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 [serviceAccount]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-[supported configurations]: https://github.com/elastic/helm-charts/tree/7.x/README.md#supported-configurations
+[supported configurations]: https://github.com/elastic/helm-charts/tree/7.9/README.md#supported-configurations
 [tolerations]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 [updateStrategy]: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
-[values.yaml]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/values.yaml
+[values.yaml]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/values.yaml

--- a/metricbeat/examples/default/README.md
+++ b/metricbeat/examples/default/README.md
@@ -22,6 +22,6 @@ This example deploy Metricbeat 7.9.0-SNAPSHOT using [default values][].
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/default/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/default/test/goss.yaml
-[default values]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/default/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples/default/test/goss.yaml
+[default values]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/values.yaml

--- a/metricbeat/examples/oss/README.md
+++ b/metricbeat/examples/oss/README.md
@@ -23,5 +23,5 @@ You can also run [goss integration tests][] using `make test`
 
 
 [metricbeat oss]: https://www.elastic.co/downloads/beats/metricbeat-oss
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/oss/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/oss/test/goss.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/oss/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples/oss/test/goss.yaml

--- a/metricbeat/examples/security/README.md
+++ b/metricbeat/examples/security/README.md
@@ -23,6 +23,6 @@ Elasticsearch (see [values][]).
 You can also run [goss integration tests][] using `make test`
 
 
-[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security/
-[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/security/test/goss.yaml
-[values]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/security/values.yaml
+[elasticsearch helm chart]: https://github.com/elastic/helm-charts/tree/7.9/elasticsearch/examples/security/
+[goss integration tests]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples/security/test/goss.yaml
+[values]: https://github.com/elastic/helm-charts/tree/7.9/metricbeat/examples/security/values.yaml

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -150,7 +150,7 @@ spec:
         - name: data
           mountPath: /usr/share/metricbeat/data
         # Necessary when using autodiscovery; avoid mounting it otherwise
-        # See: https://www.elastic.co/guide/en/beats/metricbeat/7.x/configuration-autodiscover.html
+        # See: https://www.elastic.co/guide/en/beats/metricbeat/7.9/configuration-autodiscover.html
         - name: varrundockersock
           mountPath: /var/run/docker.sock
           readOnly: true


### PR DESCRIPTION
This commit initiates the 7.9 branch which will be dedicated to the 7.9.x releases for the Helm Charts. 

It will allow to:
- test this branch with the daily Stack Docker images 7.9.0-SNAPSHOT via dedicated Jenkins jobs
- test the staging 7.9.x Docker images before a release

This branch is based on 7.x which was initiated in #605.