### PR TITLE
[6.8] [meta] remove support for k8s <1.14 & helm <2.17.0 (#916)

### DIFF
--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -34,8 +34,8 @@ SLA of official GA features (see [supported configurations][] for more details).
 
 ## Requirements
 
-* Kubernetes >= 1.9
-* [Helm][] >= 2.8.0
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
 
 See [supported configurations][] for more details.
 

--- a/apm-server/templates/_helpers.tpl
+++ b/apm-server/templates/_helpers.tpl
@@ -20,23 +20,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "apm.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-{{- define "apm.autoscaling.apiVersion" -}}
-{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.Version -}}
-{{- print "autoscaling/v2beta1" -}}
-{{- else -}}
-{{- print "autoscaling/v2beta2" -}}
-{{- end -}}
-{{- end -}}
-{{/*
 Use the fullname if the serviceAccount value is not set
 */}}
 {{- define "apm.serviceAccount" -}}

--- a/apm-server/templates/hpa.yaml
+++ b/apm-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: {{ template "apm.autoscaling.apiVersion" . }}
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "apm.fullname" . }}

--- a/apm-server/templates/ingress.yaml
+++ b/apm-server/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "apm.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{ template "apm.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "apm.fullname" . }}

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -41,8 +41,8 @@ This Helm chart is a lightweight way to configure and run our official
 
 ## Requirements
 
-* [Helm][] >=2.8.0 and <3.0.0
-* Kubernetes >=1.8
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
 * Minimum cluster requirements include the following to run this chart with
 default settings. All of these settings are configurable.
   * Three Kubernetes nodes to respect the default "hard" affinity settings

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -55,25 +55,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for statefulset.
-*/}}
-{{- define "elasticsearch.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
-{{- print "apps/v1beta2" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "elasticsearch.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "elasticsearch.uname" . -}}
 {{- $servicePort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{ template "elasticsearch.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "elasticsearch.uname" . }}
@@ -152,9 +152,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if semverCompare ">1.13-0" .Capabilities.KubeVersion.Version }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
-      {{- end }}
       initContainers:
       {{- if .Values.sysctlInitContainer.enabled }}
       - name: configure-sysctl

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -31,8 +31,8 @@ This Helm chart is a lightweight way to configure and run our official
 
 ## Requirements
 
-* [Helm][] >=2.8.0 and <3.0.0
-* Kubernetes >=1.9
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
 
 See [supported configurations][] for more details.
 

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -33,8 +33,8 @@ This Helm chart is a lightweight way to configure and run our official
 
 ## Requirements
 
-* [Helm][] >=2.8.0 and <3.0.0
-* Kubernetes >=1.9
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
 
 See [supported configurations][] for more details.
 

--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -20,17 +20,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "kibana.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Common labels
 */}}
 {{- define "kibana.labels" -}}

--- a/kibana/templates/ingress.yaml
+++ b/kibana/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "kibana.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{ template "kibana.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -34,8 +34,8 @@ SLA of official GA features (see [supported configurations][] for more details).
 
 ## Requirements
 
-* [Helm][] >=2.8.0 and <3.0.0
-* Kubernetes >=1.8
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
 
 See [supported configurations][] for more details.
 

--- a/logstash/templates/_helpers.tpl
+++ b/logstash/templates/_helpers.tpl
@@ -18,25 +18,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for statefulset.
-*/}}
-{{- define "logstash.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
-{{- print "apps/v1beta2" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "logstash.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/logstash/templates/ingress.yaml
+++ b/logstash/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "logstash.fullname" . -}}
-apiVersion: {{ template "logstash.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,6 +28,6 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ .servicePort }}
-        {{- end }}    
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/logstash/templates/statefulset.yaml
+++ b/logstash/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: {{ template "logstash.statefulset.apiVersion" . }}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "logstash.fullname" . }}

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -32,8 +32,8 @@ This Helm chart is a lightweight way to configure and run our official
 
 ## Requirements
 
-* [Helm][] >=2.8.0 and <3.0.0
-* Kubernetes >=1.9
+* Kubernetes >= 1.14
+* [Helm][] >= 2.17.0
 
 See [supported configurations][] for more details.
 


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [meta] remove support for k8s <1.14 & helm <2.17.0 (#916)