### PR TITLE
[elasticsearch] update test hook annotations

### DIFF
--- a/elasticsearch/templates/test/test-elasticsearch-health.yaml
+++ b/elasticsearch/templates/test/test-elasticsearch-health.yaml
@@ -4,7 +4,8 @@ kind: Pod
 metadata:
   name: "{{ .Release.Name }}-{{ randAlpha 5 | lower }}-test"
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   securityContext:
 {{ toYaml .Values.podSecurityContext | indent 4 }}


### PR DESCRIPTION
This commit update Elasticsearch chart test hook annotations for Helm 3
and add a new annotation to automate test pod deletion when test is
successful.

Related to https://github.com/elastic/helm-charts/issues/401#issuecomment-729555952
