### PR TITLE
[metricbeat] use relocated stable repo for kube-state-metrics

### DIFF
--- a/metricbeat/requirements.lock
+++ b/metricbeat/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 2.4.1
 digest: sha256:948dca129bc7c16b138ed8bcbdf666c324d812e43af59d475b8bb74a53e99778
-generated: "2020-04-16T16:14:03.9537312+03:00"
+generated: "2020-10-30T18:58:57.381827+01:00"


### PR DESCRIPTION
This commit update metricbeat chart dependencies to get
kube-state-metrics subchart from the newly relocated stable repo url
(https://charts.helm.sh/stable).

This is required because the legacy stable repo url will not work
anymore starting November 13th.

More details in https://helm.sh/blog/new-location-stable-incubator-charts/
