### PR TITLE
[elasticsearch] Fix spelling

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -122,7 +122,7 @@ podSecurityPolicy:
 persistence:
   enabled: true
   labels:
-    # Add default labels for the volumeClaimTemplate fo the StatefulSet
+    # Add default labels for the volumeClaimTemplate of the StatefulSet
     enabled: false
   annotations: {}
 


### PR DESCRIPTION
- [x] Fix spelling in `values.yaml`
