### PR TITLE
Helm 3 (#516)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   - [Support Matrix](#support-matrix)
   - [Kubernetes Versions](#kubernetes-versions)
   - [Helm versions](#helm-versions)
-    - [Helm 3 beta](#helm-3-beta)
 - [ECK](#eck)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -76,13 +75,8 @@ exact versions are defined under `KUBERNETES_VERSIONS` in
 ### Helm versions
 
 While we are checking backward compatibility, the charts are only tested with
-Helm version mentioned in [helm-tester Dockerfile][] (currently 2.17.0).
+Helm version mentioned in [helm-tester Dockerfile][] (currently 3.4.1).
 
-#### Helm 3 beta
-
-While we don't have automated tests for [Helm 3][] yet, we fixed the main
-blockers to use it. We now have enough feedbacks from internal and external
-users to add support in beta.
 
 ## ECK
 
@@ -96,7 +90,6 @@ Kubernetes.
 [elastic cloud on kubernetes]: https://github.com/elastic/cloud-on-k8s
 [elastic helm repo]: https://helm.elastic.co
 [github releases]: https://github.com/elastic/helm-charts/releases
-[helm 3]: https://v3.helm.sh
 [helm-tester Dockerfile]: https://github.com/elastic/helm-charts/blob/7.x/helpers/helm-tester/Dockerfile
 [helpers/matrix.yml]: https://github.com/elastic/helm-charts/blob/7.x/helpers/matrix.yml
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -50,8 +50,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name apm-server --version <version> elastic/apm-server`
-  - with [Helm 3 (beta)][]: `helm install apm-server --version <version> elastic/apm-server`
+  - with Helm 3: `helm install apm-server --version <version> elastic/apm-server`
+  - with Helm 2 (deprecated): `helm install --name apm-server --version <version> elastic/apm-server`
 
 
 ### Install development version using 7.x branch and 7.10.0-SNAPSHOT versions
@@ -59,8 +59,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 2: `helm install --name apm-server ./helm-charts/apm-server --set imageTag=7.10.0-SNAPSHOT`
-  - with [Helm 3 (beta)][]: `helm install apm-server ./helm-charts/apm-server --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 3: `helm install apm-server ./helm-charts/apm-server --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 2 (deprecated): `helm install --name apm-server ./helm-charts/apm-server --set imageTag=7.10.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -84,42 +84,42 @@ as a reference. They are also used in the automated testing of this chart.
 
 ## Configuration
 
-| Parameter                | Description                                                                                                                                                | Default                            |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| `affinity`               | Configurable [affinity][]                                                                                                                                  | `{}`                               |
-| `apmConfig`              | Allows you to add any config files in `/usr/share/apm-server/config` such as `apm-server.yml`                                                              | see [values.yaml][]                |
-| `autoscaling`            | Enable the [horizontal pod autoscaler][]                                                                                                                   | `enabled: false`                   |
-| `envFrom`                | Templatable string to be passed to the [environment from variables][] which will be appended to the `envFrom:` definition for the container                | `[]`                               |
-| `extraContainers`        | Templatable string of additional containers to be passed to the `tpl` function                                                                             | `""`                               |
-| `extraEnvs`              | Extra [environment variables][] which will be appended to the `env:` definition for the container                                                          | `[]`                               |
-| `extraInitContainers`    | Templatable string of additional containers to be passed to the `tpl` function                                                                             | `""`                               |
-| `extraVolumeMounts`      | List of additional `volumeMounts`                                                                                                                          | `[]`                               |
-| `extraVolumes`           | List of additional `volumes`                                                                                                                               | `[]`                               |
-| `fullnameOverride`       | Overrides the full name of the resources. If not set the name will default to `.Release.Name` - `.Values.nameOverride` or `.Chart.Name`                    | `""`                               |
-| `imagePullPolicy`        | The Kubernetes [imagePullPolicy][] value                                                                                                                   | `IfNotPresent`                     |
-| `imagePullSecrets`       | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                               | `[]`                               |
-| `imageTag`               | The APM Server Docker image tag                                                                                                                            | `7.10.0-SNAPSHOT`                   |
-| `image`                  | The APM Server Docker image                                                                                                                                | `docker.elastic.co/apm/apm-server` |
-| `ingress`                | Configurable [ingress][] to expose the APM Server service                                                                                                  | see [values.yaml][]                |
-| `labels`                 | Configurable [labels][] applied to all APM server pods                                                                                                     | `{}`                               |
-| `lifecycle`              | Configurable [lifecycle hooks][]                                                                                                                           | `false`                            |
-| `livenessProbe`          | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                 | see [values.yaml][]                |
-| `managedServiceAccount`  | Whether the `serviceAccount` should be managed by this Helm chart. Set this to `false` in order to manage your own service account and related roles       | `true`                             |
-| `nameOverride`           | Overrides the chart name for resources. If not set the name will default to `.Chart.Name`                                                                  | `""`                               |
-| `nodeSelector`           | Configurable [nodeSelector][]                                                                                                                              | `{}`                               |
-| `podAnnotations`         | Configurable [annotations][] applied to all APM Server pods                                                                                                | `{}`                               |
-| `podSecurityContext`     | Configurable [podSecurityContext][] for APM Server pod execution environment                                                                               | see [values.yaml][]                |
-| `priorityClassName`      | The name of the [PriorityClass][]. No default is supplied as the `PriorityClass` must be created first                                                     | `""`                               |
-| `readinessProbe`         | Parameters to pass to readiness [probe][] checks for values such as timeouts and thresholds                                                                | see [values.yaml][]                |
-| `replicas`               | Number of APM servers to run                                                                                                                               | `1`                                |
-| `resources`              | Allows you to set the [resources][] for the `Deployment`                                                                                                   | see [values.yaml][]                |
-| `secretMounts`           | Allows you easily mount a secret as a file inside the `Deployment`. Useful for mounting certificates and other secrets. See [values.yaml][] for an example | `[]`                               |
-| `serviceAccount`         | Custom [serviceAccount][] that APM Server will use during execution. By default will use the `serviceAccount` created by this chart                        | `""`                               |
-| `serviceAccountAnnotations` | Annotations to be added to the ServiceAccount that is created by this chart.                                                                            | `{}`
-| `service`                | Configurable [service][] to expose the APM Server service. See [values.yaml][] for an example                                                              | see [values.yaml][]                |
-| `terminationGracePeriod` | Termination period (in seconds) to wait before killing APM Server pod process on pod shutdown                                                              | `30`                               |
-| `tolerations`            | Configurable [tolerations][]                                                                                                                               | `[]`                               |
-| `updateStrategy`         | Allows you to change the default [updateStrategy][] for the deployment                                                                                     | see [values.yaml][]                |
+| Parameter                   | Description                                                                                                                                                | Default                            |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| `affinity`                  | Configurable [affinity][]                                                                                                                                  | `{}`                               |
+| `apmConfig`                 | Allows you to add any config files in `/usr/share/apm-server/config` such as `apm-server.yml`                                                              | see [values.yaml][]                |
+| `autoscaling`               | Enable the [horizontal pod autoscaler][]                                                                                                                   | `enabled: false`                   |
+| `envFrom`                   | Templatable string to be passed to the [environment from variables][] which will be appended to the `envFrom:` definition for the container                | `[]`                               |
+| `extraContainers`           | Templatable string of additional containers to be passed to the `tpl` function                                                                             | `""`                               |
+| `extraEnvs`                 | Extra [environment variables][] which will be appended to the `env:` definition for the container                                                          | `[]`                               |
+| `extraInitContainers`       | Templatable string of additional containers to be passed to the `tpl` function                                                                             | `""`                               |
+| `extraVolumeMounts`         | List of additional `volumeMounts`                                                                                                                          | `[]`                               |
+| `extraVolumes`              | List of additional `volumes`                                                                                                                               | `[]`                               |
+| `fullnameOverride`          | Overrides the full name of the resources. If not set the name will default to `.Release.Name` - `.Values.nameOverride` or `.Chart.Name`                    | `""`                               |
+| `imagePullPolicy`           | The Kubernetes [imagePullPolicy][] value                                                                                                                   | `IfNotPresent`                     |
+| `imagePullSecrets`          | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                               | `[]`                               |
+| `imageTag`                  | The APM Server Docker image tag                                                                                                                            | `7.10.0-SNAPSHOT`                  |
+| `image`                     | The APM Server Docker image                                                                                                                                | `docker.elastic.co/apm/apm-server` |
+| `ingress`                   | Configurable [ingress][] to expose the APM Server service                                                                                                  | see [values.yaml][]                |
+| `labels`                    | Configurable [labels][] applied to all APM server pods                                                                                                     | `{}`                               |
+| `lifecycle`                 | Configurable [lifecycle hooks][]                                                                                                                           | `false`                            |
+| `livenessProbe`             | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                 | see [values.yaml][]                |
+| `managedServiceAccount`     | Whether the `serviceAccount` should be managed by this Helm chart. Set this to `false` in order to manage your own service account and related roles       | `true`                             |
+| `nameOverride`              | Overrides the chart name for resources. If not set the name will default to `.Chart.Name`                                                                  | `""`                               |
+| `nodeSelector`              | Configurable [nodeSelector][]                                                                                                                              | `{}`                               |
+| `podAnnotations`            | Configurable [annotations][] applied to all APM Server pods                                                                                                | `{}`                               |
+| `podSecurityContext`        | Configurable [podSecurityContext][] for APM Server pod execution environment                                                                               | see [values.yaml][]                |
+| `priorityClassName`         | The name of the [PriorityClass][]. No default is supplied as the `PriorityClass` must be created first                                                     | `""`                               |
+| `readinessProbe`            | Parameters to pass to readiness [probe][] checks for values such as timeouts and thresholds                                                                | see [values.yaml][]                |
+| `replicas`                  | Number of APM servers to run                                                                                                                               | `1`                                |
+| `resources`                 | Allows you to set the [resources][] for the `Deployment`                                                                                                   | see [values.yaml][]                |
+| `secretMounts`              | Allows you easily mount a secret as a file inside the `Deployment`. Useful for mounting certificates and other secrets. See [values.yaml][] for an example | `[]`                               |
+| `serviceAccount`            | Custom [serviceAccount][] that APM Server will use during execution. By default will use the `serviceAccount` created by this chart                        | `""`                               |
+| `serviceAccountAnnotations` | Annotations to be added to the ServiceAccount that is created by this chart.                                                                               | `{}`                               |
+| `service`                   | Configurable [service][] to expose the APM Server service. See [values.yaml][] for an example                                                              | see [values.yaml][]                |
+| `terminationGracePeriod`    | Termination period (in seconds) to wait before killing APM Server pod process on pod shutdown                                                              | `30`                               |
+| `tolerations`               | Configurable [tolerations][]                                                                                                                               | `[]`                               |
+| `updateStrategy`            | Allows you to change the default [updateStrategy][] for the deployment                                                                                     | see [values.yaml][]                |
 
 
 ## FAQ
@@ -161,7 +161,6 @@ about our development and testing process.
 [examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/oss
 [examples/security]: https://github.com/elastic/helm-charts/tree/7.x/apm-server/examples/security
 [helm]: https://helm.sh
-[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [horizontal pod autoscaler]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret

--- a/apm-server/examples/default/Makefile
+++ b/apm-server/examples/default/Makefile
@@ -5,9 +5,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-apm-server-default
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/apm-server/examples/oss/Makefile
+++ b/apm-server/examples/oss/Makefile
@@ -5,9 +5,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-apm-server-oss
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/apm-server/examples/security/Makefile
+++ b/apm-server/examples/security/Makefile
@@ -5,9 +5,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-apm-server-security
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/apm-server/templates/_helpers.tpl
+++ b/apm-server/templates/_helpers.tpl
@@ -23,14 +23,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "apm.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
 {{- define "apm.autoscaling.apiVersion" -}}
-{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.Version -}}
 {{- print "autoscaling/v2beta1" -}}
 {{- else -}}
 {{- print "autoscaling/v2beta2" -}}

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -60,8 +60,9 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name elasticsearch --version <version> elastic/elasticsearch`
-  - with [Helm 3 (beta)][]: `helm install elasticsearch --version <version> elastic/elasticsearch`
+  - with Helm 3: `helm install elasticsearch --version <version> elastic/elasticsearch`
+  - with Helm 2 (deprecated): `helm install --name elasticsearch --version <version> elastic/elasticsearch`
+
 
 
 ### Install development version using 7.x branch and 7.10.0-SNAPSHOT versions
@@ -69,8 +70,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 2: `helm install --name elasticsearch ./helm-charts/elasticsearch --set imageTag=7.10.0-SNAPSHOT`
-  - with [Helm 3 (beta)][]: `helm install elasticsearch ./helm-charts/elasticsearch --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 3: `helm install elasticsearch ./helm-charts/elasticsearch --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 2 (deprecated): `helm install --name elasticsearch ./helm-charts/elasticsearch --set imageTag=7.10.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -126,7 +127,7 @@ support multiple versions with minimal changes.
 | `httpPort`                         | The http port that Kubernetes will use for the healthchecks and the service. If you change this you will also need to set [http.port][] in `extraEnvs`                                                                                                    | `9200`                                          |
 | `imagePullPolicy`                  | The Kubernetes [imagePullPolicy][] value                                                                                                                                                                                                                  | `IfNotPresent`                                  |
 | `imagePullSecrets`                 | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                                                                                              | `[]`                                            |
-| `imageTag`                         | The Elasticsearch Docker image tag                                                                                                                                                                                                                        | `7.10.0-SNAPSHOT`                                |
+| `imageTag`                         | The Elasticsearch Docker image tag                                                                                                                                                                                                                        | `7.10.0-SNAPSHOT`                               |
 | `image`                            | The Elasticsearch Docker image                                                                                                                                                                                                                            | `docker.elastic.co/elasticsearch/elasticsearch` |
 | `ingress`                          | Configurable [ingress][] to expose the Elasticsearch service. See [values.yaml][] for an example                                                                                                                                                          | see [values.yaml][]                             |
 | `initResources`                    | Allows you to set the [resources][] for the `initContainer` in the StatefulSet                                                                                                                                                                            | `{}`                                            |
@@ -158,7 +159,7 @@ support multiple versions with minimal changes.
 | `secretMounts`                     | Allows you easily mount a secret as a file inside the StatefulSet. Useful for mounting certificates and other secrets. See [values.yaml][] for an example                                                                                                 | `[]`                                            |
 | `securityContext`                  | Allows you to set the [securityContext][] for the container                                                                                                                                                                                               | see [values.yaml][]                             |
 | `service.annotations`              | [LoadBalancer annotations][] that Kubernetes will use for the service. This will configure load balancer if `service.type` is `LoadBalancer`                                                                                                              | `{}`                                            |
-| `service.externalTrafficPolicy`              | Some cloud providers allow you to specify the [LoadBalancer externalTrafficPolicy][]. Kubernetes will use this to preserve the client source IP. This will configure load balancer if `service.type` is `LoadBalancer`                                                                                                              | `""`                                            |
+| `service.externalTrafficPolicy`    | Some cloud providers allow you to specify the [LoadBalancer externalTrafficPolicy][]. Kubernetes will use this to preserve the client source IP. This will configure load balancer if `service.type` is `LoadBalancer`                                    | `""`                                            |
 | `service.httpPortName`             | The name of the http port within the service                                                                                                                                                                                                              | `http`                                          |
 | `service.labelsHeadless`           | Labels to be added to headless service                                                                                                                                                                                                                    | `{}`                                            |
 | `service.labels`                   | Labels to be added to non-headless service                                                                                                                                                                                                                | `{}`                                            |
@@ -414,7 +415,6 @@ about our development and testing process.
 [examples/security]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
-[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [helm/charts stable]: https://github.com/helm/charts/tree/master/stable/elasticsearch/
 [how to install plugins guide]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#how-to-install-plugins
 [how to use the keystore]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/README.md#how-to-use-the-keystore

--- a/elasticsearch/examples/config/Makefile
+++ b/elasticsearch/examples/config/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-config
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values ./values.yaml ../../
 
 secrets:
 	kubectl delete secret elastic-config-credentials elastic-config-secret elastic-config-slack elastic-config-custom-path || true
@@ -16,4 +16,4 @@ secrets:
 test: secrets install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/default/Makefile
+++ b/elasticsearch/examples/default/Makefile
@@ -5,12 +5,12 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-default
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=900s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/docker-for-mac/Makefile
+++ b/elasticsearch/examples/docker-for-mac/Makefile
@@ -3,10 +3,10 @@ default: test
 RELEASE := helm-es-docker-for-mac
 
 install:
-	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200s --install --values values.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/kubernetes-kind/Makefile
+++ b/elasticsearch/examples/kubernetes-kind/Makefile
@@ -3,14 +3,14 @@ default: test
 RELEASE := helm-es-kind
 
 install:
-	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200s --install --values values.yaml $(RELEASE) ../../
 
 install-local-path:
 	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
-	helm upgrade --wait --timeout=1200 --install --values values-local-path.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200s --install --values values-local-path.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/microk8s/Makefile
+++ b/elasticsearch/examples/microk8s/Makefile
@@ -3,10 +3,10 @@ default: test
 RELEASE := helm-es-microk8s
 
 install:
-	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200s --install --values values.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/migration/Makefile
+++ b/elasticsearch/examples/migration/Makefile
@@ -1,10 +1,10 @@
 PREFIX := helm-es-migration
 
 data:
-	helm upgrade --wait --timeout=900 --install --values ./data.yml $(PREFIX)-data ../../
+	helm upgrade --wait --timeout=900s --install --values ./data.yml $(PREFIX)-data ../../
 
 master:
-	helm upgrade --wait --timeout=900 --install --values ./master.yml $(PREFIX)-master ../../
+	helm upgrade --wait --timeout=900s --install --values ./master.yml $(PREFIX)-master ../../
 
 client:
-	helm upgrade --wait --timeout=900 --install --values ./client.yml $(PREFIX)-client ../../
+	helm upgrade --wait --timeout=900s --install --values ./client.yml $(PREFIX)-client ../../

--- a/elasticsearch/examples/minikube/Makefile
+++ b/elasticsearch/examples/minikube/Makefile
@@ -3,10 +3,10 @@ default: test
 RELEASE := helm-es-minikube
 
 install:
-	helm upgrade --wait --timeout=1200 --install --values values.yaml $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200s --install --values values.yaml $(RELEASE) ../../
 
 test: install
 	helm test $(RELEASE)
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/multi/Makefile
+++ b/elasticsearch/examples/multi/Makefile
@@ -6,13 +6,13 @@ PREFIX := helm-es-multi
 RELEASE := helm-es-multi-master
 
 install:
-	helm upgrade --wait --timeout=900 --install --values ./master.yml $(PREFIX)-master ../../
-	helm upgrade --wait --timeout=900 --install --values ./data.yml $(PREFIX)-data ../../
-	helm upgrade --wait --timeout=900 --install --values ./client.yml $(PREFIX)-client ../../
+	helm upgrade --wait --timeout=900s --install --values ./master.yml $(PREFIX)-master ../../
+	helm upgrade --wait --timeout=900s --install --values ./data.yml $(PREFIX)-data ../../
+	helm upgrade --wait --timeout=900s --install --values ./client.yml $(PREFIX)-client ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(PREFIX)-master
-	helm del --purge $(PREFIX)-data
-	helm del --purge $(PREFIX)-client
+	helm del $(PREFIX)-master
+	helm del $(PREFIX)-data
+	helm del $(PREFIX)-client

--- a/elasticsearch/examples/openshift/Makefile
+++ b/elasticsearch/examples/openshift/Makefile
@@ -7,9 +7,9 @@ template:
 	helm template --values ./values.yaml ../../
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/oss/Makefile
+++ b/elasticsearch/examples/oss/Makefile
@@ -4,9 +4,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-es-oss
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values ./values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -6,11 +6,11 @@ RELEASE := helm-es-security
 ELASTICSEARCH_IMAGE := docker.elastic.co/elasticsearch/elasticsearch:$(STACK_VERSION)
 
 install:
-	helm upgrade --wait --timeout=900 --install --values ./security.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install --values ./security.yml $(RELEASE) ../../
 
 purge:
 	kubectl delete secrets elastic-credentials elastic-certificates elastic-certificate-pem elastic-certificate-crt|| true
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)
 
 test: secrets install goss
 

--- a/elasticsearch/examples/upgrade/Makefile
+++ b/elasticsearch/examples/upgrade/Makefile
@@ -7,10 +7,7 @@ RELEASE := helm-es-upgrade
 install:
 	./scripts/upgrade.sh --release $(RELEASE)
 
-init:
-	helm init --client-only
-
-test: init install goss
+test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/upgrade/scripts/upgrade.sh
+++ b/elasticsearch/examples/upgrade/scripts/upgrade.sh
@@ -67,10 +67,10 @@ helm repo add elastic https://helm.elastic.co
 
 # Initial install
 printf "Installing Elasticsearch chart %s\n" "$FROM"
-helm upgrade --wait --timeout=600 --install "$RELEASE" elastic/elasticsearch --version "$FROM" --set clusterName=upgrade
+helm upgrade --wait --timeout=600s --install "$RELEASE" elastic/elasticsearch --version "$FROM" --set clusterName=upgrade
 kubectl rollout status sts/upgrade-master --timeout=600s
 
 # Upgrade
 printf "Upgrading Elasticsearch chart\n"
-helm upgrade --wait --timeout=600 --set terminationGracePeriod=121 --install "$RELEASE" ../../ --set clusterName=upgrade
+helm upgrade --wait --timeout=600s --set terminationGracePeriod=121 --install "$RELEASE" ../../ --set clusterName=upgrade
 kubectl rollout status sts/upgrade-master --timeout=600s

--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Watch all cluster members come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "elasticsearch.uname" . }} -w
 2. Test cluster health using Helm test.
-  $ helm test {{ .Release.Name }} --cleanup
+  $ helm test {{ .Release.Name }}

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -68,7 +68,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "elasticsearch.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -79,7 +79,7 @@ Return the appropriate apiVersion for statefulset.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "elasticsearch.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -28,7 +28,6 @@ spec:
       name: {{ template "elasticsearch.uname" . }}
     {{- if .Values.persistence.labels.enabled }}
       labels:
-        heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: "{{ .Chart.Name }}"
         app: "{{ template "elasticsearch.uname" . }}"
@@ -47,7 +46,6 @@ spec:
     metadata:
       name: "{{ template "elasticsearch.uname" . }}"
       labels:
-        heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: "{{ .Chart.Name }}"
         app: "{{ template "elasticsearch.uname" . }}"
@@ -154,7 +152,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if semverCompare ">1.13-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- if semverCompare ">1.13-0" .Capabilities.KubeVersion.Version }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- end }}
       initContainers:

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -492,7 +492,10 @@ persistence:
         "volumeClaimTemplates"
     ][0]["metadata"]["labels"]
     statefulset_labels = r["statefulset"][uname]["metadata"]["labels"]
-    assert volume_claim_template_labels == statefulset_labels
+    expected_labels = statefulset_labels
+    # heritage label shouldn't be present in volumeClaimTemplates labels
+    expected_labels.pop("heritage")
+    assert volume_claim_template_labels == expected_labels
 
 
 def test_adding_a_secret_mount():

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -47,8 +47,9 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name filebeat --version <version> elastic/filebeat`
-  - with [Helm 3 (beta)][]: `helm install filebeat --version <version> elastic/filebeat`
+  - with Helm 3: `helm install filebeat --version <version> elastic/filebeat`
+  - with Helm 2 (deprecated): `helm install --name filebeat --version <version> elastic/filebeat`
+
 
 
 ### Install development version using 7.x branch and 7.10.0-SNAPSHOT versions
@@ -56,8 +57,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 2: `helm install --name filebeat ./helm-charts/filebeat --set imageTag=7.10.0-SNAPSHOT`
-  - with [Helm 3 (beta)][]: `helm install filebeat ./helm-charts/filebeat --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 3: `helm install filebeat ./helm-charts/filebeat --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 2 (deprecated): `helm install --name filebeat ./helm-charts/filebeat --set imageTag=7.10.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -90,40 +91,40 @@ as a reference. They are also used in the automated testing of this chart.
 
 ## Configuration
 
-| Parameter                | Description                                                                                                                                                                     | Default                            |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| `affinity`               | Configurable [affinity][]                                                                                                                                                       | `{}`                               |
-| `envFrom`                | Templatable string of envFrom to be passed to the [environment from variables][] which will be appended to the `envFrom:` definition for the container                          | `[]`                               |
-| `extraContainers`        | List of additional init containers to be added at the DaemonSet                                                                                                                 | `""`                               |
-| `extraEnvs`              | Extra [environment variables][] which will be appended to the `env:` definition for the container                                                                               | `[]`                               |
-| `extraInitContainers`    | List of additional init containers to be added at the DaemonSet. It also accepts a templatable string of additional containers to be passed to the `tpl` function               | `[]`                               |
-| `extraVolumeMounts`      | List of additional volumeMounts to be mounted on the DaemonSet                                                                                                                  | `[]`                               |
-| `extraVolumes`           | List of additional volumes to be mounted on the DaemonSet                                                                                                                       | `[]`                               |
-| `filebeatConfig`         | Allows you to add any config files in `/usr/share/filebeat` such as `filebeat.yml`                                                                                              | see [values.yaml][]                |
-| `fullnameOverride`       | Overrides the full name of the resources. If not set the name will default to " `.Release.Name` - `.Values.nameOverride or .Chart.Name` "                                       | `""`                               |
-| `hostNetworking`         | Use host networking in the DaemonSet so that hostname is reported correctly                                                                                                     | `false`                            |
-| `dnsConfig`              | Configurable [dnsConfig][]                                                                                                                                                      | `{}`                               |
-| `hostPathRoot`           | Fully-qualified [hostPath][] that will be used to persist Filebeat registry data                                                                                                | `/var/lib`                         |
-| `imagePullPolicy`        | The Kubernetes [imagePullPolicy][] value                                                                                                                                        | `IfNotPresent`                     |
-| `imagePullSecrets`       | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                    | `[]`                               |
-| `imageTag`               | The Filebeat Docker image tag                                                                                                                                                   | `7.10.0-SNAPSHOT`                   |
-| `image`                  | The Filebeat Docker image                                                                                                                                                       | `docker.elastic.co/beats/filebeat` |
-| `labels`                 | Configurable [labels][] applied to all Filebeat pods                                                                                                                            | `{}`                               |
-| `livenessProbe`          | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                                      | see [values.yaml][]                |
-| `managedServiceAccount`  | Whether the `serviceAccount` should be managed by this Helm chart. Set this to `false` in order to manage your own service account and related roles                            | `true`                             |
-| `nameOverride`           | Overrides the chart name for resources. If not set the name will default to `.Chart.Name`                                                                                       | `""`                               |
-| `nodeSelector`           | Configurable [nodeSelector][]                                                                                                                                                   | `{}`                               |
-| `podAnnotations`         | Configurable [annotations][] applied to all Filebeat pods                                                                                                                       | `{}`                               |
-| `podSecurityContext`     | Configurable [podSecurityContext][] for Filebeat pod execution environment                                                                                                      | see [values.yaml][]                |
-| `priorityClassName`      | The name of the [PriorityClass][]. No default is supplied as the PriorityClass must be created first                                                                            | `""`                               |
-| `readinessProbe`         | Parameters to pass to readiness [probe][] checks for values such as timeouts and thresholds                                                                                     | see [values.yaml][]                |
-| `resources`              | Allows you to set the [resources][] for the `DaemonSet`                                                                                                                         | see [values.yaml][]                |
-| `secretMounts`           | Allows you easily mount a secret as a file inside the `DaemonSet`. Useful for mounting certificates and other secrets. See [values.yaml][] for an example                       | `[]`                               |
-| `serviceAccount`         | Custom [serviceAccount][] that Filebeat will use during execution. By default will use the service account created by this chart                                                | `""`                               |
-| `serviceAccountAnnotations` | Annotations to be added to the ServiceAccount that is created by this chart.                                                                                                 | `{}`
-| `terminationGracePeriod` | Termination period (in seconds) to wait before killing Filebeat pod process on pod shutdown                                                                                     | `30`                               |
-| `tolerations`            | Configurable [tolerations][]                                                                                                                                                    | `[]`                               |
-| `updateStrategy`         | The [updateStrategy][] for the `DaemonSet`. By default Kubernetes will kill and recreate pods on updates. Setting this to `OnDelete` will require that pods be deleted manually | `RollingUpdate`                    |
+| Parameter                   | Description                                                                                                                                                                     | Default                            |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| `affinity`                  | Configurable [affinity][]                                                                                                                                                       | `{}`                               |
+| `envFrom`                   | Templatable string of envFrom to be passed to the [environment from variables][] which will be appended to the `envFrom:` definition for the container                          | `[]`                               |
+| `extraContainers`           | List of additional init containers to be added at the DaemonSet                                                                                                                 | `""`                               |
+| `extraEnvs`                 | Extra [environment variables][] which will be appended to the `env:` definition for the container                                                                               | `[]`                               |
+| `extraInitContainers`       | List of additional init containers to be added at the DaemonSet. It also accepts a templatable string of additional containers to be passed to the `tpl` function               | `[]`                               |
+| `extraVolumeMounts`         | List of additional volumeMounts to be mounted on the DaemonSet                                                                                                                  | `[]`                               |
+| `extraVolumes`              | List of additional volumes to be mounted on the DaemonSet                                                                                                                       | `[]`                               |
+| `filebeatConfig`            | Allows you to add any config files in `/usr/share/filebeat` such as `filebeat.yml`                                                                                              | see [values.yaml][]                |
+| `fullnameOverride`          | Overrides the full name of the resources. If not set the name will default to " `.Release.Name` - `.Values.nameOverride or .Chart.Name` "                                       | `""`                               |
+| `hostNetworking`            | Use host networking in the DaemonSet so that hostname is reported correctly                                                                                                     | `false`                            |
+| `dnsConfig`                 | Configurable [dnsConfig][]                                                                                                                                                      | `{}`                               |
+| `hostPathRoot`              | Fully-qualified [hostPath][] that will be used to persist Filebeat registry data                                                                                                | `/var/lib`                         |
+| `imagePullPolicy`           | The Kubernetes [imagePullPolicy][] value                                                                                                                                        | `IfNotPresent`                     |
+| `imagePullSecrets`          | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                    | `[]`                               |
+| `imageTag`                  | The Filebeat Docker image tag                                                                                                                                                   | `7.10.0-SNAPSHOT`                  |
+| `image`                     | The Filebeat Docker image                                                                                                                                                       | `docker.elastic.co/beats/filebeat` |
+| `labels`                    | Configurable [labels][] applied to all Filebeat pods                                                                                                                            | `{}`                               |
+| `livenessProbe`             | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                                      | see [values.yaml][]                |
+| `managedServiceAccount`     | Whether the `serviceAccount` should be managed by this Helm chart. Set this to `false` in order to manage your own service account and related roles                            | `true`                             |
+| `nameOverride`              | Overrides the chart name for resources. If not set the name will default to `.Chart.Name`                                                                                       | `""`                               |
+| `nodeSelector`              | Configurable [nodeSelector][]                                                                                                                                                   | `{}`                               |
+| `podAnnotations`            | Configurable [annotations][] applied to all Filebeat pods                                                                                                                       | `{}`                               |
+| `podSecurityContext`        | Configurable [podSecurityContext][] for Filebeat pod execution environment                                                                                                      | see [values.yaml][]                |
+| `priorityClassName`         | The name of the [PriorityClass][]. No default is supplied as the PriorityClass must be created first                                                                            | `""`                               |
+| `readinessProbe`            | Parameters to pass to readiness [probe][] checks for values such as timeouts and thresholds                                                                                     | see [values.yaml][]                |
+| `resources`                 | Allows you to set the [resources][] for the `DaemonSet`                                                                                                                         | see [values.yaml][]                |
+| `secretMounts`              | Allows you easily mount a secret as a file inside the `DaemonSet`. Useful for mounting certificates and other secrets. See [values.yaml][] for an example                       | `[]`                               |
+| `serviceAccount`            | Custom [serviceAccount][] that Filebeat will use during execution. By default will use the service account created by this chart                                                | `""`                               |
+| `serviceAccountAnnotations` | Annotations to be added to the ServiceAccount that is created by this chart.                                                                                                    | `{}`                               |
+| `terminationGracePeriod`    | Termination period (in seconds) to wait before killing Filebeat pod process on pod shutdown                                                                                     | `30`                               |
+| `tolerations`               | Configurable [tolerations][]                                                                                                                                                    | `[]`                               |
+| `updateStrategy`            | The [updateStrategy][] for the `DaemonSet`. By default Kubernetes will kill and recreate pods on updates. Setting this to `OnDelete` will require that pods be deleted manually | `RollingUpdate`                    |
 
 
 ## FAQ
@@ -202,7 +203,6 @@ about our development and testing process.
 [filebeat oss docker image]: https://www.docker.elastic.co/r/beats/filebeat-oss
 [filebeat outputs]: https://www.elastic.co/guide/en/beats/filebeat/7.x/configuring-output.html
 [helm]: https://helm.sh
-[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [dnsConfig]: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath

--- a/filebeat/examples/default/Makefile
+++ b/filebeat/examples/default/Makefile
@@ -5,9 +5,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-filebeat-default
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/filebeat/examples/oss/Makefile
+++ b/filebeat/examples/oss/Makefile
@@ -5,9 +5,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-filebeat-oss
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/filebeat/examples/security/Makefile
+++ b/filebeat/examples/security/Makefile
@@ -5,9 +5,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-filebeat-security
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/helpers/common.mk
+++ b/helpers/common.mk
@@ -13,18 +13,10 @@ build: ## Build helm-tester docker image
 
 .PHONY: deps
 deps: ## Update helm charts dependencies
-	sed --in-place '/charts\//d' ./.helmignore
 	helm dependency update
-
-.PHONY: helm
-helm: ## Deploy helm on k8s cluster
-	kubectl get cs
-	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default || true
-	helm init --wait --upgrade
 
 .PHONY: lint
 lint: ## Lint helm templates
-	grep 'charts/' ./.helmignore || echo 'charts/' >> ./.helmignore
 	helm lint --strict ./
 
 .PHONY: lint-python
@@ -44,4 +36,4 @@ test: build ## Run all tests in a docker container
 	docker run --rm -i --user "$$(id -u):$$(id -g)" -v $$(pwd)/../:/app -w /app/$$(basename $$(pwd)) helm-tester make test-all
 
 .PHONY: test-all ## Run all tests
-test-all: lint deps template pytest
+test-all: deps lint template pytest

--- a/helpers/helm-tester/Dockerfile
+++ b/helpers/helm-tester/Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.7
 
-ENV HELM_VERSION=2.17.0
+ENV HELM_VERSION=3.4.1
 
-RUN wget --no-verbose https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+RUN wget --no-verbose https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     tar xfv helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/ && \
-    rm -rf linux-amd64 && \
-    HOME=/ helm init --client-only && \
-    chmod 777 -R /.helm
+    mkdir --parents --mode=777 /.config/helm && \
+    HOME=/ helm repo add stable https://charts.helm.sh/stable && \
+    rm -rf helm-v${HELM_VERSION}-linux-amd64.tar.gz linux-amd64
 
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt

--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -9,7 +9,7 @@ def helm_template(config):
     with tempfile.NamedTemporaryFile() as temp:
         with open(temp.name, "w") as values:
             values.write(config)
-        helm_cmd = "helm template -f {0} --namespace default ./".format(temp.name)
+        helm_cmd = "helm template release-name -f {0} ./".format(temp.name)
         result = yaml.load_all(check_output(helm_cmd.split()))
 
         results = {}

--- a/helpers/terraform/Dockerfile
+++ b/helpers/terraform/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 ENV VAULT_VERSION 0.9.3
 ENV TERRAFORM_VERSION=0.11.7
 ENV KUBECTL_VERSION=1.16.10
-ENV HELM_VERSION=2.17.0
+ENV HELM_VERSION=3.4.1
 ENV DOCKER_VERSION=18.09.7
 ENV JQ_VERSION=1.6
 
@@ -22,6 +22,7 @@ RUN yum -y install \
 RUN curl -O https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
     unzip vault_${VAULT_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
     chmod +x /usr/local/bin/vault && \
+    rm -f vault_${VAULT_VERSION}_linux_amd64.zip && \
     vault version
 
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
@@ -34,17 +35,17 @@ RUN curl -O https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL
     chmod a+x /usr/local/bin/kubectl && \
     kubectl version --client
 
-RUN curl -O https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+RUN curl -O https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     tar xfv helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/ && \
-    rm -rf linux-amd64 && \
+    rm -rf helm-v${HELM_VERSION}-linux-amd64.tar.gz linux-amd64 && \
     helm version --client
 
 RUN curl -O https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
     tar xfv docker* && \
     mv docker/docker /usr/local/bin && \
-    rm -rf docker/ && \
-    docker
+    rm -rf docker-${DOCKER_VERSION}.tgz docker/ && \
+    docker -v
 
 RUN curl -O -L https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
     mv jq-linux64 /usr/local/bin/jq && \

--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -65,8 +65,8 @@ creds: credentials.json ## Get gke credentials
 	kubectl create namespace $(NAMESPACE) || true
 	kubectl config set-context $$(kubectl config current-context) --namespace=$(NAMESPACE)
 
-.PHONY: k8s
-k8s: apply creds ## Configure gke cluster
+.PHONY: up
+up: apply creds ## Configure gke cluster
 	kubectl get cs
 
 .PHONY: k8s-staging-registry
@@ -77,15 +77,10 @@ k8s-staging-registry: creds ## Create the staging registry auth secret in k8s
 		--docker-username="devops-ci" \
 		--docker-password="$$DOCKER_PASSWORD"
 
-.PHONY: up
-up: k8s ## Install helm on gke cluster
-	kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default || true
-	for i in 1 2 3 4 5; do helm init --wait --upgrade && break || sleep 5; done
-
 .PHONY: integration
 integration: creds ## Deploy helm chart and run integration tests
 	cd ../../$(CHART)/ && \
-	helm init --client-only && \
+	helm repo add stable https://charts.helm.sh/stable && \
 	helm dependency update && \
 	cd ./examples/$(SUITE) && \
 	make
@@ -98,4 +93,3 @@ build: ## Build helm-charts docker image
 pull-private-images: ## Pull private images used in testing
 	cd ../../elasticsearch/examples/security/ && \
 		make pull-elasticsearch-image
-

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -48,8 +48,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name kibana --version <version> elastic/kibana`
-  - with [Helm 3 (beta)][]: `helm install kibana --version <version> elastic/kibana`
+  - with Helm 3: `helm install kibana --version <version> elastic/kibana`
+  - with Helm 2 (deprecated): `helm install --name kibana --version <version> elastic/kibana`
 
 
 ### Install development version using 7.x branch and 7.10.0-SNAPSHOT versions
@@ -57,8 +57,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 2: `helm install --name kibana ./helm-charts/kibana --set imageTag=7.10.0-SNAPSHOT`
-  - with [Helm 3 (beta)][]: `helm install kibana ./helm-charts/kibana --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 3: `helm install kibana ./helm-charts/kibana --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 2 (deprecated): `helm install --name kibana ./helm-charts/kibana --set imageTag=7.10.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -217,7 +217,6 @@ about our development and testing process.
 [examples/security]: https://github.com/elastic/helm-charts/tree/7.x/kibana/examples/security
 [gke]: https://cloud.google.com/kubernetes-engine
 [helm]: https://helm.sh
-[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/kibana/examples/default/Makefile
+++ b/kibana/examples/default/Makefile
@@ -5,9 +5,9 @@ RELEASE := helm-kibana-default
 
 install:
 	echo "Goss container: $(GOSS_CONTAINER)"
-	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/kibana/examples/openshift/Makefile
+++ b/kibana/examples/openshift/Makefile
@@ -7,9 +7,9 @@ template:
 	helm template --values ./values.yml ../../
 
 install:
-	helm upgrade --wait --timeout=900 --install --values ./values.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install --values ./values.yml $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/kibana/examples/oss/Makefile
+++ b/kibana/examples/oss/Makefile
@@ -4,9 +4,9 @@ include ../../../helpers/examples.mk
 RELEASE := helm-kibana-oss
 
 install:
-	helm upgrade --wait --timeout=900 --install --values ./values.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install --values ./values.yml $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/kibana/examples/security/Makefile
+++ b/kibana/examples/security/Makefile
@@ -4,13 +4,13 @@ include ../../../helpers/examples.mk
 RELEASE := helm-kibana-security
 
 install:
-	helm upgrade --wait --timeout=900 --install --values ./security.yml $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install --values ./security.yml $(RELEASE) ../../
 
 test: secrets install goss
 
 purge:
 	kubectl delete secret kibana || true
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)
 
 secrets:
 	encryptionkey=$$(docker run --rm busybox:1.31.1 /bin/sh -c "< /dev/urandom tr -dc _A-Za-z0-9 | head -c50") && \

--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -23,7 +23,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "kibana.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -50,8 +50,9 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name logstash --version <version> elastic/logstash`
-  - with [Helm 3 (beta)][]: `helm install logstash --version <version> elastic/logstash`
+  - with Helm 3: `helm install logstash --version <version> elastic/logstash`
+  - with Helm 2 (deprecated): `helm install --name logstash --version <version> elastic/logstash`
+
 
 
 ### Install development version using 7.x branch and 7.10.0-SNAPSHOT versions
@@ -59,8 +60,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 2: `helm install --name logstash ./helm-charts/logstash --set imageTag=7.10.0-SNAPSHOT`
-  - with [Helm 3 (beta)][]: `helm install logstash ./helm-charts/logstash --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 3: `helm install logstash ./helm-charts/logstash --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 2 (deprecated): `helm install --name logstash ./helm-charts/logstash --set imageTag=7.10.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -116,7 +117,7 @@ useful for the [http input plugin][], for instance.
 | `httpPort`                | The http port that Kubernetes will use for the healthchecks and the service                                                                                                                                                          | `9600`                                |
 | `imagePullPolicy`         | The Kubernetes [imagePullPolicy][] value                                                                                                                                                                                             | `IfNotPresent`                        |
 | `imagePullSecrets`        | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                                                                         | `[]`                                  |
-| `imageTag`                | The Logstash Docker image tag                                                                                                                                                                                                        | `7.9.3-SNAPSHOT`                      |
+| `imageTag`                | The Logstash Docker image tag                                                                                                                                                                                                        | `7.10.0-SNAPSHOT`                     |
 | `image`                   | The Logstash Docker image                                                                                                                                                                                                            | `docker.elastic.co/logstash/logstash` |
 | `labels`                  | Configurable [labels][] applied to all Logstash pods                                                                                                                                                                                 | `{}`                                  |
 | `ingress`                 | Configurable [ingress][] for external access to Logstash HTTP port.                                                                                                                                                                  | see [values.yaml][]                   |
@@ -205,7 +206,6 @@ about our development and testing process.
 [examples]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples
 [examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/logstash/examples/oss
 [helm]: https://helm.sh
-[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [http input plugin]: https://www.elastic.co/guide/en/logstash/current/plugins-inputs-http.html
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret

--- a/logstash/examples/default/Makefile
+++ b/logstash/examples/default/Makefile
@@ -5,12 +5,12 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-default
 
 install:
-	helm upgrade --wait --timeout=1200 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=1200s --install $(RELEASE) ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/logstash/examples/elasticsearch/Makefile
+++ b/logstash/examples/elasticsearch/Makefile
@@ -5,13 +5,13 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-elasticsearch
 
 install:
-	helm upgrade --wait --timeout=1200 --install $(RELEASE) --values ./values.yaml ../../
+	helm upgrade --wait --timeout=1200s --install $(RELEASE) --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)
 	kubectl delete $$(kubectl get pvc -l release=$(RELEASE) -o name)

--- a/logstash/examples/oss/Makefile
+++ b/logstash/examples/oss/Makefile
@@ -5,12 +5,12 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-oss
 
 install:
-	helm upgrade --wait --timeout=1200 --install $(RELEASE)  --values ./values.yaml ../../
+	helm upgrade --wait --timeout=1200s --install $(RELEASE)  --values ./values.yaml ../../
 
 restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200 --install $(RELEASE) ../../
+	helm upgrade --set terminationGracePeriod=121 --wait --timeout=1200s --install $(RELEASE) ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/logstash/examples/security/Makefile
+++ b/logstash/examples/security/Makefile
@@ -5,10 +5,10 @@ include ../../../helpers/examples.mk
 RELEASE := helm-logstash-security
 
 install:
-	helm upgrade --wait --timeout=1200 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=1200s --install $(RELEASE) --values values.yaml ../../
 
 test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)
 	kubectl delete $$(kubectl get pvc -l release=$(RELEASE) -o name)

--- a/logstash/templates/_helpers.tpl
+++ b/logstash/templates/_helpers.tpl
@@ -23,7 +23,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "logstash.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -34,7 +34,7 @@ Return the appropriate apiVersion for statefulset.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "logstash.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/logstash/templates/service.yaml
+++ b/logstash/templates/service.yaml
@@ -16,7 +16,6 @@ spec:
   selector:
     app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   ports:
 {{ toYaml .Values.service.ports | indent 4 }}

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -47,8 +47,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - with Helm 2: `helm install --name metricbeat --version <version> elastic/metricbeat`
-  - with [Helm 3 (beta)][]: `helm install metricbeat --version <version> elastic/metricbeat`
+  - with Helm 3: `helm install metricbeat --version <version> elastic/metricbeat`
+  - with Helm 2 (deprecated): `helm install --name metricbeat --version <version> elastic/metricbeat`
 
 
 ### Install development version using 7.x branch and 7.10.0-SNAPSHOT versions
@@ -56,8 +56,8 @@ This chart is tested with the latest 7.10.0-SNAPSHOT versions.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 2: `helm install --name metricbeat ./helm-charts/metricbeat --set imageTag=7.10.0-SNAPSHOT`
-  - with [Helm 3 (beta)][]: `helm install metricbeat ./helm-charts/metricbeat --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 3: `helm install metricbeat ./helm-charts/metricbeat --set imageTag=7.10.0-SNAPSHOT`
+  - with Helm 2 (deprecated): `helm install --name metricbeat ./helm-charts/metricbeat --set imageTag=7.10.0-SNAPSHOT`
 
 
 ## Upgrading
@@ -125,7 +125,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `hostPathRoot`                 | Fully-qualified [hostPath][] that will be used to persist Metricbeat registry data                                                                                           | `/var/lib`                           |
 | `imagePullPolicy`              | The Kubernetes [imagePullPolicy][] value                                                                                                                                     | `IfNotPresent`                       |
 | `imagePullSecrets`             | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                 | `[]`                                 |
-| `imageTag`                     | The Metricbeat Docker image tag                                                                                                                                              | `7.10.0-SNAPSHOT`                     |
+| `imageTag`                     | The Metricbeat Docker image tag                                                                                                                                              | `7.10.0-SNAPSHOT`                    |
 | `image`                        | The Metricbeat Docker image                                                                                                                                                  | `docker.elastic.co/beats/metricbeat` |
 | `kube_state_metrics.enabled`   | Install [kube-state-metrics](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) as a dependency                                                           | `true`                               |
 | `kube_state_metrics.host`      | Define kube-state-metrics endpoint for an existing deployment. Works only if `kube_state_metrics.enabled: false`                                                             | `""`                                 |
@@ -225,7 +225,6 @@ about our development and testing process.
 [examples/oss]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/oss
 [examples/security]: https://github.com/elastic/helm-charts/tree/7.x/metricbeat/examples/security
 [helm]: https://helm.sh
-[helm 3 (beta)]: https://github.com/elastic/helm-charts/tree/master/README.md#helm-3-beta
 [hostPath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images

--- a/metricbeat/examples/default/Makefile
+++ b/metricbeat/examples/default/Makefile
@@ -6,7 +6,7 @@ RELEASE = helm-metricbeat-default
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-default-metricbeat
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) ../../
 
 test-metrics:
 	 GOSS_FILE=goss-metrics.yaml make goss GOSS_SELECTOR=release=$(RELEASE),app=helm-metricbeat-default-metricbeat-metrics
@@ -14,4 +14,4 @@ test-metrics:
 test: install goss test-metrics
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/metricbeat/examples/oss/Makefile
+++ b/metricbeat/examples/oss/Makefile
@@ -6,10 +6,10 @@ RELEASE := helm-metricbeat-oss
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-oss-metricbeat
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values values.yaml ../../
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)
 
 test-metrics:
 	 GOSS_FILE=goss-metrics.yaml make goss GOSS_SELECTOR=release=$(RELEASE),app=helm-metricbeat-oss-metricbeat-metrics

--- a/metricbeat/examples/security/Makefile
+++ b/metricbeat/examples/security/Makefile
@@ -6,10 +6,10 @@ RELEASE := helm-metricbeat-security
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-security-metricbeat
 
 install:
-	helm upgrade --wait --timeout=900 --install $(RELEASE) --values values.yaml ../../
+	helm upgrade --wait --timeout=900s --install $(RELEASE) --values values.yaml ../../
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)
 
 test-metrics:
 	 GOSS_FILE=goss-metrics.yaml make goss GOSS_SELECTOR=release=$(RELEASE),app=helm-metricbeat-security-metricbeat-metrics

--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
   selector:
     matchLabels:
       app: '{{ template "metricbeat.fullname" . }}-metrics'
-      heritage: '{{ .Release.Service }}'
       release: '{{ .Release.Name }}'
   template:
     metadata:
@@ -45,7 +44,6 @@ spec:
       labels:
         app: '{{ template "metricbeat.fullname" . }}-metrics'
         chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
-        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
         {{- if .Values.deployment.labels }}
         {{- range $key, $value := .Values.deployment.labels }}


### PR DESCRIPTION
* bump helm version to helm 3.4.1
* update doc to make helm 3 the recommended version
* update helm commands arguments for helm 3
* remove helm init and tiller install commands
* add stable repo for metricbeat dependencies
* remove the charts dance in helmignore (related to https://github.com/elastic/helm-charts/pull/127)
* optimize docker images
* replace deprecated gitversion capability (related to https://github.com/helm/helm/pull/5601)
* remove some heritage labels in immutable fields
