### PR TITLE
Fix - Metricbeat default values - output module config

### DIFF
--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -68,7 +68,7 @@ livenessProbe:
       - |
         #!/usr/bin/env bash -e
         curl --fail 127.0.0.1:5066
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
@@ -81,7 +81,7 @@ readinessProbe:
       - |
         #!/usr/bin/env bash -e
         filebeat test output
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -68,7 +68,7 @@ livenessProbe:
       - |
         #!/usr/bin/env bash -e
         curl --fail 127.0.0.1:5066
-  failureThreshold: 5
+  failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
@@ -81,7 +81,7 @@ readinessProbe:
       - |
         #!/usr/bin/env bash -e
         filebeat test output
-  failureThreshold: 5
+  failureThreshold: 3
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -72,7 +72,7 @@ daemonset:
         - drop_event.when.regexp:
             system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
       output.elasticsearch:
-        hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
+        hosts: '${ELASTICSEARCH_HOSTS}:elasticsearch-master:9200'
   nodeSelector: {}
   # A list of secrets and their paths to mount inside the pod
   # This is useful for mounting certificates for security other sensitive values
@@ -134,7 +134,7 @@ deployment:
         period: 10s
         hosts: ["${KUBE_STATE_METRICS_HOSTS}"]
       output.elasticsearch:
-        hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
+        hosts: '${ELASTICSEARCH_HOSTS}:elasticsearch-master:9200'
   nodeSelector: {}
   # A list of secrets and their paths to mount inside the pod
   # This is useful for mounting certificates for security other sensitive values


### PR DESCRIPTION
I believe there is a typo in the current configuration. The environment variable is meant to be templated as a prefix in the elastic output 'hosts' value string but the lines misplace the closing brace.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes - n/a.
- [ ] Updated template tests in `${CHART}/tests/*.py` - see comment.
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml` - see comment.

I can't quite work out how to run the template tests and haven't tried with the integration ones.

I think the template tests should check that '${ELASTICSEARCH_HOSTS}' is includes in the output config.

I'd imagine you could check that the host value doesn't get applied as "" at runtime. I don't know how this passes testing now because surely the ES output will never work with the default values. 

Maybe I am missing something aha. Please get back to me on if there is any misunderstanding here or any docs so I can help add to the testing in the ways i've described above. 