### PR TITLE
Fix formatting issue in `values.yaml`

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -244,9 +244,8 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
+    - chart-example.local
+  path: /
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
The template looks like this:

```
{{- range .Values.ingress.hosts }}
    {{- if $ingressPath }}
    - host: {{ . }}
      http:
        paths:
          - path: {{ $ingressPath }}
            backend:
              serviceName: {{ $fullName }}
              servicePort: {{ $httpPort }}
```

where `$ingressPath` is `.Values.ingress.path`

This means that following the format in the `values.yaml` doesn't work. Assuming that the template is correct, this is the fix (it works for us)

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
