### PR TITLE
[meta] increase helm timeout

### DIFF
--- a/apm-server/examples/default/Makefile
+++ b/apm-server/examples/default/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-apm-server-default
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/apm-server/examples/oss/Makefile
+++ b/apm-server/examples/oss/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-apm-server-oss
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 

--- a/apm-server/examples/security/Makefile
+++ b/apm-server/examples/security/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-apm-server-security
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 

--- a/elasticsearch/examples/config/Makefile
+++ b/elasticsearch/examples/config/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-config
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
 
 secrets:
 	kubectl delete secret elastic-config-credentials elastic-config-secret elastic-config-slack elastic-config-custom-path || true

--- a/elasticsearch/examples/default/Makefile
+++ b/elasticsearch/examples/default/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-default
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/elasticsearch/examples/docker-for-mac/Makefile
+++ b/elasticsearch/examples/docker-for-mac/Makefile
@@ -3,7 +3,7 @@ default: test
 RELEASE := helm-es-docker-for-mac
 
 install:
-	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)

--- a/elasticsearch/examples/kubernetes-kind/Makefile
+++ b/elasticsearch/examples/kubernetes-kind/Makefile
@@ -3,11 +3,11 @@ default: test
 RELEASE := helm-es-kind
 
 install:
-	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
 
 install-local-path:
 	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
-	helm upgrade --wait --timeout=900 --install --values values-local-path.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200 --install --values values-local-path.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)

--- a/elasticsearch/examples/microk8s/Makefile
+++ b/elasticsearch/examples/microk8s/Makefile
@@ -3,7 +3,7 @@ default: test
 RELEASE := helm-es-microk8s
 
 install:
-	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)

--- a/elasticsearch/examples/migration/Makefile
+++ b/elasticsearch/examples/migration/Makefile
@@ -1,10 +1,10 @@
 PREFIX := helm-es-migration
 
 data:
-	helm upgrade --wait --timeout=600 --install --values ./data.yml $(PREFIX)-data ../../
+	helm upgrade --wait --timeout=900 --install --values ./data.yml $(PREFIX)-data ../../
 
 master:
-	helm upgrade --wait --timeout=600 --install --values ./master.yml $(PREFIX)-master ../../
+	helm upgrade --wait --timeout=900 --install --values ./master.yml $(PREFIX)-master ../../
 
 client:
-	helm upgrade --wait --timeout=600 --install --values ./client.yml $(PREFIX)-client ../../
+	helm upgrade --wait --timeout=900 --install --values ./client.yml $(PREFIX)-client ../../

--- a/elasticsearch/examples/minikube/Makefile
+++ b/elasticsearch/examples/minikube/Makefile
@@ -3,7 +3,7 @@ default: test
 RELEASE := helm-es-minikube
 
 install:
-	helm upgrade --wait --timeout=900 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)

--- a/elasticsearch/examples/multi/Makefile
+++ b/elasticsearch/examples/multi/Makefile
@@ -6,9 +6,9 @@ PREFIX := helm-es-multi
 RELEASE := helm-es-multi-master
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./master.yml $(PREFIX)-master ../../
-	helm upgrade --wait --timeout=600 --install --values ./data.yml $(PREFIX)-data ../../
-	helm upgrade --wait --timeout=600 --install --values ./client.yml $(PREFIX)-client ../../
+	helm upgrade --wait --timeout=900 --install --values ./master.yml $(PREFIX)-master ../../
+	helm upgrade --wait --timeout=900 --install --values ./data.yml $(PREFIX)-data ../../
+	helm upgrade --wait --timeout=900 --install --values ./client.yml $(PREFIX)-client ../../
 
 test: install goss
 

--- a/elasticsearch/examples/openshift/Makefile
+++ b/elasticsearch/examples/openshift/Makefile
@@ -7,7 +7,7 @@ template:
 	helm template --values ./values.yaml ../../
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 

--- a/elasticsearch/examples/oss/Makefile
+++ b/elasticsearch/examples/oss/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-oss
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 

--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -6,7 +6,7 @@ RELEASE := helm-es-security
 ELASTICSEARCH_IMAGE := docker.elastic.co/elasticsearch/elasticsearch:$(STACK_VERSION)
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install --values ./security.yml $(RELEASE) ../../
 
 purge:
 	kubectl delete secrets elastic-credentials elastic-certificates elastic-certificate-pem elastic-certificate-crt|| true

--- a/filebeat/examples/default/Makefile
+++ b/filebeat/examples/default/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-filebeat-default
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/filebeat/examples/oss/Makefile
+++ b/filebeat/examples/oss/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-filebeat-oss
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 

--- a/filebeat/examples/security/Makefile
+++ b/filebeat/examples/security/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-filebeat-security
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 

--- a/kibana/examples/default/Makefile
+++ b/kibana/examples/default/Makefile
@@ -5,7 +5,7 @@ RELEASE := helm-kibana-default
 
 install:
 	echo "Goss container: $(GOSS_CONTAINER)"
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/kibana/examples/openshift/Makefile
+++ b/kibana/examples/openshift/Makefile
@@ -6,10 +6,10 @@ RELEASE := kibana
 template:
 	helm template --values ./values.yml ../../
 
-install: 
-	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../
+install:
+	helm upgrade --wait --timeout=900 --install --values ./values.yml $(RELEASE) ../../
 
 test: install goss
-	
+
 purge:
 	helm del --purge $(RELEASE)

--- a/kibana/examples/oss/Makefile
+++ b/kibana/examples/oss/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-kibana-oss
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./values.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install --values ./values.yml $(RELEASE) ../../
 
 test: install goss
 

--- a/kibana/examples/security/Makefile
+++ b/kibana/examples/security/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-kibana-security
 
 install:
-	helm upgrade --wait --timeout=600 --install --values ./security.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install --values ./security.yml $(RELEASE) ../../
 
 test: secrets install goss
 

--- a/logstash/examples/default/Makefile
+++ b/logstash/examples/default/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-default
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200 --install $(RELEASE) ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/logstash/examples/elasticsearch/Makefile
+++ b/logstash/examples/elasticsearch/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-elasticsearch
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=1200 --install $(RELEASE) --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/logstash/examples/oss/Makefile
+++ b/logstash/examples/oss/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-oss
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE)  --values ./values.yaml ../../
+	helm upgrade --wait --timeout=1200 --install $(RELEASE)  --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200 --install $(RELEASE) ../../
 
 test: install goss
 

--- a/logstash/examples/security/Makefile
+++ b/logstash/examples/security/Makefile
@@ -5,7 +5,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-security
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=1200 --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 

--- a/metricbeat/examples/default/Makefile
+++ b/metricbeat/examples/default/Makefile
@@ -6,7 +6,7 @@ RELEASE = helm-metricbeat-default
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-default-metricbeat
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
 
 test-metrics:
 	 GOSS_FILE=goss-metrics.yaml make goss GOSS_SELECTOR=release=$(RELEASE),app=helm-metricbeat-default-metricbeat-metrics

--- a/metricbeat/examples/oss/Makefile
+++ b/metricbeat/examples/oss/Makefile
@@ -6,7 +6,7 @@ RELEASE := helm-metricbeat-oss
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-oss-metricbeat
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
 
 purge:
 	helm del --purge $(RELEASE)

--- a/metricbeat/examples/security/Makefile
+++ b/metricbeat/examples/security/Makefile
@@ -6,7 +6,7 @@ RELEASE := helm-metricbeat-security
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-security-metricbeat
 
 install:
-	helm upgrade --wait --timeout=600 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
 
 purge:
 	helm del --purge $(RELEASE)


### PR DESCRIPTION
This commit increase the timeout for helm upgrade commands examples to
avoid timeout error when deploying all example releases in // in helm
test gke cluster.
