### PR TITLE
[6.8] elasticsearch: add emptyDir to podSecurityPolicy as allowed volume-type (#975)

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -116,6 +116,7 @@ podSecurityPolicy:
       - secret
       - configMap
       - persistentVolumeClaim
+      - emptyDir      
 
 persistence:
   enabled: true


### PR DESCRIPTION
Backports the following commits to 6.8:
 - elasticsearch: add emptyDir to podSecurityPolicy as allowed volume-type (#975)