### PR TITLE
elasticsearch: add emptyDir to podSecurityPolicy as allowed volume-type

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -118,6 +118,7 @@ podSecurityPolicy:
       - secret
       - configMap
       - persistentVolumeClaim
+      - emptyDir      
 
 persistence:
   enabled: true


### PR DESCRIPTION
When adding custom keystore via `keystore:` for _values.yml_, the initContainer wants to create an emptyDir-based volume as seen [here](https://github.com/elastic/helm-charts/blob/master/elasticsearch/templates/statefulset.yaml#L135).

If you have `podSecurityPolicy.create: true` set at the same time, the current policy does not permit the use of _emptyDir_.

In such a case deployment is then failing:

```
create Pod elasticsearch-master-2 in StatefulSet elasticsearch-master failed error: pods "elasticsearch-master-2" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.volumes[4]: Invalid value: "emptyDir": emptyDir volumes are not allowed to be used
```