### PR TITLE
[elasticsearch]: 5.6 compability

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -12,7 +12,7 @@ roles:
   master: "true"
   ingest: "true"
   data: "true"
-  remote_cluster_client: "true"
+# remote_cluster_client: "true" # remote_cluster_client is not availble with elasticsearch 5.6
 # ml: "true" # ml is not availble with elasticsearch-oss
 
 replicas: 3


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

`remote_cluster_client` is not available on es 5.6