### PR TITLE
[7.x] elasticsearch: add emptyDir to podSecurityPolicy as allowed volume-type (#975)

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -118,6 +118,7 @@ podSecurityPolicy:
       - secret
       - configMap
       - persistentVolumeClaim
+      - emptyDir      
 
 persistence:
   enabled: true


### PR DESCRIPTION
Backports the following commits to 7.x:
 - elasticsearch: add emptyDir to podSecurityPolicy as allowed volume-type (#975)