### PR TITLE
[Metricbeat] Dont generate config if not enabled

### DIFF
--- a/metricbeat/templates/configmap.yaml
+++ b/metricbeat/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
 {{- end -}}
 {{- end -}}
 
-{{- if .Values.daemonset.metricbeatConfig }}
+{{- if and .Values.daemonset.enabled .Values.daemonset.metricbeatConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -34,7 +34,7 @@ data:
 {{- end -}}
 {{- end -}}
 
-{{- if .Values.deployment.metricbeatConfig }}
+{{- if and .Values.deployment.enabled .Values.deployment.metricbeatConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -1179,8 +1179,11 @@ daemonset:
     enabled: false
 """
     r = helm_template(config)
+    cfg = r["configmap"]
 
     assert name not in r.get("daemonset", {})
+    assert name + "-daemonset-config" not in cfg
+    assert name + "-deployment-config" in cfg
 
 
 def test_disable_deployment():
@@ -1189,8 +1192,11 @@ deployment:
     enabled: false
 """
     r = helm_template(config)
+    cfg = r["configmap"]
 
     assert name + "-metrics" not in r.get("deployment", {})
+    assert name + "-daemonset-config" in cfg
+    assert name + "-deployment-config" not in cfg
 
 
 def test_do_not_install_kube_stat_metrics():


### PR DESCRIPTION
If for daemonset/deployment is not enabled, dont generate useless config YAML.

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
