### PR TITLE
Fixing the respository of kube-state-metrics for metricbeats

### DIFF
--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: 'kube-state-metrics'
-    version: '2.4.1'
-    repository: '@stable'
+    version: '1.2.0'
+    repository: '@bitnami'
     condition: kube_state_metrics.enabled


### PR DESCRIPTION
Kube state metrics that were used in the metric beats charts were pointing towards deprecated helm chart repository "@stable", in order to fix that we needed to point the chart to @bitnami/kube-state-metrics which are stable and compatible with the metric beats deployment.


- [*] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [*] README.md updated with any new values or changes
- [*] Updated template tests in `${CHART}/tests/*.py` 
- [*] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
