### PR TITLE
[elasticsearch] fix secrets in config example

### DIFF
--- a/elasticsearch/examples/config/test/goss.yaml
+++ b/elasticsearch/examples/config/test/goss.yaml
@@ -2,6 +2,8 @@ http:
   http://localhost:9200/_cluster/health:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTIC_USERNAME }}"
+    password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - "green"
       - '"number_of_nodes":1'
@@ -10,6 +12,8 @@ http:
   http://localhost:9200:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTIC_USERNAME }}"
+    password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - '"cluster_name" : "config"'
       - "You Know, for Search"

--- a/elasticsearch/examples/config/values.yaml
+++ b/elasticsearch/examples/config/values.yaml
@@ -7,12 +7,12 @@ extraEnvs:
   - name: ELASTIC_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: elastic-credentials
+        name: elastic-config-credentials
         key: password
   - name: ELASTIC_USERNAME
     valueFrom:
       secretKeyRef:
-        name: elastic-credentials
+        name: elastic-config-credentials
         key: username
 
 # This is just a dummy file to make sure that

--- a/elasticsearch/examples/config/values.yaml
+++ b/elasticsearch/examples/config/values.yaml
@@ -20,6 +20,7 @@ extraEnvs:
 # as a custom elasticsearch.yml
 esConfig:
   elasticsearch.yml: |
+    xpack.security.enabled: true
     path.data: /usr/share/elasticsearch/data
 
 keystore:


### PR DESCRIPTION
This commit fix the secret name for credentials in config example

Fix #1008
