### PR TITLE
[meta] drop gke 1.14 tests

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -33,6 +33,5 @@ APM_SERVER_SUITE:
   - oss
   - security
 KUBERNETES_VERSION:
-  - '1.14'
   - '1.15'
   - '1.16'


### PR DESCRIPTION
This PR fix CI builds failing because GKE 1.14 is no more available in GCP:

```
08:46:14 Error: Error applying plan:
08:46:14 
08:46:14 1 error(s) occurred:
08:46:14 
08:46:14 * google_container_cluster.cluster: 1 error(s) occurred:
08:46:14 
08:46:14 * google_container_cluster.cluster: googleapi: Error 400: No valid versions with the prefix "1.14" found., badRequest
08:46:14 
08:46:14 Terraform does not automatically rollback in the face of errors.
08:46:14 Instead, your Terraform state file has been partially updated with
08:46:14 any resources that successfully completed. Please address the error
08:46:14 above and apply again to incrementally change your infrastructure.
```

https://devops-ci.elastic.co/job/elastic+helm-charts+6.8+cluster-creation/KUBERNETES_VERSION=1.14,label=docker&&virtual/178/console
