### PR TITLE
[6.8] [apm-server] Add  option loadBalancerIP to service (#1075)

### DIFF
--- a/apm-server/templates/service.yaml
+++ b/apm-server/templates/service.yaml
@@ -13,6 +13,13 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml . | indent 4 }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       {{- with .Values.service.nodePort }}

--- a/apm-server/tests/apmserver_test.py
+++ b/apm-server/tests/apmserver_test.py
@@ -26,6 +26,9 @@ def test_defaults():
     assert c["image"].startswith("docker.elastic.co/apm/apm-server:")
     assert c["ports"][0]["containerPort"] == 8200
 
+    # Make sure that the default 'loadBalancerIP' string is empty
+    assert "loadBalancerIP" not in r["service"][name]["spec"]
+
     assert "hostAliases" not in r["deployment"][name]["spec"]["template"]["spec"]
 
 
@@ -376,3 +379,14 @@ hostAliases:
     r = helm_template(config)
     hostAliases = r["deployment"][name]["spec"]["template"]["spec"]["hostAliases"]
     assert {"ip": "127.0.0.1", "hostnames": ["foo.local", "bar.local"]} in hostAliases
+
+
+def test_adding_loadBalancerIP():
+    config = """
+    service:
+      loadBalancerIP: 12.5.11.79
+    """
+
+    r = helm_template(config)
+
+    assert r["service"][name]["spec"]["loadBalancerIP"] == "12.5.11.79"

--- a/apm-server/values.yaml
+++ b/apm-server/values.yaml
@@ -172,6 +172,7 @@ ingress:
 
 service:
   type: ClusterIP
+  loadBalancerIP: ""
   port: 8200
   nodePort: ""
   annotations: {}


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [apm-server] Add  option loadBalancerIP to service (#1075)