### PR TITLE
6.8.13 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 6.8.13
+
+* 6.8.13 as default version.
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#858](https://github.com/elastic/helm-charts/pull/858) | [@nkammah](https://github.com/nkammah) | [all] Simplify doc in 6.8 branch  |
+| [#767](https://github.com/elastic/helm-charts/pull/767) | [@ebuildy](https://github.com/ebuildy) | [Metricbeat] Dont generate config if not enabled  |
+| [#793](https://github.com/elastic/helm-charts/pull/793) | [@jnbelo](https://github.com/jnbelo) | Added ingress support to the logstash chart  |
+| [#839](https://github.com/elastic/helm-charts/pull/839) | [@jmlrt](https://github.com/jmlrt) | [logstash] use only httpPort in headless service  |
+| [#659](https://github.com/elastic/helm-charts/pull/659) | [@orong-pp](https://github.com/orong-pp) | [filebeat] introduce dnsConfig values for the containers  |
+| [#820](https://github.com/elastic/helm-charts/pull/820) | [@v1r7u](https://github.com/v1r7u) | [metricbeat] support deployment/daemonset specific metrics  |
+| [#717](https://github.com/elastic/helm-charts/pull/717) | [@qqshfox](https://github.com/qqshfox) | support tpl in logstashConfig, logstashPipeline and kibanaConfig  |
+| [#818](https://github.com/elastic/helm-charts/pull/818) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch][kibana] disable nss dentry cache  |
+| [#816](https://github.com/elastic/helm-charts/pull/816) | [@jmlrt](https://github.com/jmlrt) | [helm] bump helm version to 2.16.12  |
+| [#811](https://github.com/elastic/helm-charts/pull/811) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] fix secrets names in examples  |
+| [#729](https://github.com/elastic/helm-charts/pull/729) | [@floretan](https://github.com/floretan) | Include pre-releases in the semver range.  |
+| [#810](https://github.com/elastic/helm-charts/pull/810) | [@luanguimaraesla](https://github.com/luanguimaraesla) | [elasticsearch] add loadBalancer externalTrafficPolicy option  |
+| [#778](https://github.com/elastic/helm-charts/pull/778) | [@erihanse](https://github.com/erihanse) | [metricbeat] Support secrets  |
+| [#786](https://github.com/elastic/helm-charts/pull/786) | [@caiconkhicon](https://github.com/caiconkhicon) | Fix serviceAccount for APM server  |
+| [#770](https://github.com/elastic/helm-charts/pull/770) | [@vliubko](https://github.com/vliubko) | [metricbeat] Add missing labels for deployment  |
+| [#776](https://github.com/elastic/helm-charts/pull/776) | [@itssimon](https://github.com/itssimon) | [logstash] Fix headless service ports spec  |
+| [#763](https://github.com/elastic/helm-charts/pull/763) | [@ebuildy](https://github.com/ebuildy) | Remove duplicate "initialDelaySeconds" field  |
+| [#752](https://github.com/elastic/helm-charts/pull/752) | [@AhmedSamirAhmed](https://github.com/AhmedSamirAhmed) | Missing deletion of "elastic-certificate-crt"  |
+| [#744](https://github.com/elastic/helm-charts/pull/744) | [@SlavaSubotskiy](https://github.com/SlavaSubotskiy) | Fix typo in FAQ  |
+| [#797](https://github.com/elastic/helm-charts/pull/797) | [@jmlrt](https://github.com/jmlrt) | [helm] bump helm version to 2.16.10  |
+| [#798](https://github.com/elastic/helm-charts/pull/798) | [@jmlrt](https://github.com/jmlrt) | [meta] drop gke 1.14 tests  |
+| [#790](https://github.com/elastic/helm-charts/pull/790) | [@ygel](https://github.com/ygel) | Bump version to 6.8.13-SNAPSHOT   |
+
+
 ## 7.9.2 - 2020/09/24
 * 7.9.2 as the default stack version
 * Bump Helm version to 2.16.12 ([@jmlrt](https://github.com/jmlrt))

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ versions.
 
 | Chart                                      | Docker documentation                                                            |Latest 7 Version|Latest 6 Version|
 |--------------------------------------------|---------------------------------------------------------------------------------|-----------|-----------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       |[`7.9.2`][apm-7] |[`6.8.12`][apm-6] |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     |[`7.9.2`][elasticsearch-7] |[`6.8.12`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   |[`7.9.2`][filebeat-7] |[`6.8.12`][filebeat-6] |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      |[`7.9.2`][kibana-7] |[`6.8.12`][kibana-6] |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    |[`7.9.2`][logstash-7] |[`6.8.12`][logstash-6] |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html |[`7.9.2`][metricbeat-7] |[`6.8.12`][metricbeat-6] |
+| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       |[`7.9.2`][apm-7] |[`6.8.13`][apm-6] |
+| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     |[`7.9.2`][elasticsearch-7] |[`6.8.13`][elasticsearch-6] |
+| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   |[`7.9.2`][filebeat-7] |[`6.8.13`][filebeat-6] |
+| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      |[`7.9.2`][kibana-7] |[`6.8.13`][kibana-6] |
+| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    |[`7.9.2`][logstash-7] |[`6.8.13`][logstash-6] |
+| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html |[`7.9.2`][metricbeat-7] |[`6.8.13`][metricbeat-6] |
 
 ## Supported Configurations
 
@@ -104,14 +104,14 @@ Kubernetes.
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 
 [apm-7]: https://github.com/elastic/helm-charts/tree/7.9.2/apm-server/README.md
-[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.12/apm-server/README.md
+[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.13/apm-server/README.md
 [elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.9.2/elasticsearch/README.md
-[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.12/elasticsearch/README.md
+[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.13/elasticsearch/README.md
 [filebeat-7]: https://github.com/elastic/helm-charts/tree/7.9.2/filebeat/README.md
-[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.12/filebeat/README.md
+[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.13/filebeat/README.md
 [kibana-7]: https://github.com/elastic/helm-charts/tree/7.9.2/kibana/README.md
-[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.12/kibana/README.md
+[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.13/kibana/README.md
 [logstash-7]: https://github.com/elastic/helm-charts/tree/7.9.2/logstash/README.md
-[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.12/logstash/README.md
+[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.13/logstash/README.md
 [metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.9.2/metricbeat/README.md
-[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.12/metricbeat/README.md
+[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.13/metricbeat/README.md


### PR DESCRIPTION

## 6.8.13

* 6.8.13 as default version.

| PR | Author | Title |
| --- | --- | --- |
| [#858](https://github.com/elastic/helm-charts/pull/858) | [@nkammah](https://github.com/nkammah) | [all] Simplify doc in 6.8 branch  |
| [#767](https://github.com/elastic/helm-charts/pull/767) | [@ebuildy](https://github.com/ebuildy) | [Metricbeat] Dont generate config if not enabled  |
| [#793](https://github.com/elastic/helm-charts/pull/793) | [@jnbelo](https://github.com/jnbelo) | Added ingress support to the logstash chart  |
| [#839](https://github.com/elastic/helm-charts/pull/839) | [@jmlrt](https://github.com/jmlrt) | [logstash] use only httpPort in headless service  |
| [#659](https://github.com/elastic/helm-charts/pull/659) | [@orong-pp](https://github.com/orong-pp) | [filebeat] introduce dnsConfig values for the containers  |
| [#820](https://github.com/elastic/helm-charts/pull/820) | [@v1r7u](https://github.com/v1r7u) | [metricbeat] support deployment/daemonset specific metrics  |
| [#717](https://github.com/elastic/helm-charts/pull/717) | [@qqshfox](https://github.com/qqshfox) | support tpl in logstashConfig, logstashPipeline and kibanaConfig  |
| [#818](https://github.com/elastic/helm-charts/pull/818) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch][kibana] disable nss dentry cache  |
| [#816](https://github.com/elastic/helm-charts/pull/816) | [@jmlrt](https://github.com/jmlrt) | [helm] bump helm version to 2.16.12  |
| [#811](https://github.com/elastic/helm-charts/pull/811) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] fix secrets names in examples  |
| [#729](https://github.com/elastic/helm-charts/pull/729) | [@floretan](https://github.com/floretan) | Include pre-releases in the semver range.  |
| [#810](https://github.com/elastic/helm-charts/pull/810) | [@luanguimaraesla](https://github.com/luanguimaraesla) | [elasticsearch] add loadBalancer externalTrafficPolicy option  |
| [#778](https://github.com/elastic/helm-charts/pull/778) | [@erihanse](https://github.com/erihanse) | [metricbeat] Support secrets  |
| [#786](https://github.com/elastic/helm-charts/pull/786) | [@caiconkhicon](https://github.com/caiconkhicon) | Fix serviceAccount for APM server  |
| [#770](https://github.com/elastic/helm-charts/pull/770) | [@vliubko](https://github.com/vliubko) | [metricbeat] Add missing labels for deployment  |
| [#776](https://github.com/elastic/helm-charts/pull/776) | [@itssimon](https://github.com/itssimon) | [logstash] Fix headless service ports spec  |
| [#763](https://github.com/elastic/helm-charts/pull/763) | [@ebuildy](https://github.com/ebuildy) | Remove duplicate "initialDelaySeconds" field  |
| [#752](https://github.com/elastic/helm-charts/pull/752) | [@AhmedSamirAhmed](https://github.com/AhmedSamirAhmed) | Missing deletion of "elastic-certificate-crt"  |
| [#744](https://github.com/elastic/helm-charts/pull/744) | [@SlavaSubotskiy](https://github.com/SlavaSubotskiy) | Fix typo in FAQ  |
| [#797](https://github.com/elastic/helm-charts/pull/797) | [@jmlrt](https://github.com/jmlrt) | [helm] bump helm version to 2.16.10  |
| [#798](https://github.com/elastic/helm-charts/pull/798) | [@jmlrt](https://github.com/jmlrt) | [meta] drop gke 1.14 tests  |
| [#790](https://github.com/elastic/helm-charts/pull/790) | [@ygel](https://github.com/ygel) | Bump version to 6.8.13-SNAPSHOT   |

