### PR TITLE
[filebeat] Add service and deployment ports functionality

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -123,6 +123,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `daemonset.hostAliases`        | Configurable [hostAliases][] for filebeat Deployment                                                                                                                         | `[]`                               |
 | `deployment.filebeatConfig`    | Allows you to add any config files in `/usr/share/filebeat` such as `filebeat.yml` for filebeat Deployment                                                                   | see [values.yaml][]                |
 | `deployment.nodeSelector`      | Configurable [nodeSelector][] for filebeat Deployment                                                                                                                        | `{}`                               |
+| `deployment.ports`             | Ports configuration for the deployment                                                                                                                                       | `[]`                               |
 | `deployment.secretMounts`      | Allows you easily mount a secret as a file inside the Deployment Useful for mounting certificates and other secrets. See [values.yaml][] for an example                      | `[]`                               |
 | `deployment.resources`         | Allows you to set the [resources][] for filebeat Deployment                                                                                                                  | see [values.yaml][]                |
 | `deployment.securityContext`   | Configurable [securityContext][] for filebeat Deployment pod execution environment                                                                                           | see [values.yaml][]                |
@@ -146,6 +147,11 @@ as a reference. They are also used in the automated testing of this chart.
 | `serviceAccountAnnotations`    | Annotations to be added to the ServiceAccount that is created by this chart.                                                                                                 | `{}`                               |
 | `terminationGracePeriod`       | Termination period (in seconds) to wait before killing filebeat pod process on pod shutdown                                                                                  | `30`                               |
 | `updateStrategy`               | The [updateStrategy][] for the DaemonSet By default Kubernetes will kill and recreate pods on updates. Setting this to `OnDelete` will require that pods be deleted manually | `RollingUpdate`                    |
+| `service.enabled`              | If true, enable service                                                 | `false`                            |
+| `service.labels`               | Configurable [labels][] applied to the service                          | `{}`                               |
+| `service.annotations`          | Configurable [annotations][] applied to the service                     | `{}`                               |
+| `service.type`                 | The service type configuration for the service                          | `ClusterIP`                        |
+| `service.ports`                | Ports configuration for the service                                     | `[]`                               |
 
 ### Deprecated
 

--- a/filebeat/templates/deployment.yaml
+++ b/filebeat/templates/deployment.yaml
@@ -112,6 +112,10 @@ spec:
           - "-e"
           - "-E"
           - "http.enabled=true"
+        ports:
+{{- if .Values.deployment.ports }}
+{{ toYaml .Values.deployment.ports | indent 10 }}
+{{- end }}
         livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:

--- a/filebeat/templates/service.yaml
+++ b/filebeat/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: "{{ template "filebeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4}}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "filebeat.fullname" . }}"
+  ports:
+{{ toYaml .Values.service.ports | indent 4 }}
+{{- end }}

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -100,6 +100,8 @@ deployment:
         host: '${NODE_NAME}'
         hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
   nodeSelector: {}
+  # Ports configuration for the filebeat container
+  ports: []
   # A list of secrets and their paths to mount inside the pod
   # This is useful for mounting certificates for security other sensitive values
   secretMounts: []
@@ -214,6 +216,13 @@ updateStrategy: RollingUpdate
 # Only edit these if you know what you're doing
 nameOverride: ""
 fullnameOverride: ""
+
+service:
+  enabled: false
+  labels: {}
+  annotations: {}
+  type: ClusterIP
+  ports: []
 
 # DEPRECATED
 affinity: {}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Adds ports configuration possibilty for filebeat deployments and also an optional servcie. Use case: Running filebeat with e.g. the checkpoint module and sending external UDP syslog traffic via nodeport service.