### PR TITLE
[7.x] [meta] enable metricbeat upgrade test (#940)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -26,7 +26,7 @@ METRICBEAT_SUITE:
   - default
   - oss
   - security
-  #- upgrade TODO: uncomment after 7.10.0 release
+  - upgrade
 LOGSTASH_SUITE:
   - default
   - oss

--- a/metricbeat/examples/upgrade/Makefile
+++ b/metricbeat/examples/upgrade/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 
 CHART := metricbeat
 RELEASE := helm-metricbeat-upgrade
-#FROM := 7.10.0	# upgrade from version < 7.10.0 is failing due to selector
+FROM := 7.10.0	# upgrade from version < 7.10.0 is failing due to selector
 								# breaking change in https://github.com/elastic/helm-charts/pull/516
 
 install:
@@ -13,8 +13,7 @@ install:
 	kubectl rollout status deployment $(RELEASE)-metricbeat-metrics
 	kubectl rollout status deployment $(RELEASE)-kube-state-metrics
 
-#TODO: uncomment after 7.10.0 release
-test: #install goss
+test: install goss
 
 purge:
 	helm del $(RELEASE)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [meta] enable metricbeat upgrade test (#940)