### PR TITLE
[meta] update rbac.authorization.k8s.io api

### DIFF
--- a/apm-server/templates/clusterrole.yaml
+++ b/apm-server/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedServiceAccount }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "apm.serviceAccount" . }}-cluster-role

--- a/apm-server/templates/clusterrolebinding.yaml
+++ b/apm-server/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedServiceAccount }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "apm.serviceAccount" . }}-cluster-role-binding

--- a/filebeat/templates/clusterrole.yaml
+++ b/filebeat/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedServiceAccount }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "filebeat.serviceAccount" . }}-cluster-role

--- a/filebeat/templates/clusterrolebinding.yaml
+++ b/filebeat/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedServiceAccount }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "filebeat.serviceAccount" . }}-cluster-role-binding

--- a/metricbeat/templates/clusterrole.yaml
+++ b/metricbeat/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedServiceAccount }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "metricbeat.serviceAccount" . }}-cluster-role

--- a/metricbeat/templates/clusterrolebinding.yaml
+++ b/metricbeat/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedServiceAccount }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "metricbeat.serviceAccount" . }}-cluster-role-binding


### PR DESCRIPTION
This commit updates Kubernetes [rbac.authorization.k8s.io][0] api from
v1beta1 in apm-server, filebeat and metricbeat charts.

- `rbac.authorization.k8s.io/v1` has been released in Kubernetes 1.8
- `rbac.authorization.k8s.io/v1beta1` is being deprecated in Kubernetes
1.17 and will be fully removed in 1.22

In addition, this is required for Helm 3 support to make `helm lint
--strict` happy.

Related to #401 

[0]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
