### PR TITLE
master nodes dont need persistence

### DIFF
--- a/elasticsearch/examples/multi/master.yaml
+++ b/elasticsearch/examples/multi/master.yaml
@@ -9,3 +9,6 @@ roles:
   data: "false"
   ml: "false"
   remote_cluster_client: "false"
+
+persistence:
+  enabled: false


### PR DESCRIPTION
Disable data volume for master nodes.

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
