### PR TITLE
[metricbeat] Add missing labels for deployment

### DIFF
--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}


### PR DESCRIPTION
Earlier, `.Values.labels` were propagated for the **daemonset** only.
https://github.com/elastic/helm-charts/blob/master/metricbeat/templates/daemonset.yaml#L44

This PR will resolve this and add these labels for the **deployment** too.