### PR TITLE
[metricbeat] Fixing the respository of kube-state-metrics for metricbeats

### DIFF
--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -50,8 +50,7 @@ See [supported configurations][] for more details.
 * Install it:
   - with Helm 3: `helm install metricbeat elastic/metricbeat`
   - with Helm 2 (deprecated): `helm install --name metricbeat elastic/metricbeat`
-
-Note: If you choose to enable `kube-state-metrics` than you should also add the bitnami repostory to your helm3 installation as follows
+  - Add the Elastic Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add stable https://charts.helm.sh/stable`
 
 ```
 helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -48,9 +48,9 @@ See [supported configurations][] for more details.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
+  - Add the Elastic Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add stable https://charts.helm.sh/stable`
   - with Helm 3: `helm install metricbeat elastic/metricbeat`
   - with Helm 2 (deprecated): `helm install --name metricbeat elastic/metricbeat`
-  - Add the Elastic Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add stable https://charts.helm.sh/stable`
 
 ### Install development version using master branch
 

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -51,6 +51,12 @@ See [supported configurations][] for more details.
   - with Helm 3: `helm install metricbeat elastic/metricbeat`
   - with Helm 2 (deprecated): `helm install --name metricbeat elastic/metricbeat`
 
+Note: If you choose to enable `kube-state-metrics` than you should also add the bitnami repostory to your helm3 installation as follows
+
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+```
+For more on @bitnami/kube-state-metrics please goto the charts [readme](https://github.com/bitnami/charts/tree/master/bitnami/kube-state-metrics/)
 
 ### Install development version using master branch
 

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -52,11 +52,6 @@ See [supported configurations][] for more details.
   - with Helm 2 (deprecated): `helm install --name metricbeat elastic/metricbeat`
   - Add the Elastic Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add stable https://charts.helm.sh/stable`
 
-```
-helm repo add bitnami https://charts.bitnami.com/bitnami
-```
-For more on @bitnami/kube-state-metrics please goto the charts [readme](https://github.com/bitnami/charts/tree/master/bitnami/kube-state-metrics/)
-
 ### Install development version using master branch
 
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`

--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: 'kube-state-metrics'
-    version: '1.2.0'
-    repository: '@bitnami'
+    version: '2.4.1'
+    repository: '@stable'
     condition: kube_state_metrics.enabled

--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: 'kube-state-metrics'
-    version: '2.4.1'
-    repository: '@stable'
+    version: '1.2.0'
+    repository: '@bitnami'
     condition: kube_state_metrics.enabled


### PR DESCRIPTION
Kube state metrics that were used in the metricbeat's charts were pointing towards the deprecated helm chart repository i.e "@stable" and in order to fix that we needed to point the chart towards @bitnami/kube-state-metrics which are stable and compatible with the metricbeat's deployment.

Without this small change, the charts are rendered useless since it breaks at the requirements phase.

- [x ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [✔️ ] README.md updated with any new values or changes
- [x ] Updated template tests in `${CHART}/tests/*.py` 
- [x ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
