### PR TITLE
[logstash] use only httpPort in headless service

### DIFF
--- a/logstash/templates/service-headless.yaml
+++ b/logstash/templates/service-headless.yaml
@@ -16,9 +16,5 @@ spec:
   selector:
     app: "{{ template "logstash.fullname" . }}"
   ports:
-{{- if .Values.service }}
-{{ toYaml .Values.service.ports | indent 4 }}
-{{- else }}
     - name: http
       port: {{ .Values.httpPort }}
-{{- end }}

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -860,13 +860,6 @@ service:
         "protocol": "TCP",
         "targetPort": 5044,
     }
-    h = r["service"][name + "-headless"]
-    assert h["spec"]["ports"][0] == {
-        "name": "beats",
-        "port": 5044,
-        "protocol": "TCP",
-        "targetPort": 5044,
-    }
 
 
 def test_setting_fullnameOverride():


### PR DESCRIPTION
This commit fix an issue introduced in 8ed75a9 where helm
install/upgrade is failing if a NodePort service is defined.

Logstash headless service used to manage Statefulset does not anymore include
`.Values.service.ports` and include only Logstash httpPort.

This is done because headless service `ports` doesn't accept `nodePort`
values that can be included in `.Values.service.ports` when adding a
NodePort service.

Fix https://github.com/elastic/helm-charts/issues/807
