### PR TITLE
[7.10] [kibana] add service.httpPortName config in chart (#843)

### DIFF
--- a/kibana/templates/service.yaml
+++ b/kibana/templates/service.yaml
@@ -26,7 +26,7 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.httpPortName | default "http" }}
       targetPort: {{ .Values.httpPort }}
   selector:
     app: {{ .Chart.Name }}

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -629,3 +629,16 @@ def test_adding_loadBalancerIP():
     r = helm_template(config)
 
     assert r["service"][name]["spec"]["loadBalancerIP"] == "12.5.11.79"
+
+
+def test_service_port_name():
+    r = helm_template("")
+
+    config = """
+    service:
+      httpPortName: istio
+    """
+
+    r = helm_template(config)
+
+    assert r["service"][name]["spec"]["ports"][0]["name"] == "istio"

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -107,6 +107,7 @@ service:
     # service.beta.kubernetes.io/cce-load-balancer-internal-vpc: "true"
   loadBalancerSourceRanges: []
     # 0.0.0.0/0
+  httpPortName: http
 
 ingress:
   enabled: false


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [kibana] add service.httpPortName config in chart (#843)