### PR TITLE
[metricbeat] Add missing labels for deployment

### DIFF
--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Earlier, `.Values.labels` were propagated for the daemonset only.
https://github.com/elastic/helm-charts/blob/master/metricbeat/templates/daemonset.yaml#L44

This PR will resolve this and add these labels for the deployment too.