### PR TITLE
Reworked the way to mapping node roles. Node roles are mapped as "nod…

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -317,9 +317,17 @@ spec:
             value: "{{ .Values.networkHost }}"
           - name: ES_JAVA_OPTS
             value: "{{ .Values.esJavaOpts }}"
+          # setting node.roles if at least one role enabled
+          {{- $rolesStr := ""}}
           {{- range $role, $enabled := .Values.roles }}
-          - name: node.{{ $role }}
-            value: "{{ $enabled }}"
+          {{- if eq $enabled "true" }}
+            {{- $rolesStr = cat $rolesStr $role}}
+          {{- end }}
+          {{- end }}
+          {{- $rolesStr = trim $rolesStr }}
+          {{- if $rolesStr | empty | not }}
+          - name: node.roles
+            value: "{{ $rolesStr | replace " " "," }}"
           {{- end }}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -318,10 +318,10 @@ spec:
           - name: ES_JAVA_OPTS
             value: "{{ .Values.esJavaOpts }}"
           # setting node.roles if at least one role enabled
-          {{- $rolesStr := ""}}
+          {{- $rolesStr := "" }}
           {{- range $role, $enabled := .Values.roles }}
           {{- if eq $enabled "true" }}
-            {{- $rolesStr = cat $rolesStr $role}}
+            {{- $rolesStr = cat $rolesStr $role }}
           {{- end }}
           {{- end }}
           {{- $rolesStr = trim $rolesStr }}

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -7,11 +7,14 @@ nodeGroup: "master"
 masterService: ""
 
 # Elasticsearch roles that will be applied to this nodeGroup
-# These will be set as environment variables. E.g. node.master=true
+# These will be set as roles environment variable. E.g. node.roles="master,data_hot"
 roles:
   master: "true"
   ingest: "true"
   data: "true"
+  data_hot: "true"
+  data_warm: "true"
+  data_cold: "true"
   remote_cluster_client: "true"
   ml: "true"
 


### PR DESCRIPTION
I had experienced a problem when I tried to set up nodes data tiers through "roles" parameter.
During ElasticSearch pod starting I had the error: "unknown setting [node.data_cold] please check that any required plugins are installed", as well as I found another message caused by the same way to set roles: "[node.master] setting was deprecated in Elasticsearch and will be removed in a future release!"
According to this, I reworked the node roles setting.