### PR TITLE
[elasticsearch] Add namespace to helm test command in NOTES.txt

### DIFF
--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Watch all cluster members come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "elasticsearch.uname" . }} -w
 2. Test cluster health using Helm test.
-  $ helm test {{ .Release.Name }}
+  $ helm --namespace={{ .Release.Namespace }} test {{ .Release.Name }}


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Helm chart NOTES.txt was missing namespace in the test section:
before change:
```NAME: elasticsearch
LAST DEPLOYED: Mon Mar 15 21:24:35 2021
NAMESPACE: elk
STATUS: deployed
REVISION: 1
NOTES:
1. Watch all cluster members come up.
  $ kubectl get pods --namespace=elk -l app=elasticsearch-master -w
2. Test cluster health using Helm test.
  $ helm test elasticsearch
```

after change:

```LAST DEPLOYED: Mon Mar 15 21:25:59 2021
NAMESPACE: elk
STATUS: deployed
REVISION: 1
NOTES:
1. Watch all cluster members come up.
  $ kubectl get pods --namespace=elk -l app=elasticsearch-master -w
2. Test cluster health using Helm test.
  $ helm --namespace=elk test elasticsearch
```