### PR TITLE
7.10.1 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 7.10.1
+
+* 7.10.1 as default version.
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#958](https://github.com/elastic/helm-charts/pull/958) | [@jmlrt](https://github.com/jmlrt) | [7.10] [kibana] add service.httpPortName config in chart (#843)  |
+| [#955](https://github.com/elastic/helm-charts/pull/955) | [@jmlrt](https://github.com/jmlrt) | [7.10] [apm-server] Add missing fields to HPA (#782)  |
+| [#950](https://github.com/elastic/helm-charts/pull/950) | [@jmlrt](https://github.com/jmlrt) | [7.10] [meta] enable metricbeat upgrade test (#940)  |
+| [#945](https://github.com/elastic/helm-charts/pull/945) | [@jmlrt](https://github.com/jmlrt) | [7.10] [logstash] add rbac custom annotations (#764)  |
+| [#942](https://github.com/elastic/helm-charts/pull/942) | [@jmlrt](https://github.com/jmlrt) | [7.10] ES Statefulset empty initContainers fix (#795)  |
+| [#932](https://github.com/elastic/helm-charts/pull/932) | [@elasticmachine](https://github.com/elasticmachine) | Bump 7.10 branch to 7.10.1-SNAPSHOT  |
+| [#937](https://github.com/elastic/helm-charts/pull/937) | [@jmlrt](https://github.com/jmlrt) | [7.10] [meta] stabilize CI tests (#935)  |
+
+
 ## 7.10.0
 
 * 7.10.0 as default version.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ versions.
 
 | Chart                                      | Docker documentation                                                            | Latest 7 Version           | Latest 6 Version            |
 |--------------------------------------------|---------------------------------------------------------------------------------|----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.10.0`][apm-7]           | [`6.8.13`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.10.0`][elasticsearch-7] | [`6.8.13`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.10.0`][filebeat-7]      | [`6.8.13`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.10.0`][kibana-7]        | [`6.8.13`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.10.0`][logstash-7]      | [`6.8.13`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.10.0`][metricbeat-7]    | [`6.8.13`][metricbeat-6]    |
+| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.10.1`][apm-7]           | [`6.8.13`][apm-6]           |
+| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.10.1`][elasticsearch-7] | [`6.8.13`][elasticsearch-6] |
+| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.10.1`][filebeat-7]      | [`6.8.13`][filebeat-6]      |
+| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.10.1`][kibana-7]        | [`6.8.13`][kibana-6]        |
+| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.10.1`][logstash-7]      | [`6.8.13`][logstash-6]      |
+| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.10.1`][metricbeat-7]    | [`6.8.13`][metricbeat-6]    |
 
 ## Supported Configurations
 
@@ -98,15 +98,15 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 [helpers/matrix.yml]: https://github.com/elastic/helm-charts/blob/master/helpers/matrix.yml
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
-[apm-7]: https://github.com/elastic/helm-charts/tree/7.10.0/apm-server/README.md
+[apm-7]: https://github.com/elastic/helm-charts/tree/7.10.1/apm-server/README.md
 [apm-6]: https://github.com/elastic/helm-charts/tree/6.8.13/apm-server/README.md
-[elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.10.0/elasticsearch/README.md
+[elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.10.1/elasticsearch/README.md
 [elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.13/elasticsearch/README.md
-[filebeat-7]: https://github.com/elastic/helm-charts/tree/7.10.0/filebeat/README.md
+[filebeat-7]: https://github.com/elastic/helm-charts/tree/7.10.1/filebeat/README.md
 [filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.13/filebeat/README.md
-[kibana-7]: https://github.com/elastic/helm-charts/tree/7.10.0/kibana/README.md
+[kibana-7]: https://github.com/elastic/helm-charts/tree/7.10.1/kibana/README.md
 [kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.13/kibana/README.md
-[logstash-7]: https://github.com/elastic/helm-charts/tree/7.10.0/logstash/README.md
+[logstash-7]: https://github.com/elastic/helm-charts/tree/7.10.1/logstash/README.md
 [logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.13/logstash/README.md
-[metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.10.0/metricbeat/README.md
+[metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.10.1/metricbeat/README.md
 [metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.13/metricbeat/README.md


### PR DESCRIPTION

## 7.10.1

* 7.10.1 as default version.


| PR | Author | Title |
| --- | --- | --- |
| [#958](https://github.com/elastic/helm-charts/pull/958) | [@jmlrt](https://github.com/jmlrt) | [7.10] [kibana] add service.httpPortName config in chart (#843)  |
| [#955](https://github.com/elastic/helm-charts/pull/955) | [@jmlrt](https://github.com/jmlrt) | [7.10] [apm-server] Add missing fields to HPA (#782)  |
| [#950](https://github.com/elastic/helm-charts/pull/950) | [@jmlrt](https://github.com/jmlrt) | [7.10] [meta] enable metricbeat upgrade test (#940)  |
| [#945](https://github.com/elastic/helm-charts/pull/945) | [@jmlrt](https://github.com/jmlrt) | [7.10] [logstash] add rbac custom annotations (#764)  |
| [#942](https://github.com/elastic/helm-charts/pull/942) | [@jmlrt](https://github.com/jmlrt) | [7.10] ES Statefulset empty initContainers fix (#795)  |
| [#932](https://github.com/elastic/helm-charts/pull/932) | [@elasticmachine](https://github.com/elasticmachine) | Bump 7.10 branch to 7.10.1-SNAPSHOT  |
| [#937](https://github.com/elastic/helm-charts/pull/937) | [@jmlrt](https://github.com/jmlrt) | [7.10] [meta] stabilize CI tests (#935)  |

