### PR TITLE
[meta] remove version from dev install section title

### DIFF
--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -42,7 +42,7 @@ See [supported configurations][] for more details.
 
 ## Installing
 
-This chart is tested with the latest 7.11.0-SNAPSHOT versions.
+This chart is tested with the latest 7.11.0-SNAPSHOT version.
 
 ### Install released version using Helm repository
 
@@ -53,10 +53,11 @@ This chart is tested with the latest 7.11.0-SNAPSHOT versions.
   - with Helm 3: `helm install apm-server --version <version> elastic/apm-server`
   - with Helm 2 (deprecated): `helm install --name apm-server --version <version> elastic/apm-server`
 
-
-### Install development version using 7.x branch and 7.11.0-SNAPSHOT versions
+### Install development version from a branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
+
+* Checkout the branch : `git checkout 7.x`
 
 * Install it:
   - with Helm 3: `helm install apm-server ./helm-charts/apm-server --set imageTag=7.11.0-SNAPSHOT`

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -52,7 +52,7 @@ See [supported configurations][] for more details.
 
 ## Installing
 
-This chart is tested with the latest 7.11.0-SNAPSHOT versions.
+This chart is tested with the latest 7.11.0-SNAPSHOT version.
 
 ### Install released version using Helm repository
 
@@ -63,11 +63,11 @@ This chart is tested with the latest 7.11.0-SNAPSHOT versions.
   - with Helm 3: `helm install elasticsearch --version <version> elastic/elasticsearch`
   - with Helm 2 (deprecated): `helm install --name elasticsearch --version <version> elastic/elasticsearch`
 
-
-
-### Install development version using 7.x branch and 7.11.0-SNAPSHOT versions
+### Install development version from a branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
+
+* Checkout the branch : `git checkout 7.x`
 
 * Install it:
   - with Helm 3: `helm install elasticsearch ./helm-charts/elasticsearch --set imageTag=7.11.0-SNAPSHOT`
@@ -389,7 +389,6 @@ about our development and testing process.
 
 [7.x]: https://github.com/elastic/helm-charts/releases
 [#63]: https://github.com/elastic/helm-charts/issues/63
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/elasticsearch/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -39,7 +39,7 @@ See [supported configurations][] for more details.
 
 ## Installing
 
-This chart is tested with the latest 7.11.0-SNAPSHOT versions.
+This chart is tested with the latest 7.11.0-SNAPSHOT version.
 
 ### Install released version using Helm repository
 
@@ -50,12 +50,11 @@ This chart is tested with the latest 7.11.0-SNAPSHOT versions.
   - with Helm 3: `helm install filebeat --version <version> elastic/filebeat`
   - with Helm 2 (deprecated): `helm install --name filebeat --version <version> elastic/filebeat`
 
-
-
-### Install development version using 7.x branch and 7.11.0-SNAPSHOT versions
+### Install development version from a branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
+* Checkout the branch : `git checkout 7.x`
 * Install it:
   - with Helm 3: `helm install filebeat ./helm-charts/filebeat --set imageTag=7.11.0-SNAPSHOT`
   - with Helm 2 (deprecated): `helm install --name filebeat ./helm-charts/filebeat --set imageTag=7.11.0-SNAPSHOT`
@@ -187,7 +186,6 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 [7.x]: https://github.com/elastic/helm-charts/releases
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/filebeat/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -40,7 +40,7 @@ See [supported configurations][] for more details.
 
 ## Installing
 
-This chart is tested with the latest 7.11.0-SNAPSHOT versions.
+This chart is tested with the latest 7.11.0-SNAPSHOT version.
 
 ### Install released version using Helm repository
 
@@ -51,10 +51,11 @@ This chart is tested with the latest 7.11.0-SNAPSHOT versions.
   - with Helm 3: `helm install kibana --version <version> elastic/kibana`
   - with Helm 2 (deprecated): `helm install --name kibana --version <version> elastic/kibana`
 
-
-### Install development version using 7.x branch and 7.11.0-SNAPSHOT versions
+### Install development version from a branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
+
+* Checkout the branch : `git checkout 7.x`
 
 * Install it:
   - with Helm 3: `helm install kibana ./helm-charts/kibana --set imageTag=7.11.0-SNAPSHOT`
@@ -203,7 +204,6 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 [7.x]: https://github.com/elastic/helm-charts/releases
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/kibana/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -42,7 +42,7 @@ See [supported configurations][] for more details.
 
 ## Installing
 
-This chart is tested with the latest 7.11.0-SNAPSHOT versions.
+This chart is tested with the latest 7.11.0-SNAPSHOT version.
 
 ### Install released version using Helm repository
 
@@ -53,11 +53,11 @@ This chart is tested with the latest 7.11.0-SNAPSHOT versions.
   - with Helm 3: `helm install logstash --version <version> elastic/logstash`
   - with Helm 2 (deprecated): `helm install --name logstash --version <version> elastic/logstash`
 
-
-
-### Install development version using 7.x branch and 7.11.0-SNAPSHOT versions
+### Install development version from a branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
+
+* Checkout the branch : `git checkout 7.x`
 
 * Install it:
   - with Helm 3: `helm install logstash ./helm-charts/logstash --set imageTag=7.11.0-SNAPSHOT`
@@ -192,7 +192,6 @@ Please check [CONTRIBUTING.md][] before any contribution or for any questions
 about our development and testing process.
 
 [7.x]: https://github.com/elastic/helm-charts/releases
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/logstash/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -39,7 +39,7 @@ See [supported configurations][] for more details.
 
 ## Installing
 
-This chart is tested with the latest 7.11.0-SNAPSHOT versions.
+This chart is tested with the latest 7.11.0-SNAPSHOT version.
 
 ### Install released version using Helm repository
 
@@ -50,10 +50,11 @@ This chart is tested with the latest 7.11.0-SNAPSHOT versions.
   - with Helm 3: `helm install metricbeat --version <version> elastic/metricbeat`
   - with Helm 2 (deprecated): `helm install --name metricbeat --version <version> elastic/metricbeat`
 
-
-### Install development version using 7.x branch and 7.11.0-SNAPSHOT versions
+### Install development version from a branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
+
+* Checkout the branch : `git checkout 7.x`
 
 * Install it:
   - with Helm 3: `helm install metricbeat ./helm-charts/metricbeat --set imageTag=7.11.0-SNAPSHOT`
@@ -211,7 +212,6 @@ about our development and testing process.
 
 [7.x]: https://github.com/elastic/helm-charts/releases
 [#471]: https://github.com/elastic/helm-charts/pull/471
-[7.7.1]: https://github.com/elastic/helm-charts/blob/7.7.1/metricbeat/README.md
 [BREAKING_CHANGES.md]: https://github.com/elastic/helm-charts/blob/master/BREAKING_CHANGES.md
 [CHANGELOG.md]: https://github.com/elastic/helm-charts/blob/master/CHANGELOG.md
 [CONTRIBUTING.md]: https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
This commit update charts readme to remove the version from the dev
install section title. This is required to simplify bumping automation
and avoid having to manage toc update.

This was done in 7.9 branch in #831

Also remove an unused link
