### PR TITLE
Fix serviceAccount for APM server

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -33,9 +33,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-      {{- if .Values.serviceAccount }}
-      serviceAccountName: {{ .Values.serviceAccount }}
-      {{- end }}
+      serviceAccountName: {{ template "apm.serviceAccount" . }}
       volumes:
         {{- range .Values.secretMounts }}
         - name: {{ .name }}


### PR DESCRIPTION
Why
----
- In the current Helm chart for `apm-server`, serviceAccount for the
Deployment is only set when `serviceAccount` is set in `values.yaml`.
However, it is wrong. `serviceAccount` should always be set because even
when no `serviceAccount` is set in `values.yaml`, a managed one is still
created.

What
----
- Always set `serviceAccount` for apm-server Deployment to the template
apm.serviceAccount defined in `_helpers.tpl`

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
