### PR TITLE
[metricbeat] support deployment/daemonset specific metrics

### DIFF
--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -90,6 +90,7 @@ as a reference. They are also used in the automated testing of this chart.
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | `clusterRoleRules`             | Configurable [cluster role rules][] that Metricbeat uses to access Kubernetes resources                                                                                      | see [values.yaml][]                  |
 | `daemonset.annotations`        | Configurable [annotations][] for Metricbeat daemonset                                                                                                                        | `{}`                                 |
+| `daemonset.labels`             | Configurable [labels][] applied to all Metricbeat DaemonSet pods                                                                                                             | `{}`                                 |
 | `daemonset.affinity`           | Configurable [affinity][] for Metricbeat daemonset                                                                                                                           | `{}`                                 |
 | `daemonset.enabled`            | If true, enable daemonset                                                                                                                                                    | `true`                               |
 | `daemonset.envFrom`            | Templatable string of `envFrom` to be passed to the  [environment from variables][] which will be appended to Metricbeat container for DaemonSet                             | `[]`                                 |
@@ -104,6 +105,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `daemonset.securityContext`    | Configurable [securityContext][] for Metricbeat DaemonSet pod execution environment                                                                                          | see [values.yaml][]                  |
 | `daemonset.tolerations`        | Configurable [tolerations][] for Metricbeat DaemonSet                                                                                                                        | `[]`                                 |
 | `deployment.annotations`       | Configurable [annotations][] for Metricbeat Deployment                                                                                                                       | `{}`                                 |
+| `deployment.labels`            | Configurable [labels][] applied to all Metricbeat Deployment pods                                                                                                            | `{}`                                 |
 | `deployment.affinity`          | Configurable [affinity][] for Metricbeat Deployment                                                                                                                          | `{}`                                 |
 | `deployment.enabled`           | If true, enable deployment                                                                                                                                                   | `true`                               |
 | `deployment.envFrom`           | Templatable string of `envFrom` to be passed to the  [environment from variables][] which will be appended to Metricbeat container for Deployment                            | `[]`                                 |
@@ -126,7 +128,6 @@ as a reference. They are also used in the automated testing of this chart.
 | `image`                        | The Metricbeat Docker image                                                                                                                                                  | `docker.elastic.co/beats/metricbeat` |
 | `kube_state_metrics.enabled`   | Install [kube-state-metrics](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) as a dependency                                                           | `true`                               |
 | `kube_state_metrics.host`      | Define kube-state-metrics endpoint for an existing deployment. Works only if `kube_state_metrics.enabled: false`                                                             | `""`                                 |
-| `labels`                       | Configurable [labels][] applied to all Metricbeat pods                                                                                                                       | `{}`                                 |
 | `livenessProbe`                | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                                   | see [values.yaml][]                  |
 | `managedServiceAccount`        | Whether the `serviceAccount` should be managed by this helm chart. Set this to `false` in order to manage your own service account and related roles                         | `true`                               |
 | `nameOverride`                 | Overrides the chart name for resources. If not set the name will default to `.Chart.Name`                                                                                    | `""`                                 |
@@ -155,6 +156,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `resources`          | Allows you to set the [resources][] for both Metricbeat DaemonSet and Deployment                                                                       | `{}`    |
 | `secretMounts`       | Allows you easily mount a secret as a file inside DaemonSet and Deployment Useful for mounting certificates and other secrets                          | `[]`    |
 | `tolerations`        | Configurable [tolerations][] for both Metricbeat DaemonSet and Deployment                                                                              | `[]`    |
+| `labels`             | Configurable [labels][] applied to all Metricbeat pods                                                                                                 | `[]`    |
 
 
 ## FAQ

--- a/metricbeat/templates/daemonset.yaml
+++ b/metricbeat/templates/daemonset.yaml
@@ -9,8 +9,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    {{- if .Values.daemonset.labels }}
+    {{- range $key, $value := .Values.daemonset.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- else }}
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- end }}
   {{- if .Values.daemonset.annotations}}
   annotations:
@@ -41,8 +47,14 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
+        {{- if .Values.daemonset.labels }}
+        {{- range $key, $value := .Values.daemonset.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- else }}
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
         {{- end }}
     spec:
       affinity: {{ toYaml ( .Values.affinity | default .Values.daemonset.affinity ) | nindent 8 }}

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -10,6 +10,15 @@ metadata:
     chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
+    {{- if .Values.deployment.labels }}
+    {{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- else }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
   {{- if .Values.deployment.annotations}}
   annotations:
     {{- range $key, $value := .Values.deployment.annotations }}
@@ -38,8 +47,14 @@ spec:
         chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
+        {{- if .Values.deployment.labels }}
+        {{- range $key, $value := .Values.deployment.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- else }}
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
         {{- end }}
     spec:
       affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}

--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -968,7 +968,7 @@ clusterRoleRules:
     assert rules["resources"][0] == "something"
 
 
-def test_adding_legacy_labels():
+def test_adding_deprecated_labels():
     config = """
 labels:
   app-test: metricbeat

--- a/metricbeat/tests/metricbeat_test.py
+++ b/metricbeat/tests/metricbeat_test.py
@@ -968,21 +968,98 @@ clusterRoleRules:
     assert rules["resources"][0] == "something"
 
 
-def test_adding_pod_labels():
+def test_adding_legacy_labels():
     config = """
 labels:
-  app.kubernetes.io/name: metricbeat
+  app-test: metricbeat
 """
     r = helm_template(config)
+    assert r["daemonset"][name]["metadata"]["labels"]["app-test"] == "metricbeat"
     assert (
-        r["daemonset"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        r["deployment"][name + "-metrics"]["metadata"]["labels"]["app-test"]
         == "metricbeat"
     )
     assert (
-        r["daemonset"][name]["spec"]["template"]["metadata"]["labels"][
-            "app.kubernetes.io/name"
+        r["daemonset"][name]["spec"]["template"]["metadata"]["labels"]["app-test"]
+        == "metricbeat"
+    )
+    assert (
+        r["deployment"][name + "-metrics"]["spec"]["template"]["metadata"]["labels"][
+            "app-test"
         ]
         == "metricbeat"
+    )
+
+
+def test_adding_daemonset_labels():
+    config = """
+daemonset:
+  labels:
+    app-test: metricbeat
+"""
+    r = helm_template(config)
+    assert r["daemonset"][name]["metadata"]["labels"]["app-test"] == "metricbeat"
+    assert (
+        r["daemonset"][name]["spec"]["template"]["metadata"]["labels"]["app-test"]
+        == "metricbeat"
+    )
+
+
+def test_adding_daemonset_labels_surpasses_root_labels():
+    config = """
+labels:
+  app-test: root-metricbeat
+daemonset:
+  labels:
+    app-test: daemonset-metricbeat
+"""
+    r = helm_template(config)
+    assert (
+        r["daemonset"][name]["metadata"]["labels"]["app-test"] == "daemonset-metricbeat"
+    )
+    assert (
+        r["daemonset"][name]["spec"]["template"]["metadata"]["labels"]["app-test"]
+        == "daemonset-metricbeat"
+    )
+
+
+def test_adding_deployment_labels():
+    config = """
+deployment:
+  labels:
+    app-test: metricbeat
+"""
+    r = helm_template(config)
+    assert (
+        r["deployment"][name + "-metrics"]["metadata"]["labels"]["app-test"]
+        == "metricbeat"
+    )
+    assert (
+        r["deployment"][name + "-metrics"]["spec"]["template"]["metadata"]["labels"][
+            "app-test"
+        ]
+        == "metricbeat"
+    )
+
+
+def test_adding_deployment_labels_surpasses_root_labels():
+    config = """
+labels:
+  app-test: root-metricbeat
+deployment:
+  labels:
+    app-test: deployment-metricbeat
+"""
+    r = helm_template(config)
+    assert (
+        r["deployment"][name + "-metrics"]["metadata"]["labels"]["app-test"]
+        == "deployment-metricbeat"
+    )
+    assert (
+        r["deployment"][name + "-metrics"]["spec"]["template"]["metadata"]["labels"][
+            "app-test"
+        ]
+        == "deployment-metricbeat"
     )
 
 

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -3,6 +3,8 @@
 daemonset:
   # Annotations to apply to the daemonset
   annotations: {}
+  # additionals labels
+  labels: {}
   affinity: {}
   # Include the daemonset
   enabled: true
@@ -97,6 +99,8 @@ daemonset:
 deployment:
   # Annotations to apply to the deployment
   annotations: {}
+  # additionals labels
+  labels: {}
   affinity: {}
   # Include the deployment
   enabled: true
@@ -197,9 +201,6 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 5
 
-# additionals labels
-labels: {}
-
 # Whether this chart should self-manage its service account, role, and associated role binding.
 managedServiceAccount: true
 
@@ -285,3 +286,4 @@ podSecurityContext: {}
 resources: {}
 secretMounts: []
 tolerations: []
+labels: {}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Closes #812

Turned out, initially labeling was completely implemented for DaemonSet (both daemon-set and pod labels), but only partially for Deployment (only pod-level labels). I decided to make these properties to be consistent for both object types, while still keeping to the design we agreed in the linked issue