### PR TITLE
Empty initContainers, preventing kustomize patches.

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -157,7 +157,9 @@ spec:
       {{- if semverCompare ">1.13" .Capabilities.KubeVersion.GitVersion }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- end }}
+      {{- if or (.Values.extraInitContainers) (.Values.sysctlInitContainer.enabled) (.Values.keystore)  }} 
       initContainers:
+      {{- end }}
       {{- if .Values.sysctlInitContainer.enabled }}
       - name: configure-sysctl
         securityContext:


### PR DESCRIPTION
Modyfied elasticsearch statefulset template, so if none of the initContainers are declared, there will be no **initContainers:** directive.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

### Problem
Unable to patch image names/tags by using [kustomize](https://kustomize.io/), when an empty `initContainers` directive is provided.
Error:
`Error: containers path is not of type []interface{} but <nil>`

### Example with turned off all initContainers in values files.

```yaml
extraInitContainers: []

sysctlInitContainer:
  enabled: false

keystore: []
```
Part of the statefulset
```yaml
      terminationGracePeriodSeconds: 120
      volumes:
      enableServiceLinks: true
      initContainers:

      containers:
      - name: "elasticsearch"
        securityContext:
          capabilities:
            drop:
            - ALL
```
A fast workaround is to add a dummy initContainer.

### What I've done in PR
Add an `{{- if or }}` statement to the `initContainers:` directive that will check if any of them is enabled. 

### Chart version
Elasticsearch chart
elastic/elasticsearch 7.9.0

### Tools versions
Helm version
Client: &version.Version{SemVer:"v2.16.10", GitCommit:"bceca24a91639f045f22ab0f41e47589a932cf5e", GitTreeState:"clean"}

kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}