### PR TITLE
[filebeat] variable maxUnavailable updateStrategy

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -106,6 +106,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `daemonset.hostAliases`        | Configurable [hostAliases][] for filebeat DaemonSet                                                                                                                          | `[]`                               |
 | `daemonset.hostNetworking`     | Enable filebeat DaemonSet to use `hostNetwork`                                                                                                                               | `false`                            |
 | `daemonset.filebeatConfig`     | Allows you to add any config files in `/usr/share/filebeat` such as `filebeat.yml` for filebeat DaemonSet                                                                    | see [values.yaml][]                |
+| `daemonset.maxUnavailable`     | The [maxUnavailable][] value for the pod disruption budget. By default this will prevent Kubernetes from having more than 1 unhealthy pod in the node group                  | `1`                                |
 | `daemonset.nodeSelector`       | Configurable [nodeSelector][] for filebeat DaemonSet                                                                                                                         | `{}`                               |
 | `daemonset.secretMounts`       | Allows you easily mount a secret as a file inside the DaemonSet. Useful for mounting certificates and other secrets. See [values.yaml][] for an example                      | `[]`                               |
 | `daemonset.podSecurityContext` | Configurable [podSecurityContext][] for filebeat DaemonSet pod execution environment                                                                                         | see [values.yaml][]                |
@@ -258,6 +259,7 @@ about our development and testing process.
 [kafka output]: https://www.elastic.co/guide/en/beats/filebeat/current/kafka-output.html
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[maxUnavailable]: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 [podSecurityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 [priorityClass]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -29,14 +29,12 @@ spec:
     matchLabels:
       app: "{{ template "filebeat.fullname" . }}"
       release: {{ .Release.Name | quote }}
-  {{- if .Values.updateStrategy }}
   updateStrategy:
     {{- if eq .Values.updateStrategy "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
+      maxUnavailable: {{ .Values.maxUnavailable }}
     {{- end }}
     type: {{ .Values.updateStrategy }}
-  {{- end }}
   template:
     metadata:
       annotations:

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
   updateStrategy:
     {{- if eq .Values.updateStrategy "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.maxUnavailable }}
+      maxUnavailable: {{ .Values.daemonset.maxUnavailable }}
     {{- end }}
     type: {{ .Values.updateStrategy }}
   template:

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -36,6 +36,7 @@ spec:
       maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
     {{- end }}
     type: {{ .Values.updateStrategy }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -29,7 +29,12 @@ spec:
     matchLabels:
       app: "{{ template "filebeat.fullname" . }}"
       release: {{ .Release.Name | quote }}
+  {{- if .Values.updateStrategy }}
   updateStrategy:
+    {{- if eq .Values.updateStrategy "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
+    {{- end }}
     type: {{ .Values.updateStrategy }}
   template:
     metadata:

--- a/filebeat/tests/filebeat_test.py
+++ b/filebeat/tests/filebeat_test.py
@@ -51,7 +51,12 @@ def test_defaults():
 
     assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "RollingUpdate"
 
-    assert r["daemonset"][name]["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"] == 1
+    assert (
+        r["daemonset"][name]["spec"]["updateStrategy"]["rollingUpdate"][
+            "maxUnavailable"
+        ]
+        == 1
+    )
 
     assert (
         r["daemonset"][name]["spec"]["template"]["spec"]["serviceAccountName"] == name
@@ -412,7 +417,12 @@ def test_override_the_default_update_strategy():
 
     r = helm_template(config)
     assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "RollingUpdate"
-    assert r["daemonset"][name]["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"] == 2
+    assert (
+        r["daemonset"][name]["spec"]["updateStrategy"]["rollingUpdate"][
+            "maxUnavailable"
+        ]
+        == 2
+    )
 
     config = """
     updateStrategy: OnDelete

--- a/filebeat/tests/filebeat_test.py
+++ b/filebeat/tests/filebeat_test.py
@@ -51,6 +51,8 @@ def test_defaults():
 
     assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "RollingUpdate"
 
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"] == 1
+
     assert (
         r["daemonset"][name]["spec"]["template"]["spec"]["serviceAccountName"] == name
     )
@@ -404,7 +406,16 @@ tolerations:
 
 def test_override_the_default_update_strategy():
     config = """
-updateStrategy: OnDelete
+    daemonset:
+      maxUnavailable: 2
+"""
+
+    r = helm_template(config)
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["type"] == "RollingUpdate"
+    assert r["daemonset"][name]["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"] == 2
+
+    config = """
+    updateStrategy: OnDelete
 """
 
     r = helm_template(config)

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -208,7 +208,7 @@ priorityClassName: ""
 
 updateStrategy: RollingUpdate
 # Only used when updateStrategy is set to "RollingUpdate"
-MaxUnavalaible: 1
+MaxUnavailable: 1
 
 # Override various naming aspects of this chart
 # Only edit these if you know what you're doing

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -207,6 +207,8 @@ terminationGracePeriod: 30
 priorityClassName: ""
 
 updateStrategy: RollingUpdate
+# Only used when updateStrategy is set to "RollingUpdate"
+MaxUnavalaible: 1
 
 # Override various naming aspects of this chart
 # Only edit these if you know what you're doing

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -40,6 +40,8 @@ daemonset:
       output.elasticsearch:
         host: '${NODE_NAME}'
         hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
+  # Only used when updateStrategy is set to "RollingUpdate"
+  maxUnavailable: 1
   nodeSelector: {}
   # A list of secrets and their paths to mount inside the pod
   # This is useful for mounting certificates for security other sensitive values
@@ -207,8 +209,6 @@ terminationGracePeriod: 30
 priorityClassName: ""
 
 updateStrategy: RollingUpdate
-# Only used when updateStrategy is set to "RollingUpdate"
-MaxUnavailable: 1
 
 # Override various naming aspects of this chart
 # Only edit these if you know what you're doing


### PR DESCRIPTION

# Problem

Unable to set a custom value for the `MaxUnavalaible` for the `rollingUpdate` filebeat's update strategy.
This option should be available especially for filbert, because there is no need to have a MaxUnavailable set to 1 when there's one filebeat pod per node. 


# What I've done in PR

Add an `{{- if }}` statement to the `updateStrategy` regarding the `MaxUnavaillable` variable. If the variable is not set, the default value is et to **1** (current value set right now).

Chart version

filebeat 7.9.1

Tools versions

Helm version
Client: {Version:"v3.3.0", GitCommit:"8a4aeec08d67a7b84472007529e8097ec3742105", GitTreeState:"dirty", GoVersion:"go1.14.6"}

kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.8", GitCommit:"9f2892aab98fe339f3bd70e3c470144299398ace", GitTreeState:"clean", BuildDate:"2020-08-13T16:12:48Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"darwin/amd64"}