### PR TITLE
[logtash] use Helm recommended labels

### DIFF
--- a/logstash/templates/_helpers.tpl
+++ b/logstash/templates/_helpers.tpl
@@ -44,6 +44,6 @@ helm.sh/chart: {{ include "logstash.chart" . }}
 Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
 */}}
 {{- define "logstash.matchLabels" -}}
-app.kubernetes.io/name: {{ include "logstash.name" . }}
+app.kubernetes.io/name: {{ include "logstash.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/logstash/templates/_helpers.tpl
+++ b/logstash/templates/_helpers.tpl
@@ -18,3 +18,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "logstash.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "logstash.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "logstash.fullname" . }}
+app.kubernetes.io/version: {{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+helm.sh/chart: {{ include "logstash.chart" . }}
+{{- range $key, $value := .Values.labels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "logstash.matchLabels" -}}
+app.kubernetes.io/name: {{ include "logstash.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/logstash/templates/configmap-config.yaml
+++ b/logstash/templates/configmap-config.yaml
@@ -4,11 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "logstash.fullname" . }}-config
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.logstashConfig }}
   {{ $path }}: |

--- a/logstash/templates/configmap-pipeline.yaml
+++ b/logstash/templates/configmap-pipeline.yaml
@@ -4,11 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "logstash.fullname" . }}-pipeline
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.logstashPipeline }}
   {{ $path }}: |

--- a/logstash/templates/ingress.yaml
+++ b/logstash/templates/ingress.yaml
@@ -4,11 +4,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    app: {{ $fullName | quote}}
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/logstash/templates/poddisruptionbudget.yaml
+++ b/logstash/templates/poddisruptionbudget.yaml
@@ -4,11 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "logstash.fullname" . }}-pdb"
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.maxUnavailable }}
   selector:

--- a/logstash/templates/podsecuritypolicy.yaml
+++ b/logstash/templates/podsecuritypolicy.yaml
@@ -4,11 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 spec:
 {{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
 {{- end -}}

--- a/logstash/templates/role.yaml
+++ b/logstash/templates/role.yaml
@@ -4,11 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $fullName | quote }}
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - extensions

--- a/logstash/templates/rolebinding.yaml
+++ b/logstash/templates/rolebinding.yaml
@@ -4,11 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $fullName | quote }}
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     {{- if eq .Values.rbac.serviceAccountName "" }}

--- a/logstash/templates/secret.yaml
+++ b/logstash/templates/secret.yaml
@@ -6,14 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-%s" $fullName .name | quote }}
-  labels:
-    app: {{ $fullName | quote }}
-    chart: {{ $.Chart.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
-    release: {{ $.Release.Name | quote }}
-    {{- range $key, $value := $.Values.labels }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  labels: {{- include "logstash.labels" $ | nindent 4 }}
 data:
 {{- range $key, $val := .value }}
   {{- if hasSuffix "filepath" $key }}

--- a/logstash/templates/service-headless.yaml
+++ b/logstash/templates/service-headless.yaml
@@ -3,14 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: "{{ template "logstash.fullname" . }}-headless"
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-{{- if .Values.labels }}
-{{ toYaml .Values.labels | indent 4 }}
-{{- end }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   selector:

--- a/logstash/templates/service.yaml
+++ b/logstash/templates/service.yaml
@@ -4,11 +4,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: "{{ template "logstash.fullname" . }}"
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:

--- a/logstash/templates/serviceaccount.yaml
+++ b/logstash/templates/serviceaccount.yaml
@@ -12,11 +12,7 @@ metadata:
     {{- with .Values.rbac.serviceAccountAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
   {{- if .Values.rbac.annotations }}
   annotations:
     {{- range $key, $value := .Values.rbac.annotations }}

--- a/logstash/templates/statefulset.yaml
+++ b/logstash/templates/statefulset.yaml
@@ -3,20 +3,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "logstash.fullname" . }}
-  labels:
-    app: "{{ template "logstash.fullname" . }}"
-    chart: "{{ .Chart.Name }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    {{- range $key, $value := .Values.labels }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  labels: {{- include "logstash.labels" . | nindent 4 }}
 spec:
   serviceName: {{ template "logstash.fullname" . }}-headless
   selector:
-    matchLabels:
-      app: "{{ template "logstash.fullname" . }}"
-      release: {{ .Release.Name | quote }}
+    matchLabels: {{- include "logstash.matchLabels" . | nindent 8 }}
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
@@ -35,14 +26,7 @@ spec:
   template:
     metadata:
       name: "{{ template "logstash.fullname" . }}"
-      labels:
-        app: "{{ template "logstash.fullname" . }}"
-        chart: "{{ .Chart.Name }}"
-        heritage: {{ .Release.Service | quote }}
-        release: {{ .Release.Name | quote }}
-        {{- range $key, $value := .Values.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+      labels: {{- include "logstash.labels" . | nindent 8 }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -88,7 +72,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                 - "{{ template "logstash.fullname" .}}"
@@ -101,7 +85,7 @@ spec:
               topologyKey: {{ .Values.antiAffinityTopologyKey }}
               labelSelector:
                 matchExpressions:
-                - key: app
+                - key: app.kubernetes.io/name
                   operator: In
                   values:
                   - "{{ template "logstash.fullname" . }}"

--- a/logstash/test_values.yaml
+++ b/logstash/test_values.yaml
@@ -1,0 +1,4 @@
+secrets:
+  - name: "env"
+    value:
+      ELASTICSEARCH_PASSWORD: LS1CRUdJTiBgUFJJVkFURSB

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -22,7 +22,7 @@ def test_defaults():
         "podAntiAffinity"
     ]["requiredDuringSchedulingIgnoredDuringExecution"][0] == {
         "labelSelector": {
-            "matchExpressions": [{"key": "app", "operator": "In", "values": [name]}]
+            "matchExpressions": [{"key": "app.kubernetes.io/name", "operator": "In", "values": [name]}]
         },
         "topologyKey": "kubernetes.io/hostname",
     }
@@ -321,7 +321,7 @@ secrets:
     r = helm_template(config)
     secret_name = name + "-env"
     s = r["secret"][secret_name]
-    assert s["metadata"]["labels"]["app"] == name
+    assert s["metadata"]["labels"]["app.kubernetes.io/name"] == name
     assert len(r["secret"]) == 1
     assert len(s["data"]) == 1
     assert s["data"] == {"ELASTICSEARCH_PASSWORD": content_b64}
@@ -362,7 +362,7 @@ secrets:
     r = helm_template(config)
     secret_name = name + "-tls"
     s = r["secret"][secret_name]
-    assert s["metadata"]["labels"]["app"] == name
+    assert s["metadata"]["labels"]["app.kubernetes.io/name"] == name
     assert len(r["secret"]) == 1
     assert len(s["data"]) == 1
     assert s["data"] == {
@@ -397,7 +397,7 @@ secrets:
     r = helm_template(config)
     secret_name = name + "-env"
     s = r["secret"][secret_name]
-    assert s["metadata"]["labels"]["app"] == name
+    assert s["metadata"]["labels"]["app.kubernetes.io/name"] == name
     assert len(r["secret"]) == 1
     assert len(s["data"]) == 2
     assert s["data"] == {


### PR DESCRIPTION
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

**This update labels to Helm recommended format** , according https://helm.sh/docs/chart_best_practices/labels/. I noticed elastic use legacy format when I setup networkPolicy for my elasticsearch cluster.

If this PR is ok, I can work on other elastic products.