### PR TITLE
[elasticsearch] Add support for single-node clusters

### DIFF
--- a/elasticsearch/examples/single-node/Makefile
+++ b/elasticsearch/examples/single-node/Makefile
@@ -1,0 +1,13 @@
+default: test
+
+RELEASE := helm-es-single-node
+TIMEOUT := 1200s
+
+install:
+	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
+
+test: install
+	helm test $(RELEASE)
+
+purge:
+	helm del $(RELEASE)

--- a/elasticsearch/examples/single-node/README.md
+++ b/elasticsearch/examples/single-node/README.md
@@ -1,0 +1,38 @@
+# Single node
+
+This example deploy a single node Elasticsearch 7.11.0-SNAPSHOT cluster on [Minikube][]
+using [custom values][].
+
+If helm or kubectl timeouts occur, you may consider creating a minikube VM with
+more CPU cores or memory allocated.
+
+Note that this configuration should be used for test only and isn't recommended
+for production.
+
+
+## Requirements
+
+In order to properly support the required persistent volume claims for the
+Elasticsearch StatefulSet, the `default-storageclass` and `storage-provisioner`
+minikube addons must be enabled.
+
+```
+minikube addons enable default-storageclass
+minikube addons enable storage-provisioner
+```
+
+
+## Usage
+
+* Deploy Elasticsearch chart with the default values: `make install`
+
+* You can now setup a port forward to query Elasticsearch API:
+
+  ```
+  kubectl port-forward svc/elasticsearch-master 9200
+  curl localhost:9200/_cat/indices
+  ```
+
+
+[custom values]: https://github.com/elastic/helm-charts/tree/7.x/elasticsearch/examples/minikube/values.yaml
+[minikube]: https://minikube.sigs.k8s.io/docs/

--- a/elasticsearch/examples/single-node/values.yaml
+++ b/elasticsearch/examples/single-node/values.yaml
@@ -1,0 +1,26 @@
+---
+# Enable discovery type of single-node
+singleNode: true
+
+# Permit co-located instances for solitary minikube virtual machines.
+antiAffinity: "soft"
+
+# Shrink default JVM heap.
+esJavaOpts: "-Xmx128m -Xms128m"
+
+# Allocate smaller chunks of memory per pod.
+resources:
+  requests:
+    cpu: "100m"
+    memory: "512M"
+  limits:
+    cpu: "1000m"
+    memory: "512M"
+
+# Request smaller persistent volumes.
+volumeClaimTemplate:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "standard"
+  resources:
+    requests:
+      storage: 100M

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -18,7 +18,11 @@ spec:
   selector:
     matchLabels:
       app: "{{ template "elasticsearch.uname" . }}"
+  {{- if .Values.singleNode }}
+  replicas: 1
+  {{- else }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
@@ -297,8 +301,13 @@ spec:
                 fieldPath: metadata.name
           {{- if eq .Values.roles.master "true" }}
           {{- if ge (int (include "elasticsearch.esMajorVersion" .)) 7 }}
+          {{- if .Values.singleNode }}
+          - name: discovery.type
+            value: "single-node"
+          {{- else }}
           - name: cluster.initial_master_nodes
             value: "{{ template "elasticsearch.endpoints" . }}"
+          {{- end }}
           {{- else }}
           - name: discovery.zen.minimum_master_nodes
             value: "{{ .Values.minimumMasterNodes }}"
@@ -311,8 +320,10 @@ spec:
           - name: discovery.seed_hosts
             value: "{{ template "elasticsearch.masterService" . }}-headless"
           {{- end }}
+          {{- if not .Values.singleNode }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"
+          {{- end }}
           - name: network.host
             value: "{{ .Values.networkHost }}"
           - name: ES_JAVA_OPTS

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -1375,3 +1375,19 @@ hostAliases:
     r = helm_template(config)
     hostAliases = r["statefulset"][uname]["spec"]["template"]["spec"]["hostAliases"]
     assert {"ip": "127.0.0.1", "hostnames": ["foo.local", "bar.local"]} in hostAliases
+
+def test_single_node():
+    ## Make sure we can use a name override
+    config = """
+singleNode: "true"
+"""
+    r = helm_template(config)
+
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][0]["env"]
+
+    assert {
+        "name": "discovery.type",
+        "value": "single-node",
+    } in env
+
+    assert r["statefulset"][uname]["spec"]["replicas"] == 1

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -282,6 +282,9 @@ sysctlInitContainer:
 
 keystore: []
 
+# Enable discovery.type of single-node and disable clustering
+singleNode: false
+
 # Deprecated
 # please use the above podSecurityContext.fsGroup instead
 fsGroup: ""


### PR DESCRIPTION
Enables support for discovery.type single-node and provides examples. While running a large stack locally elasticsearch provisioning multiple containers can take to many resources on a local cluster. This enables single-node and resolves issue #783 

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [X] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
