### PR TITLE
[elasticsearch] Add volumeClaimTemplate.storageClassName

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -97,6 +97,7 @@ sidecarResources: {}
 networkHost: "0.0.0.0"
 
 volumeClaimTemplate:
+  # storageClassName: ssd
   accessModes: [ "ReadWriteOnce" ]
   resources:
     requests:


### PR DESCRIPTION
default to ssd

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
