### PR TITLE
[elasticsearch] remove roles unavailable on 6.8

### DIFF
--- a/elasticsearch/examples/multi/client.yml
+++ b/elasticsearch/examples/multi/client.yml
@@ -7,8 +7,6 @@ roles:
   master: "false"
   ingest: "false"
   data: "false"
-  ml: "false"
-  remote_cluster_client: "false"
 
 persistence:
   enabled: false

--- a/elasticsearch/examples/multi/data.yml
+++ b/elasticsearch/examples/multi/data.yml
@@ -7,5 +7,3 @@ roles:
   master: "false"
   ingest: "true"
   data: "true"
-  ml: "false"
-  remote_cluster_client: "false"

--- a/elasticsearch/examples/multi/master.yml
+++ b/elasticsearch/examples/multi/master.yml
@@ -7,5 +7,3 @@ roles:
   master: "true"
   ingest: "false"
   data: "false"
-  ml: "false"
-  remote_cluster_client: "false"

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -12,8 +12,6 @@ roles:
   master: "true"
   ingest: "true"
   data: "true"
-  remote_cluster_client: "true"
-# ml: "true" # ml is not availble with elasticsearch-oss
 
 replicas: 3
 minimumMasterNodes: 2


### PR DESCRIPTION
This commit fix a bug introduced in 702ca8f where elasticsearch 6.8
start is failing because ml and remote_cluster_client node roles
are unavailable in 6.8 versions.

Related to #854