### PR TITLE
[elasticsearch] add coordinator node to multi test

### DIFF
--- a/elasticsearch/examples/multi/Makefile
+++ b/elasticsearch/examples/multi/Makefile
@@ -8,9 +8,11 @@ RELEASE := helm-es-multi-master
 install:
 	helm upgrade --wait --timeout=600 --install --values ./master.yml $(PREFIX)-master ../../
 	helm upgrade --wait --timeout=600 --install --values ./data.yml $(PREFIX)-data ../../
+	helm upgrade --wait --timeout=600 --install --values ./client.yml $(PREFIX)-client ../../
 
 test: install goss
 
 purge:
 	helm del --purge $(PREFIX)-master
 	helm del --purge $(PREFIX)-data
+	helm del --purge $(PREFIX)-client

--- a/elasticsearch/examples/multi/README.md
+++ b/elasticsearch/examples/multi/README.md
@@ -1,14 +1,15 @@
 # Multi
 
-This example deploy an Elasticsearch 8.0.0-SNAPSHOT cluster composed of 2 different Helm
+This example deploy an Elasticsearch 8.0.0-SNAPSHOT cluster composed of 3 different Helm
 releases:
 
 - `helm-es-multi-master` for the 3 master nodes using [master values][]
 - `helm-es-multi-data` for the 3 data nodes using [data values][]
+- `helm-es-multi-client` for the 3 client nodes using [client values][]
 
 ## Usage
 
-* Deploy the 2 Elasticsearch releases: `make install`
+* Deploy the 3 Elasticsearch releases: `make install`
 
 * You can now setup a port forward to query Elasticsearch API:
 
@@ -22,6 +23,8 @@ releases:
 You can also run [goss integration tests][] using `make test`
 
 
+[client values]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/multi/client.yml
 [data values]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/multi/data.yml
 [goss integration tests]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/multi/test/goss.yaml
 [master values]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/multi/master.yml
+

--- a/elasticsearch/examples/multi/client.yml
+++ b/elasticsearch/examples/multi/client.yml
@@ -1,11 +1,14 @@
 ---
 
 clusterName: "multi"
-nodeGroup: "data"
+nodeGroup: "client"
 
 roles:
   master: "false"
-  ingest: "true"
-  data: "true"
+  ingest: "false"
+  data: "false"
   ml: "false"
   remote_cluster_client: "false"
+
+persistence:
+  enabled: false

--- a/elasticsearch/examples/multi/master.yml
+++ b/elasticsearch/examples/multi/master.yml
@@ -7,3 +7,5 @@ roles:
   master: "true"
   ingest: "false"
   data: "false"
+  ml: "false"
+  remote_cluster_client: "false"

--- a/elasticsearch/examples/multi/test/goss.yaml
+++ b/elasticsearch/examples/multi/test/goss.yaml
@@ -5,5 +5,5 @@ http:
     body:
       - 'green'
       - '"cluster_name":"multi"'
-      - '"number_of_nodes":6'
+      - '"number_of_nodes":9'
       - '"number_of_data_nodes":3'

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -12,6 +12,8 @@ roles:
   master: "true"
   ingest: "true"
   data: "true"
+  ml: "true"
+  remote_cluster_client: "true"
 
 replicas: 3
 minimumMasterNodes: 2

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -12,8 +12,8 @@ roles:
   master: "true"
   ingest: "true"
   data: "true"
-  ml: "true"
   remote_cluster_client: "true"
+# ml: "true" # ml is not availble with elasticsearch-oss
 
 replicas: 3
 minimumMasterNodes: 2


### PR DESCRIPTION
This commit add a coordinator node group to elasticsearch multi test.
This also add ml and remote_cluster_client roles to default values.

Related to #832
