### PR TITLE
fix: security.yaml is 404

### DIFF
--- a/elasticsearch/examples/security/README.md
+++ b/elasticsearch/examples/security/README.md
@@ -26,4 +26,4 @@ You can also run [goss integration tests][] using `make test`
 
 [goss integration tests]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/security/test/goss.yaml
 [official docs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-tls.html#node-certificates
-[values]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/security/security.yaml
+[values]: https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/security/values.yaml


### PR DESCRIPTION
fix: security.yaml is 404

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
