### PR TITLE
[filebeat][metricbeat] Update documentation on port collisions for multiple beats agents with hostNetworking enabled.

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -221,8 +221,6 @@ readinessProbe:
 ```
 
 
-
-
 ## Contributing
 
 Please check [CONTRIBUTING.md][] before any contribution or for any questions

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -190,6 +190,14 @@ namespace which gives it access to the host loopback device, services listening
 on localhost, could be used to snoop on network activity of other pods on the
 same node.
 
+### How do I get multiple beats agents working with hostNetworking enabled?
+
+The default http port for multiple beats agents may be on the same port, for 
+example, Filebeats and Metricbeats both default to 5066. When `hostNetworking` 
+is enabled this will cause collisions when standing up the http server. The work 
+around for this is to set `http.port` in the config file for one of the beats agent
+to use a different port.
+
 ### How to change readinessProbe for outputs which don't support testing
 
 Some [Filebeat outputs][] like [Kafka output][] don't support testing using
@@ -211,6 +219,8 @@ readinessProbe:
         #!/usr/bin/env bash -e
         curl --fail 127.0.0.1:5066
 ```
+
+
 
 
 ## Contributing

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -204,6 +204,14 @@ namespace which gives it access to the host loopback device, services listening
 on localhost, could be used to snoop on network activity of other pods on the
 same node.
 
+### How do I get multiple beats agents working with hostNetworking enabled?
+
+The default http port for multiple beats agents may be on the same port, for 
+example, Filebeats and Metricbeats both default to 5066. When `hostNetworking` 
+is enabled this will cause collisions when standing up the http server. The work 
+around for this is to set `http.port` in the config file for one of the beats agent
+to use a different port.
+
 
 ## Contributing
 


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Fix #995 