### PR TITLE
[elasticsearch][kibana] disable nss dentry cache

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -233,6 +233,10 @@ spec:
                 # Once it has started only check that the node itself is responding
                 START_FILE=/tmp/.es_start_file
 
+                # Disable nss cache to avoid filling dentry cache when calling curl
+                # This is required with Elasticsearch Docker using nss < 3.52
+                export NSS_SDB_USE_CACHE=no
+
                 http () {
                   local path="${1}"
                   local args="${2}"

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -105,6 +105,11 @@ spec:
               - -c
               - |
                 #!/usr/bin/env bash -e
+
+                # Disable nss cache to avoid filling dentry cache when calling curl
+                # This is required with Kibana Docker using nss < 3.52
+                export NSS_SDB_USE_CACHE=no
+
                 http () {
                     local path="${1}"
                     set -- -XGET -s --fail -L


### PR DESCRIPTION
This PR disable nss dentry cache for Elasticsearch and Kibana
readinessProbe.

On affected system (nss < 3.52), the curl commands used by
readinessProbe are filling dentry cache which is observed in some
cases to be never reclaimed.

Elasticsearch and Kibana Docker images are based on CentOS 7 which
is using nss-3.44.0-7.el7_7.x86_64 and are affected by this bug.

This PR disable nss dentry cache in readinessProbe as a
workaround.

Related to https://github.com/elastic/cloud-on-k8s/pull/1716
