### PR TITLE
[meta] add slack notifications to CI jobs

### DIFF
--- a/.ci/jobs.t/elastic+helm-charts+{branch}+staging.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}+staging.yml
@@ -44,3 +44,10 @@
       - project: elastic+helm-charts+%BRANCH%+staging+cluster-cleanup
         current-parameters: true
         trigger-with-no-params: false
+    - slack:
+        notify-back-to-normal: True
+        notify-every-failure: True
+        room: infra-release-notify
+        team-domain: elastic
+        auth-token-id: release-slack-integration-token
+        auth-token-credential-id: release-slack-integration-token

--- a/.ci/jobs.t/elastic+helm-charts+{branch}.yml
+++ b/.ci/jobs.t/elastic+helm-charts+{branch}.yml
@@ -46,3 +46,10 @@
       - project: elastic+helm-charts+%BRANCH%+cluster-cleanup
         current-parameters: false
         trigger-with-no-params: true
+    - slack:
+        notify-back-to-normal: True
+        notify-every-failure: True
+        room: infra-release-notify
+        team-domain: elastic
+        auth-token-id: release-slack-integration-token
+        auth-token-credential-id: release-slack-integration-token


### PR DESCRIPTION
This commit add Slack notifications to Elastic Release team Slack channel for helm-charts branch and staging job templates.

This should be backported to `6.8`, `7.8` and `7.9` release branches