### PR TITLE
[meta] add helm 3 beta support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   - [Support Matrix](#support-matrix)
   - [Kubernetes Versions](#kubernetes-versions)
   - [Helm versions](#helm-versions)
-    - [Helm 3 preview](#helm-3-preview)
+    - [Helm 3 beta](#helm-3-beta)
 - [ECK](#eck)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -78,11 +78,11 @@ exact versions are defined under `KUBERNETES_VERSIONS` in
 While we are checking backward compatibility, the charts are only tested with
 Helm version mentioned in [helm-tester Dockerfile][] (currently 2.16.9).
 
-#### Helm 3 preview
+#### Helm 3 beta
 
 While we don't have automated tests for [Helm 3][] yet, we fixed the main
 blockers to use it. We now have enough feedbacks from internal and external
-users to add support it in preview.
+users to add support in beta.
 
 ## ECK
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ added below.
 
 We recommend that the Helm chart version is aligned to the version of the product
 you want to deploy. This will ensure that you using a chart version that has been
-tested against the corresponding production version.  
-This will also ensure that the documentation and examples for the chart will work 
+tested against the corresponding production version.
+This will also ensure that the documentation and examples for the chart will work
 with the version of the product you are installing.
 
 For example if you want to deploy an Elasticsearch `7.7.1` cluster, use the
@@ -76,7 +76,12 @@ exact versions are defined under `KUBERNETES_VERSIONS` in
 
 While we are checking backward compatibility, the charts are only tested with
 Helm version mentioned in [helm-tester Dockerfile][] (currently 2.16.9).
-Note that we don't support [Helm 3][] version.
+
+#### Helm 3 preview
+
+While we don't have automated tests for [Helm 3][] yet, we fixed the main
+blockers to use it. We now have enough feedbacks from internal and external
+users to add support it in preview.
 
 ## ECK
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Support Matrix](#support-matrix)
   - [Kubernetes Versions](#kubernetes-versions)
   - [Helm versions](#helm-versions)
+    - [Helm 3 preview](#helm-3-preview)
 - [ECK](#eck)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -49,7 +49,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name apm-server elastic/apm-server`
-  - with [Helm 3 (preview)][]: `helm install apm-server elastic/apm-server`
+  - with [Helm 3 (beta)][]: `helm install apm-server elastic/apm-server`
 
 
 ### Install development version using master branch
@@ -58,7 +58,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name apm-server ./helm-charts/apm-server  --set imageTag=8.0.0-SNAPSHOT`
-  - with [Helm 3 (preview)][]: `helm install apm-server ./helm-charts/apm-server  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (beta)][]: `helm install apm-server ./helm-charts/apm-server  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -160,7 +160,7 @@ about our development and testing process.
 [examples/oss]: https://github.com/elastic/helm-charts/tree/master/apm-server/examples/oss
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/apm-server/examples/security
 [helm]: https://helm.sh
-[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
+[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [horizontal pod autoscaler]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -47,13 +47,18 @@ See [supported configurations][] for more details.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install it: `helm install --name apm-server elastic/apm-server`
+* Install it:
+  - with Helm 2: `helm install --name apm-server elastic/apm-server`
+  - with [Helm 3 (preview)][]: `helm install apm-server elastic/apm-server`
+
 
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it: `helm install --name apm-server ./helm-charts/apm-server  --set imageTag=8.0.0-SNAPSHOT`
+* Install it:
+  - with Helm 2: `helm install --name apm-server ./helm-charts/apm-server  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (preview)][]: `helm install apm-server ./helm-charts/apm-server  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -155,6 +160,7 @@ about our development and testing process.
 [examples/oss]: https://github.com/elastic/helm-charts/tree/master/apm-server/examples/oss
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/apm-server/examples/security
 [helm]: https://helm.sh
+[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
 [horizontal pod autoscaler]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -60,7 +60,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name elasticsearch elastic/elasticsearch`
-  - with [Helm 3 (preview)][]: `helm install elasticsearch elastic/elasticsearch`
+  - with [Helm 3 (beta)][]: `helm install elasticsearch elastic/elasticsearch`
 
 
 ### Install development version using master branch
@@ -69,7 +69,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name elasticsearch ./helm-charts/elasticsearch  --set imageTag=8.0.0-SNAPSHOT`
-  - with [Helm 3 (preview)][]: `helm install elasticsearch ./helm-charts/elasticsearch  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (beta)][]: `helm install elasticsearch ./helm-charts/elasticsearch  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -413,7 +413,7 @@ about our development and testing process.
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
-[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
+[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [helm/charts stable]: https://github.com/helm/charts/tree/master/stable/elasticsearch/
 [how to install plugins guide]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/README.md#how-to-install-plugins
 [how to use the keystore]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/README.md#how-to-use-the-keystore

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -58,13 +58,18 @@ See [supported configurations][] for more details.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install it: `helm install --name elasticsearch elastic/elasticsearch`
+* Install it:
+  - with Helm 2: `helm install --name elasticsearch elastic/elasticsearch`
+  - with [Helm 3 (preview)][]: `helm install elasticsearch elastic/elasticsearch`
+
 
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it: `helm install --name elasticsearch ./helm-charts/elasticsearch  --set imageTag=8.0.0-SNAPSHOT`
+* Install it:
+  - with Helm 2: `helm install --name elasticsearch ./helm-charts/elasticsearch  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (preview)][]: `helm install elasticsearch ./helm-charts/elasticsearch  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -408,6 +413,7 @@ about our development and testing process.
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
+[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
 [helm/charts stable]: https://github.com/helm/charts/tree/master/stable/elasticsearch/
 [how to install plugins guide]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/README.md#how-to-install-plugins
 [how to use the keystore]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/README.md#how-to-use-the-keystore

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -44,13 +44,18 @@ See [supported configurations][] for more details.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install it: `helm install --name filebeat elastic/filebeat`
+* Install it:
+  - with Helm 2: `helm install --name filebeat elastic/filebeat`
+  - with [Helm 3 (preview)][]: `helm install filebeat elastic/filebeat`
+
 
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it: `helm install --name filebeat ./helm-charts/filebeat  --set imageTag=8.0.0-SNAPSHOT`
+* Install it:
+  - with Helm 2: `helm install --name filebeat ./helm-charts/filebeat  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (preview)][]: `helm install filebeat ./helm-charts/filebeat  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -194,6 +199,7 @@ about our development and testing process.
 [filebeat oss docker image]: https://www.docker.elastic.co/r/beats/filebeat-oss
 [filebeat outputs]: https://www.elastic.co/guide/en/beats/filebeat/master/configuring-output.html
 [helm]: https://helm.sh
+[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -46,7 +46,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name filebeat elastic/filebeat`
-  - with [Helm 3 (preview)][]: `helm install filebeat elastic/filebeat`
+  - with [Helm 3 (beta)][]: `helm install filebeat elastic/filebeat`
 
 
 ### Install development version using master branch
@@ -55,7 +55,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name filebeat ./helm-charts/filebeat  --set imageTag=8.0.0-SNAPSHOT`
-  - with [Helm 3 (preview)][]: `helm install filebeat ./helm-charts/filebeat  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (beta)][]: `helm install filebeat ./helm-charts/filebeat  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -199,7 +199,7 @@ about our development and testing process.
 [filebeat oss docker image]: https://www.docker.elastic.co/r/beats/filebeat-oss
 [filebeat outputs]: https://www.elastic.co/guide/en/beats/filebeat/master/configuring-output.html
 [helm]: https://helm.sh
-[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
+[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -48,7 +48,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name kibana elastic/kibana`
-  - with [Helm 3 (preview)][]: `helm install kibana elastic/kibana`
+  - with [Helm 3 (beta)][]: `helm install kibana elastic/kibana`
 
 
 ### Install development version using master branch
@@ -57,7 +57,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name kibana ./helm-charts/kibana  --set imageTag=8.0.0-SNAPSHOT`
-  - with [Helm 3 (preview)][]: `helm install kibana ./helm-charts/kibana  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (beta)][]: `helm install kibana ./helm-charts/kibana  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -216,7 +216,7 @@ about our development and testing process.
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/kibana/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
-[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
+[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -46,13 +46,18 @@ See [supported configurations][] for more details.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install it: `helm install --name kibana elastic/kibana`
+* Install it:
+  - with Helm 2: `helm install --name kibana elastic/kibana`
+  - with [Helm 3 (preview)][]: `helm install kibana elastic/kibana`
+
 
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it: `helm install --name kibana ./helm-charts/kibana  --set imageTag=8.0.0-SNAPSHOT`
+* Install it:
+  - with Helm 2: `helm install --name kibana ./helm-charts/kibana  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (preview)][]: `helm install kibana ./helm-charts/kibana  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -211,6 +216,7 @@ about our development and testing process.
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/kibana/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
+[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -46,13 +46,18 @@ See [supported configurations][] for more details.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install it: `helm install --name logstash elastic/logstash`
+* Install it:
+  - with Helm 2: `helm install --name logstash elastic/logstash`
+  - with [Helm 3 (preview)][]: `helm install logstash elastic/logstash`
+
 
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it: `helm install --name logstash ./helm-charts/logstash  --set imageTag=8.0.0-SNAPSHOT`
+* Install it:
+  - with Helm 2: `helm install --name logstash ./helm-charts/logstash  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (preview)][]: `helm install logstash ./helm-charts/logstash  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -194,6 +199,7 @@ about our development and testing process.
 [examples]: https://github.com/elastic/helm-charts/tree/master/logstash/examples
 [examples/oss]: https://github.com/elastic/helm-charts/tree/master/logstash/examples/oss
 [helm]: https://helm.sh
+[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -48,7 +48,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name logstash elastic/logstash`
-  - with [Helm 3 (preview)][]: `helm install logstash elastic/logstash`
+  - with [Helm 3 (beta)][]: `helm install logstash elastic/logstash`
 
 
 ### Install development version using master branch
@@ -57,7 +57,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name logstash ./helm-charts/logstash  --set imageTag=8.0.0-SNAPSHOT`
-  - with [Helm 3 (preview)][]: `helm install logstash ./helm-charts/logstash  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (beta)][]: `helm install logstash ./helm-charts/logstash  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -199,7 +199,7 @@ about our development and testing process.
 [examples]: https://github.com/elastic/helm-charts/tree/master/logstash/examples
 [examples/oss]: https://github.com/elastic/helm-charts/tree/master/logstash/examples/oss
 [helm]: https://helm.sh
-[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
+[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -45,13 +45,18 @@ See [supported configurations][] for more details.
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
-* Install it: `helm install --name metricbeat elastic/metricbeat`
+* Install it:
+  - with Helm 2: `helm install --name metricbeat elastic/metricbeat`
+  - with [Helm 3 (preview)][]: `helm install metricbeat elastic/metricbeat`
+
 
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it: `helm install --name metricbeat ./helm-charts/metricbeat  --set imageTag=8.0.0-SNAPSHOT`
+* Install it:
+  - with Helm 2: `helm install --name metricbeat ./helm-charts/metricbeat  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (preview)][]: `helm install metricbeat ./helm-charts/metricbeat  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -216,6 +221,7 @@ about our development and testing process.
 [examples/oss]: https://github.com/elastic/helm-charts/tree/master/metricbeat/examples/oss
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/metricbeat/examples/security
 [helm]: https://helm.sh
+[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -47,7 +47,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name metricbeat elastic/metricbeat`
-  - with [Helm 3 (preview)][]: `helm install metricbeat elastic/metricbeat`
+  - with [Helm 3 (beta)][]: `helm install metricbeat elastic/metricbeat`
 
 
 ### Install development version using master branch
@@ -56,7 +56,7 @@ See [supported configurations][] for more details.
 
 * Install it:
   - with Helm 2: `helm install --name metricbeat ./helm-charts/metricbeat  --set imageTag=8.0.0-SNAPSHOT`
-  - with [Helm 3 (preview)][]: `helm install metricbeat ./helm-charts/metricbeat  --set imageTag=8.0.0-SNAPSHOT`
+  - with [Helm 3 (beta)][]: `helm install metricbeat ./helm-charts/metricbeat  --set imageTag=8.0.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -221,7 +221,7 @@ about our development and testing process.
 [examples/oss]: https://github.com/elastic/helm-charts/tree/master/metricbeat/examples/oss
 [examples/security]: https://github.com/elastic/helm-charts/tree/master/metricbeat/examples/security
 [helm]: https://helm.sh
-[helm 3 (preview)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-preview
+[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images


### PR DESCRIPTION
This PR add Helm 3 support in preview as the main blockers were fixed in previous PR.

Note that adding automated tests with Helm 3 is still required to add full Helm 3 support.

This PR should be backported to `6.8`, `7.x` and `7.9` branches.