### PR TITLE
[elasticsearch] Make ingress hosts optional

### DIFF
--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -30,8 +30,9 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    {{- if $ingressPath }}
+  {{- if .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
+      {{- if $ingressPath }}
     - host: {{ . }}
       http:
         paths:
@@ -39,9 +40,28 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $httpPort }}
-    {{- else }}
+      {{- else }}
     - host: {{ .host }}
       http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .servicePort | default $httpPort }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- if $ingressPath }}
+    - http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $httpPort }}
+    {{- else }}
+    - http:
         paths:
         {{- range .paths }}
           - path: {{ .path }}

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -690,6 +690,22 @@ ingress:
     assert i["rules"][2]["http"]["paths"][0]["backend"]["servicePort"] == 9999
 
 
+def test_adding_ingress_without_hosts():
+    config = """
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  path: /
+  hosts:
+"""
+
+    r = helm_template(config)
+    assert uname in r["ingress"]
+    i = r["ingress"][uname]["spec"]
+    assert i["rules"][0]["http"]["paths"][0]["path"] == "/"
+
+
 def test_adding_a_deprecated_ingress_rule():
     config = """
 ingress:


### PR DESCRIPTION
This PR allows the ingress hosts definition to be made empty, which is useful for POC situations where we really don't care about hostnames, for example in GKE using an internal loadbalancer with container native loadbalancing:
```
service:
  annotations:
    cloud.google.com/neg: '{"ingress": true}'

ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: "gce-internal"
  path: /
  hosts:
```

Without this PR the chart would generate an ingress without rules given above config, which is not accepted by kubernetes.
With this PR it generates a proper ingress template without a hostname tied to it.

- [ x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ x] README.md updated with any new values or changes
- [x ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
