### PR TITLE
Remove beta warnings 6.8

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -3,11 +3,6 @@
 This Helm chart is a lightweight way to configure and run our official
 [Elasticsearch Docker image][].
 
-**Warning**: This functionality is in beta.
-The design and code is less mature than official GA features and is being
-provided as-is with no warranties. Beta features are not subject to the support
-SLA of official GA features (see [supported configurations][] for more details).
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -3,11 +3,6 @@
 This Helm chart is a lightweight way to configure and run our official
 [Filebeat Docker image][].
 
-**Warning**: This functionality is in beta.
-The design and code is less mature than official GA features and is being
-provided as-is with no warranties. Beta features are not subject to the support
-SLA of official GA features (see [supported configurations][] for more details).
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -3,11 +3,6 @@
 This Helm chart is a lightweight way to configure and run our official
 [Kibana Docker image][].
 
-**Warning**: This functionality is in beta.
-The design and code is less mature than official GA features and is being
-provided as-is with no warranties. Beta features are not subject to the support
-SLA of official GA features (see [supported configurations][] for more details).
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -3,11 +3,6 @@
 This Helm chart is a lightweight way to configure and run our official
 [Metricbeat Docker image][].
 
-**Warning**: This functionality is in beta.
-The design and code is less mature than official GA features and is being
-provided as-is with no warranties. Beta features are not subject to the support
-SLA of official GA features (see [supported configurations][] for more details).
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
