### PR TITLE
[7.x] [meta] add config for backport (#971)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,8 @@
+{
+  "upstream": "elastic/helm-charts",
+  "targetBranchChoices": ["6.8", "7.10", "7.x"],
+  "all": true,
+  "prFilter": "label:need-backport",
+  "targetPRLabels": ["backport"],
+  "sourcePRLabels": ["backported"]
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [meta] add config for backport (#971)