### PR TITLE
[ElasticSearch Curator]: adding the helm-stable upstream elasticsearch-curator chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ The `master` version of these charts are intended to support the latest pre-rele
 versions of our products, and therefore may or may not work with current released
 versions.
 
-| Chart                                      | Docker documentation                                                            | Latest 7 Version           | Latest 6 Version            |
-|--------------------------------------------|---------------------------------------------------------------------------------|----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.10.0`][apm-7]           | [`6.8.13`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.10.0`][elasticsearch-7] | [`6.8.13`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.10.0`][filebeat-7]      | [`6.8.13`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.10.0`][kibana-7]        | [`6.8.13`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.10.0`][logstash-7]      | [`6.8.13`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.10.0`][metricbeat-7]    | [`6.8.13`][metricbeat-6]    |
+| Chart                                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
+|------------------------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
+| [APM-Server](./apm-server/README.md)                       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.10.0`][apm-7]           | [`6.8.13`][apm-6]           |
+| [Elasticsearch](./elasticsearch/README.md)                 | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.10.0`][elasticsearch-7] | [`6.8.13`][elasticsearch-6] |
+| [Elasticsearch-Curator](./elasticsearch-curator/README.md) |                                                                                 | N/A                         | N/A                         |
+| [Filebeat](./filebeat/README.md)                           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.10.0`][filebeat-7]      | [`6.8.13`][filebeat-6]      |
+| [Kibana](./kibana/README.md)                               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.10.0`][kibana-7]        | [`6.8.13`][kibana-6]        |
+| [Logstash](./logstash/README.md)                           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.10.0`][logstash-7]      | [`6.8.13`][logstash-6]      |
+| [Metricbeat](./metricbeat/README.md)                       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.10.0`][metricbeat-7]    | [`6.8.13`][metricbeat-6]    |
 
 ## Supported Configurations
 

--- a/elasticsearch-curator/Chart.yaml
+++ b/elasticsearch-curator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: "5.7.6"
+description: DEPRECATED A Helm chart for Elasticsearch Curator
+name: elasticsearch-curator
+version: 2.2.3
+home: https://github.com/elastic/curator
+keywords:
+- curator
+- elasticsearch
+- elasticsearch-curator
+sources:
+- https://github.com/kubernetes/charts/elasticsearch-curator
+- https://github.com/pires/docker-elasticsearch-curator
+deprecated: true

--- a/elasticsearch-curator/Chart.yaml
+++ b/elasticsearch-curator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "5.7.6"
-description: DEPRECATED A Helm chart for Elasticsearch Curator
+description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
 version: 2.2.3
 home: https://github.com/elastic/curator
@@ -11,4 +11,3 @@ keywords:
 sources:
 - https://github.com/kubernetes/charts/elasticsearch-curator
 - https://github.com/pires/docker-elasticsearch-curator
-deprecated: true

--- a/elasticsearch-curator/README.md
+++ b/elasticsearch-curator/README.md
@@ -1,0 +1,79 @@
+# Elasticsearch Curator Helm Chart
+
+This directory contains a Kubernetes chart to deploy the [Elasticsearch Curator](https://github.com/elastic/curator).
+
+## Prerequisites Details
+
+* Elasticsearch
+
+* The `elasticsearch-curator` cron job requires [K8s CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) support:
+    > You need a working Kubernetes cluster at version >= 1.8 (for CronJob). For previous versions of cluster (< 1.8) you need to explicitly enable `batch/v2alpha1` API by passing `--runtime-config=batch/v2alpha1=true` to the API server ([see Turn on or off an API version for your cluster for more](https://kubernetes.io/docs/admin/cluster-management/#turn-on-or-off-an-api-version-for-your-cluster)).
+
+## Chart Details
+
+This chart will do the following:
+
+* Create a CronJob which runs the Curator
+
+## Installing the Chart
+
+To install the chart, use the following:
+
+```console
+$ helm install stable/elasticsearch-curator
+```
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### To 2.0.0
+
+v2.0.0 uses docker image from `elasticsearch-curator` author, which differs in its way to install curator.
+
+If you have a hardcoded `command` value, please update it to follow the new `curator` executable path: `/curator/curator` (which is not in PATH).
+
+## Configuration
+
+The following table lists the configurable parameters of the docker-registry chart and
+their default values.
+
+|          Parameter                   |                         Description                         |                   Default                    |
+| :----------------------------------- | :---------------------------------------------------------- | :------------------------------------------- |
+| `image.pullPolicy`                   | Container pull policy                                       | `IfNotPresent`                               |
+| `image.repository`                   | Container image to use                                      | `untergeek/curator`                          |
+| `image.tag`                          | Container image tag to deploy                               | `5.7.6`                                      |
+| `hooks`                              | Whether to run job on selected hooks                        | `{ "install": false, "upgrade": false }`     |
+| `cronjob.schedule`                   | Schedule for the CronJob                                    | `0 1 * * *`                                  |
+| `cronjob.annotations`                | Annotations to add to the cronjob                           | {}                                           |
+| `cronjob.labels`                     | Labels to add to the cronjob                                | {}                                           |
+| `cronjob.concurrencyPolicy`          | `Allow\|Forbid\|Replace` concurrent jobs                    | `nil`                                        |
+| `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep                   | `nil`                                        |
+| `cronjob.successfulJobsHistoryLimit` | Specify the number of completed Jobs to keep                | `nil`                                        |
+| `cronjob.jobRestartPolicy`           | Control the Job restartPolicy                               | `Never`                                      |
+| `cronjob.startingDeadlineSeconds`    | Amount of time to try reschedule job if we can't run on time| `nil`                                         |
+| `pod.annotations`                    | Annotations to add to the pod                               | {}                                           |
+| `pod.labels`                         | Labels to add to the pod                                    | {}                                           |
+| `dryrun`                             | Run Curator in dry-run mode                                 | `false`                                      |
+| `env`                                | Environment variables to add to the cronjob container       | {}                                           |
+| `envFromSecrets`                     | Environment variables from secrets to the cronjob container | {}                                           |
+| `envFromSecrets.*.from.secret`       | - `secretKeyRef.name` used for environment variable         |                                              |
+| `envFromSecrets.*.from.key`          | - `secretKeyRef.key` used for environment variable          |                                              |
+| `command`                            | Command to execute                                          | ["/curator/curator"]                         |
+| `configMaps.action_file_yml`         | Contents of the Curator action_file.yml                     | See values.yaml                              |
+| `configMaps.config_yml`              | Contents of the Curator config.yml (overrides config)       | See values.yaml                              |
+| `resources`                          | Resource requests and limits                                | {}                                           |
+| `priorityClassName`                  | priorityClassName                                           | `nil`                                        |
+| `extraVolumeMounts`                  | Mount extra volume(s),                                      |                                              |
+| `extraVolumes`                       | Extra volumes                                               |                                              |
+| `extraInitContainers`                | Init containers to add to the cronjob container             | {}                                           |
+| `securityContext`                    | Configure PodSecurityContext                                | `false`                                      |
+| `rbac.enabled`                       | Enable RBAC resources                                       | `false`                                      |
+| `psp.create`                         | Create pod security policy resources                        | `false`                                      |
+| `serviceAccount.create`              | Create a default serviceaccount for elasticsearch curator   | `true`                                       |
+| `serviceAccount.name`                | Name for elasticsearch curator serviceaccount               | `""`                                         |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.

--- a/elasticsearch-curator/ci/default-values.yaml
+++ b/elasticsearch-curator/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/elasticsearch-curator/ci/hooks-values.yaml
+++ b/elasticsearch-curator/ci/hooks-values.yaml
@@ -1,0 +1,5 @@
+# Testing hooks are generated properly
+
+hooks:
+  install: true
+  upgrade: true

--- a/elasticsearch-curator/ci/initcontainer-values.yaml
+++ b/elasticsearch-curator/ci/initcontainer-values.yaml
@@ -1,0 +1,9 @@
+extraInitContainers:
+  test:
+    image: alpine:latest
+    command:
+    - "/bin/sh"
+    - "-c"
+    args:
+    - |
+      true

--- a/elasticsearch-curator/templates/NOTES.txt
+++ b/elasticsearch-curator/templates/NOTES.txt
@@ -1,0 +1,6 @@
+A CronJob will run with schedule {{ .Values.cronjob.schedule }}.
+
+The Jobs will not be removed automagically when deleting this Helm chart.
+To remove these jobs, run the following :
+
+    kubectl -n {{ .Release.Namespace }} delete job -l app={{ template "elasticsearch-curator.name" . }},release={{ .Release.Name }}

--- a/elasticsearch-curator/templates/_helpers.tpl
+++ b/elasticsearch-curator/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the appropriate apiVersion for cronjob APIs.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if semverCompare "< 1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v2alpha1" }}
+{{- else if semverCompare ">=1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v1beta1" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for podsecuritypolicy.
+*/}}
+{{- define "podsecuritypolicy.apiVersion" -}}
+{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch-curator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elasticsearch-curator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticsearch-curator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "elasticsearch-curator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "elasticsearch-curator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/elasticsearch-curator/templates/configmap.yaml
+++ b/elasticsearch-curator/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "elasticsearch-curator.fullname" . }}-config
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  action_file.yml: {{ required "A valid .Values.configMaps.action_file_yml entry is required!" (toYaml .Values.configMaps.action_file_yml | indent 2) }}
+  config.yml: {{ required "A valid .Values.configMaps.config_yml entry is required!" (toYaml .Values.configMaps.config_yml | indent 2) }}

--- a/elasticsearch-curator/templates/cronjob.yaml
+++ b/elasticsearch-curator/templates/cronjob.yaml
@@ -1,0 +1,127 @@
+apiVersion: {{ template "cronjob.apiVersion" . }}
+kind: CronJob
+metadata:
+  name: {{ template "elasticsearch-curator.fullname" . }}
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.cronjob.labels }}
+{{ toYaml .Values.cronjob.labels | indent 4 }}
+{{- end }}
+{{- if .Values.cronjob.annotations }}
+  annotations:
+{{ toYaml .Values.cronjob.annotations | indent 4 }}
+{{- end }}
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  {{- with .Values.cronjob.concurrencyPolicy }}
+  concurrencyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end }}
+  jobTemplate:
+    metadata:
+      labels:
+        app: {{ template "elasticsearch-curator.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ template "elasticsearch-curator.name" . }}
+            release: {{ .Release.Name }}
+{{- if .Values.pod.labels }}
+{{ toYaml .Values.pod.labels | indent 12 }}
+{{- end }}
+{{- if .Values.pod.annotations }}
+          annotations:
+{{ toYaml .Values.pod.annotations | indent 12 }}
+{{- end }}
+        spec:
+          volumes:
+            - name: config-volume
+              configMap:
+                name: {{ template "elasticsearch-curator.fullname" . }}-config
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 12 }}
+{{- end }}
+          restartPolicy: {{ .Values.cronjob.jobRestartPolicy }}
+{{- if .Values.priorityClassName }}
+          priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+{{- if .Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ .Values.image.pullSecret }}
+{{- end }}
+{{- if .Values.extraInitContainers }}
+          initContainers:
+{{- range $key, $value := .Values.extraInitContainers }}
+          - name: "{{ $key }}"
+{{ toYaml $value | indent 12 }}
+{{- end }}
+{{- end }}
+        {{- if .Values.rbac.enabled }}
+          serviceAccountName: {{ template "elasticsearch-curator.serviceAccountName" .}}
+        {{- end }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/es-curator
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 16 }}
+{{ end }}
+{{ if .Values.command }}
+              command:
+{{ toYaml .Values.command | indent 16 }}
+{{- end }}
+{{- if .Values.dryrun }}
+              args: [ "--dry-run", "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+{{- else }}
+              args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+{{- end }}
+              env:
+{{- if .Values.envFromSecrets }}
+{{- range $key,$value := .Values.envFromSecrets }}
+              - name: {{ $key | upper | quote}}
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $value.from.secret | quote}}
+                    key: {{ $value.from.key | quote}}
+{{- end }}
+{{- end }}
+{{- if .Values.env }}
+{{- range $key,$value := .Values.env }}
+              - name: {{ $key | upper | quote}}
+                value: {{ $value | quote}}
+{{- end }}
+{{- end }}
+              resources:
+{{ toYaml .Values.resources | indent 16 }}
+    {{- with .Values.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+    {{- end }}

--- a/elasticsearch-curator/templates/hooks/job.install.yaml
+++ b/elasticsearch-curator/templates/hooks/job.install.yaml
@@ -1,0 +1,72 @@
+{{- range $kind, $enabled := .Values.hooks }}
+{{ if $enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "elasticsearch-curator.fullname" $ }}-on-{{ $kind }}
+  labels:
+    app: {{ template "elasticsearch-curator.name" $ }}
+    chart: {{ template "elasticsearch-curator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+  annotations:
+    "helm.sh/hook": post-{{ $kind }}
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- if $.Values.cronjob.annotations }}
+{{ toYaml $.Values.cronjob.annotations | indent 4 }}
+{{- end }}
+spec:
+ template:
+    metadata:
+      labels:
+        app: {{ template "elasticsearch-curator.name" $ }}
+        release: {{ $.Release.Name }}
+{{- if $.Values.pod.annotations }}
+      annotations:
+{{ toYaml $.Values.pod.annotations | indent 8 }}
+{{- end }}
+    spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "elasticsearch-curator.fullname" $ }}-config
+{{- if $.Values.extraVolumes }}
+{{ toYaml $.Values.extraVolumes | indent 8 }}
+{{- end }}
+      restartPolicy: Never
+{{- if $.Values.priorityClassName }}
+      priorityClassName: "{{ $.Values.priorityClassName }}"
+{{- end }}
+      containers:
+        - name: {{ $.Chart.Name }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/es-curator
+    {{- if $.Values.extraVolumeMounts }}
+{{ toYaml $.Values.extraVolumeMounts | indent 12 }}
+    {{- end }}
+{{ if $.Values.command }}
+          command:
+{{ toYaml $.Values.command | indent 12 }}
+{{- end }}
+          args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+          resources:
+{{ toYaml $.Values.resources | indent 12 }}
+    {{- with $.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with $.Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with $.Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end -}}
+{{ end }}

--- a/elasticsearch-curator/templates/psp.yml
+++ b/elasticsearch-curator/templates/psp.yml
@@ -1,0 +1,35 @@
+{{- if .Values.psp.create }}
+apiVersion: {{ template "podsecuritypolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "elasticsearch-curator.fullname" . }}-psp
+spec:
+  privileged: true
+  #requiredDropCapabilities:
+  volumes:
+    - 'configMap'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/elasticsearch-curator/templates/role.yaml
+++ b/elasticsearch-curator/templates/role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.enabled  }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: elasticsearch-curator-configmap
+  name: {{ template "elasticsearch-curator.name" . }}-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["update", "patch"]
+{{- if .Values.psp.create }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames:
+  - {{ template "elasticsearch-curator.fullname" . }}-psp
+{{- end -}}
+{{- end -}}

--- a/elasticsearch-curator/templates/rolebinding.yaml
+++ b/elasticsearch-curator/templates/rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.enabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: elasticsearch-curator-configmap
+  name: {{ template "elasticsearch-curator.name" . }}-rolebinding
+roleRef:
+  kind: Role
+  name: {{ template "elasticsearch-curator.name" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "elasticsearch-curator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+

--- a/elasticsearch-curator/templates/serviceaccount.yaml
+++ b/elasticsearch-curator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serviceAccount.create .Values.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "elasticsearch-curator.serviceAccountName" .}}
+  labels:
+    app: {{ template "elasticsearch-curator.fullname" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}
+

--- a/elasticsearch-curator/values.yaml
+++ b/elasticsearch-curator/values.yaml
@@ -1,0 +1,160 @@
+# Default values for elasticsearch-curator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+cronjob:
+  # At 01:00 every day
+  schedule: "0 1 * * *"
+  annotations: {}
+  labels: {}
+  concurrencyPolicy: ""
+  failedJobsHistoryLimit: ""
+  successfulJobsHistoryLimit: ""
+  jobRestartPolicy: Never
+  startingDeadlineSeconds: ""
+
+pod:
+  annotations: {}
+  labels: {}
+
+rbac:
+  # Specifies whether RBAC should be enabled
+  enabled: false
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+
+psp:
+  # Specifies whether a podsecuritypolicy should be created
+  create: false
+
+image:
+  repository: untergeek/curator
+  tag: 5.7.6
+  pullPolicy: IfNotPresent
+
+hooks:
+  install: false
+  upgrade: false
+
+# run curator in dry-run mode
+dryrun: false
+
+command: ["/curator/curator"]
+env: {}
+
+configMaps:
+  # Delete indices older than 7 days
+  action_file_yml: |-
+    ---
+    actions:
+      1:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y.%m.%d'
+          unit: days
+          unit_count: 7
+          field:
+          stats_result:
+          epoch:
+          exclude: False
+  # Having config_yaml WILL override the other config
+  config_yml: |-
+    ---
+    client:
+      hosts:
+        - CHANGEME.host
+      port: 9200
+      # url_prefix:
+      # use_ssl: True
+      # certificate:
+      # client_cert:
+      # client_key:
+      # ssl_no_validate: True
+      # http_auth:
+      # timeout: 30
+      # master_only: False
+    # logging:
+    #   loglevel: INFO
+    #   logfile:
+    #   logformat: default
+    #   blacklist: ['elasticsearch', 'urllib3']
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+priorityClassName: ""
+
+# extraVolumes and extraVolumeMounts allows you to mount other volumes
+# Example Use Case: mount ssl certificates when elasticsearch has tls enabled
+# extraVolumes:
+#   - name: es-certs
+#     secret:
+#       defaultMode: 420
+#       secretName: es-certs
+# extraVolumeMounts:
+#   - name: es-certs
+#     mountPath: /certs
+#     readOnly: true
+
+# Add your own init container or uncomment and modify the given example.
+extraInitContainers: {}
+  ## Don't configure S3 repository till Elasticsearch is reachable.
+  ## Ensure that it is available at http://elasticsearch:9200
+  ##
+  # elasticsearch-s3-repository:
+  #   image: jwilder/dockerize:latest
+  #   imagePullPolicy: "IfNotPresent"
+  #   command:
+  #   - "/bin/sh"
+  #   - "-c"
+  #   args:
+  #   - |
+  #     ES_HOST=elasticsearch
+  #     ES_PORT=9200
+  #     ES_REPOSITORY=backup
+  #     S3_REGION=us-east-1
+  #     S3_BUCKET=bucket
+  #     S3_BASE_PATH=backup
+  #     S3_COMPRESS=true
+  #     S3_STORAGE_CLASS=standard
+  #     apk add curl --no-cache && \
+  #     dockerize -wait http://${ES_HOST}:${ES_PORT} --timeout 120s && \
+  #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
+  #     {
+  #       "type": "s3",
+  #       "settings": {
+  #         "bucket": "${S3_BUCKET}",
+  #         "base_path": "${S3_BASE_PATH}",
+  #         "region": "${S3_REGION}",
+  #         "compress": "${S3_COMPRESS}",
+  #         "storage_class": "${S3_STORAGE_CLASS}"
+  #       }
+  #     }
+
+securityContext:
+  runAsUser: 16  # run as cron user instead of root


### PR DESCRIPTION
Including the (soon to be deprecated) stable helm elasticsearch-curator chart to this repository. 

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
