### PR TITLE
[7.10] ES Statefulset empty initContainers fix (#795)

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -153,6 +153,7 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- if or (.Values.extraInitContainers) (.Values.sysctlInitContainer.enabled) (.Values.keystore)  }}
       initContainers:
       {{- if .Values.sysctlInitContainer.enabled }}
       - name: configure-sysctl
@@ -210,6 +211,7 @@ spec:
 {{ tpl .Values.extraInitContainers . | indent 6 }}
       {{- else }}
 {{ toYaml .Values.extraInitContainers | indent 6 }}
+      {{- end }}
       {{- end }}
       {{- end }}
       containers:

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -418,10 +418,7 @@ sysctlInitContainer:
   enabled: false
 """
     r = helm_template(config)
-    initContainers = r["statefulset"][uname]["spec"]["template"]["spec"][
-        "initContainers"
-    ]
-    assert initContainers is None
+    assert "initContainers" not in r["statefulset"][uname]["spec"]["template"]["spec"]
 
 
 def test_sysctl_init_container_enabled():


### PR DESCRIPTION
Backports the following commits to 7.10:
 - ES Statefulset empty initContainers fix (#795)