### PR TITLE
[all] Simplify doc in 6.8 branch

### DIFF
--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -8,8 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Alpha features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
-release for released version.
+**Warning**: This branch is used for development, please use the latest [6.x][] release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -148,7 +147,7 @@ An example of APM Server deployment using OSS version can be found in
 Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
-
+[6.x]: https://github.com/elastic/helm-charts/releases
 [6.8.13-SNAPSHOT]: https://github.com/elastic/helm-charts/blob/6.8.13-SNAPSHOT/apm-server/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -45,22 +45,24 @@ See [supported configurations][] for more details.
 
 This chart is tested with the latest 6.8.13-SNAPSHOT version.
 
-## Install released version using Helm repository
+### Install released version using Helm repository
 
 * Add the Elastic Helm charts repo:
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name apm-server --version 6.8.12 elastic/apm-server`
-  - with [Helm 3 (beta)][]: `helm install apm-server --version 6.8.12 elastic/apm-server`
+  - with Helm 2: `helm install --name apm-server --version <version> elastic/apm-server`
+  - with [Helm 3 (beta)][]: `helm install apm-server --version <version> elastic/apm-server`
 
 ### Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
+* Checkout the branch : git checkout 6.8
+
 * Install it:
-  - with Helm 2: `helm install --name apm-server ./helm-charts/apm-server`
-  - with [Helm 3 (beta)][]: `helm install apm-server ./helm-charts/apm-server`
+  - with Helm 2: `helm install --name apm-server --version 6.8.13-SNAPSHOT ./helm-charts/apm-server`
+  - with [Helm 3 (beta)][]: `helm install apm-server --version 6.8.13-SNAPSHOT ./helm-charts/apm-server`
 
 
 ## Upgrading

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -18,7 +18,7 @@ release for released version.
 
 - [Requirements](#requirements)
 - [Installing](#installing)
-- [Install released version using Helm repository](#install-released-version-using-helm-repository)
+  - [Install released version using Helm repository](#install-released-version-using-helm-repository)
   - [Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions](#install-development-version-using-68-branch-and-6813-snapshot-versions)
 - [Upgrading](#upgrading)
 - [Usage notes](#usage-notes)

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -8,8 +8,8 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Alpha features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [6.8.12][] release
-for released version.
+**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
+release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -8,8 +8,8 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [6.8.12][] release
-for released version.
+**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
+release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -8,8 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
-release for released version.
+**Warning**: This branch is used for development, please use the latest [6.x][] release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -394,7 +393,7 @@ lifecycle:
 Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
-
+[6.x]: https://github.com/elastic/helm-charts/releases
 [#63]: https://github.com/elastic/helm-charts/issues/63
 [6.8.13-SNAPSHOT]: https://github.com/elastic/helm-charts/blob/6.8.13-SNAPSHOT/elasticsearch/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -56,6 +56,7 @@ default settings. All of these settings are configurable.
 
 See [supported configurations][] for more details.
 
+
 ## Installing
 
 This chart is tested with the latest 6.8.13-SNAPSHOT version.
@@ -66,17 +67,18 @@ This chart is tested with the latest 6.8.13-SNAPSHOT version.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name elasticsearch --version 6.8.12 elastic/elasticsearch`
-  - with [Helm 3 (beta)][]: `helm install elasticsearch --version 6.8.12 elastic/elasticsearch`
+  - with Helm 2: `helm install --name elasticsearch --version <version> elastic/elasticsearch`
+  - with [Helm 3 (beta)][]: `helm install elasticsearch --version <version> elastic/elasticsearch`
 
 ### Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
-* Install it:
-  - with Helm 2: `helm install --name elasticsearch ./helm-charts/elasticsearch`
-  - with [Helm 3 (beta)][]: `helm install elasticsearch ./helm-charts/elasticsearch`
+* Checkout the branch : git checkout 6.8
 
+* Install it:
+  - with Helm 2: `helm install --name elasticsearch --version 6.8.13-SNAPSHOT ./helm-charts/elasticsearch`
+  - with [Helm 3 (beta)][]: `helm install elasticsearch --version 6.8.13-SNAPSHOT ./helm-charts/elasticsearch`
 
 ## Upgrading
 

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -53,16 +53,18 @@ This chart is tested with the latest 6.8.13-SNAPSHOT version.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name filebeat --version 6.8.12 elastic/filebeat`
-  - with [Helm 3 (beta)][]: `helm install filebeat --version 6.8.12 elastic/filebeat`
+  - with Helm 2: `helm install --name filebeat --version <version> elastic/filebeat`
+  - with [Helm 3 (beta)][]: `helm install filebeat --version <version> elastic/filebeat`
 
 ### Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
+* Checkout the branch : git checkout 6.8
+
 * Install it:
-  - with Helm 2: `helm install --name filebeat ./helm-charts/filebeat`
-  - with [Helm 3 (beta)][]: `helm install filebeat ./helm-charts/filebeat`
+  - with Helm 2: `helm install --name filebeat --version 6.8.13-SNAPSHOT ./helm-charts/filebeat`
+  - with [Helm 3 (beta)][]: `helm install filebeat --version 6.8.13-SNAPSHOT ./helm-charts/filebeat`
 
 
 ## Upgrading

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -8,8 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
-release for released version.
+**Warning**: This branch is used for development, please use the latest [6.x][] release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -192,7 +191,7 @@ readinessProbe:
 Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
-
+[6.x]: https://github.com/elastic/helm-charts/releases
 [6.8.13-SNAPSHOT]: https://github.com/elastic/helm-charts/blob/6.8.13-SNAPSHOT/filebeat/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -8,8 +8,8 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [6.8.12][] release
-for released version.
+**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
+release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -8,8 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
-release for released version.
+**Warning**: This branch is used for development, please use the latest [6.x][] release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -209,7 +208,7 @@ lifecycle:
 Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
-
+[6.x]: https://github.com/elastic/helm-charts/releases
 [6.8.13-SNAPSHOT]: https://github.com/elastic/helm-charts/blob/6.8.13-SNAPSHOT/kibana/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -8,8 +8,8 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [6.8.12][] release
-for released version.
+**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
+release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -54,16 +54,18 @@ This chart is tested with the latest 6.8.13-SNAPSHOT version.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name kibana --version 6.8.12 elastic/kibana`
-  - with [Helm 3 (beta)][]: `helm install kibana --version 6.8.12 elastic/kibana`
+  - with Helm 2: `helm install --name kibana --version <version> elastic/kibana`
+  - with [Helm 3 (beta)][]: `helm install kibana --version <version> elastic/kibana`
 
 ### Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
+* Checkout the branch : git checkout 6.8
+
 * Install it:
-  - with Helm 2: `helm install --name kibana ./helm-charts/kibana`
-  - with [Helm 3 (beta)][]: `helm install kibana ./helm-charts/kibana`
+  - with Helm 2: `helm install --name kibana --version 6.8.13-SNAPSHOT ./helm-charts/kibana`
+  - with [Helm 3 (beta)][]: `helm install kibana --version 6.8.13-SNAPSHOT ./helm-charts/kibana`
 
 
 ## Upgrading

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -40,7 +40,6 @@ for released version.
 
 See [supported configurations][] for more details.
 
-
 ## Installing
 
 This chart is tested with the latest 6.8.13-SNAPSHOT version.
@@ -51,16 +50,18 @@ This chart is tested with the latest 6.8.13-SNAPSHOT version.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name logstash --version 6.8.12 elastic/logstash`
-  - with [Helm 3 (beta)][]: `helm install logstash --version 6.8.12 elastic/logstash`
+  - with Helm 2: `helm install --name logstash --version <version> elastic/logstash`
+  - with [Helm 3 (beta)][]: `helm install logstash --version <version> elastic/logstash`
 
 ### Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
+* Checkout the branch : git checkout 6.8
+
 * Install it:
-  - with Helm 2: `helm install --name logstash ./helm-charts/logstash`
-  - with [Helm 3 (beta)][]: `helm install logstash ./helm-charts/logstash`
+  - with Helm 2: `helm install --name logstash --version 6.8.13-SNAPSHOT ./helm-charts/logstash`
+  - with [Helm 3 (beta)][]: `helm install logstash --version 6.8.13-SNAPSHOT ./helm-charts/logstash`
 
 
 ## Upgrading

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -8,8 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Alpha features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
-release for released version.
+**Warning**: This branch is used for development, please use the latest [6.x][] release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -191,7 +190,7 @@ against best practices of containers and immutable infrastructure.
 Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
-
+[6.x]: https://github.com/elastic/helm-charts/releases
 [6.8.13-SNAPSHOT]: https://github.com/elastic/helm-charts/blob/6.8.13-SNAPSHOT/logstash/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -8,8 +8,8 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Alpha features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [6.8.12][] release
-for released version.
+**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
+release for released version.
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -8,8 +8,7 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
-release for released version.
+**Warning**: This branch is used for development, please use the latest [6.x][] release for released version.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -215,7 +214,7 @@ same node.
 Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
-
+[6.x]: https://github.com/elastic/helm-charts/releases
 [#471]: https://github.com/elastic/helm-charts/pull/471
 [6.8.13-SNAPSHOT]: https://github.com/elastic/helm-charts/blob/6.8.13-SNAPSHOT/metricbeat/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -53,16 +53,18 @@ This chart is tested with the latest 6.8.13-SNAPSHOT version.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name apm-server --version 6.8.12 elastic/apm-server`
-  - with [Helm 3 (beta)][]: `helm install apm-server --version 6.8.12 elastic/apm-server`
+  - with Helm 2: `helm install --name metricbeat --version <version> elastic/metricbeat`
+  - with [Helm 3 (beta)][]: `helm install metricbeat --version <version> elastic/metricbeat`
 
 ### Install development version using 6.8 branch and 6.8.13-SNAPSHOT versions
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
+* Checkout the branch : git checkout 6.8
+
 * Install it:
-  - with Helm 2: `helm install --name apm-server ./helm-charts/apm-server`
-  - with [Helm 3 (beta)][]: `helm install apm-server ./helm-charts/apm-server`
+  - with Helm 2: `helm install --name metricbeat --version 6.8.13-SNAPSHOT ./helm-charts/metricbeat`
+  - with [Helm 3 (beta)][]: `helm install metricbeat --version 6.8.13-SNAPSHOT ./helm-charts/metricbeat`
 
 
 ## Upgrading

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -8,9 +8,8 @@ The design and code is less mature than official GA features and is being
 provided as-is with no warranties. Beta features are not subject to the support
 SLA of official GA features (see [supported configurations][] for more details).
 
-**Warning**: This branch is used for development, please use [6.8.12][] release
-for released version.
-
+**Warning**: This branch is used for development, please use the latest [6.8](https://github.com/elastic/helm-charts/releases)
+release for released version.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
This PR simplifies the release process by making the charts README more generic - similar fix was done [after the `7.9.2` release ](https://github.com/elastic/helm-charts/pull/831/files)