### PR TITLE
[meta] fix transient errors with stable repository

### DIFF
--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -80,8 +80,6 @@ k8s-staging-registry: creds ## Create the staging registry auth secret in k8s
 .PHONY: integration
 integration: creds ## Deploy helm chart and run integration tests
 	cd ../../$(CHART)/ && \
-	helm repo add stable https://charts.helm.sh/stable && \
-	helm dependency update && \
 	cd ./examples/$(SUITE) && \
 	make
 

--- a/metricbeat/examples/default/Makefile
+++ b/metricbeat/examples/default/Makefile
@@ -6,6 +6,8 @@ RELEASE = helm-metricbeat-default
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-default-metricbeat
 
 install:
+	helm repo add stable https://charts.helm.sh/stable
+	helm dependency update
 	helm upgrade --wait --timeout=$(TIMEOUT) --install $(RELEASE) ../../
 
 test-metrics:

--- a/metricbeat/examples/default/Makefile
+++ b/metricbeat/examples/default/Makefile
@@ -7,7 +7,7 @@ GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-default-metricbeat
 
 install:
 	helm repo add stable https://charts.helm.sh/stable
-	helm dependency update
+	helm dependency update ../../
 	helm upgrade --wait --timeout=$(TIMEOUT) --install $(RELEASE) ../../
 
 test-metrics:

--- a/metricbeat/examples/oss/Makefile
+++ b/metricbeat/examples/oss/Makefile
@@ -6,6 +6,8 @@ RELEASE := helm-metricbeat-oss
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-oss-metricbeat
 
 install:
+	helm repo add stable https://charts.helm.sh/stable
+	helm dependency update
 	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 
 test-metrics:

--- a/metricbeat/examples/oss/Makefile
+++ b/metricbeat/examples/oss/Makefile
@@ -7,7 +7,7 @@ GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-oss-metricbeat
 
 install:
 	helm repo add stable https://charts.helm.sh/stable
-	helm dependency update
+	helm dependency update ../../
 	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 
 test-metrics:

--- a/metricbeat/examples/security/Makefile
+++ b/metricbeat/examples/security/Makefile
@@ -7,7 +7,7 @@ GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-security-metricbeat
 
 install:
 	helm repo add stable https://charts.helm.sh/stable
-	helm dependency update
+	helm dependency update ../../
 	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 
 test-metrics:

--- a/metricbeat/examples/security/Makefile
+++ b/metricbeat/examples/security/Makefile
@@ -6,6 +6,8 @@ RELEASE := helm-metricbeat-security
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-security-metricbeat
 
 install:
+	helm repo add stable https://charts.helm.sh/stable
+	helm dependency update
 	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 
 test-metrics:

--- a/metricbeat/examples/upgrade/Makefile
+++ b/metricbeat/examples/upgrade/Makefile
@@ -9,7 +9,7 @@ FROM := 7.10.0	# upgrade from version < 7.10.0 is failing due to selector
 
 install:
 	helm repo add stable https://charts.helm.sh/stable
-	helm dependency update
+	helm dependency update ../../
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)
 	kubectl rollout status daemonset $(RELEASE)-metricbeat
 	kubectl rollout status deployment $(RELEASE)-metricbeat-metrics

--- a/metricbeat/examples/upgrade/Makefile
+++ b/metricbeat/examples/upgrade/Makefile
@@ -8,6 +8,8 @@ FROM := 7.10.0	# upgrade from version < 7.10.0 is failing due to selector
 								# breaking change in https://github.com/elastic/helm-charts/pull/516
 
 install:
+	helm repo add stable https://charts.helm.sh/stable
+	helm dependency update
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)
 	kubectl rollout status daemonset $(RELEASE)-metricbeat
 	kubectl rollout status deployment $(RELEASE)-metricbeat-metrics


### PR DESCRIPTION
This commit move stable chart repo setup and dependency update steps to
metricbeat specific examples.

We have lot of transient issues when running configuring stable repo:

```
helm repo add stable https://charts.helm.sh/stable && \
helm dependency update && \
cd ./examples/oss && \
make
Error: looks like "https://charts.helm.sh/stable" is not a valid chart repository or cannot be reached: read tcp 172.17.0.2:37660->185.199.108.153:443: read: connection reset by peer
make: *** [integration] Error 1
```

As stable repo is only used by Metricbeat chart, by not configuring it
for other charts tests, we should limit the risk of transient issues.
