### PR TITLE
6.8.15 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 6.8.15
+
+* 6.8.15 as default version.
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#1092](https://github.com/elastic/helm-charts/pull/1092) | [@jmlrt](https://github.com/jmlrt) | [6.8] [apm-server] Add  option loadBalancerIP to service (#1075)  |
+| [#1080](https://github.com/elastic/helm-charts/pull/1080) | [@jmlrt](https://github.com/jmlrt) | [6.8] [meta] bump helm support to 3.5.2 (#1065)  |
+| [#952](https://github.com/elastic/helm-charts/pull/952) | [@jmlrt](https://github.com/jmlrt) | [6.8] [meta] enable filebeat and metricbeat upgrade test  |
+| [#1077](https://github.com/elastic/helm-charts/pull/1077) | [@jmlrt](https://github.com/jmlrt) | [6.8] [logstash] Add support to use pattern files (#883)  |
+| [#1068](https://github.com/elastic/helm-charts/pull/1068) | [@elasticmachine](https://github.com/elasticmachine) | Bump 6.8 branch to 6.8.15-SNAPSHOT  |
+
+
 ## 7.11.2
 
 * 7.11.2 as default version.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ versions.
 
 | Chart                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
 |--------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.11.2`][apm-7]           | [`6.8.14`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.11.2`][elasticsearch-7] | [`6.8.14`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.11.2`][filebeat-7]      | [`6.8.14`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.11.2`][kibana-7]        | [`6.8.14`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.11.2`][logstash-7]      | [`6.8.14`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.11.2`][metricbeat-7]    | [`6.8.14`][metricbeat-6]    |
+| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.11.2`][apm-7]           | [`6.8.15`][apm-6]           |
+| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.11.2`][elasticsearch-7] | [`6.8.15`][elasticsearch-6] |
+| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.11.2`][filebeat-7]      | [`6.8.15`][filebeat-6]      |
+| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.11.2`][kibana-7]        | [`6.8.15`][kibana-6]        |
+| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.11.2`][logstash-7]      | [`6.8.15`][logstash-6]      |
+| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.11.2`][metricbeat-7]    | [`6.8.15`][metricbeat-6]    |
 
 ## Supported Configurations
 
@@ -101,14 +101,14 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 [apm-7]: https://github.com/elastic/helm-charts/tree/7.11.2/apm-server/README.md
-[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.14/apm-server/README.md
+[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.15/apm-server/README.md
 [elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.11.2/elasticsearch/README.md
-[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.14/elasticsearch/README.md
+[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.15/elasticsearch/README.md
 [filebeat-7]: https://github.com/elastic/helm-charts/tree/7.11.2/filebeat/README.md
-[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.14/filebeat/README.md
+[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.15/filebeat/README.md
 [kibana-7]: https://github.com/elastic/helm-charts/tree/7.11.2/kibana/README.md
-[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.14/kibana/README.md
+[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.15/kibana/README.md
 [logstash-7]: https://github.com/elastic/helm-charts/tree/7.11.2/logstash/README.md
-[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.14/logstash/README.md
+[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.15/logstash/README.md
 [metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.11.2/metricbeat/README.md
-[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.14/metricbeat/README.md
+[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.15/metricbeat/README.md


### PR DESCRIPTION

## 6.8.15

* 6.8.15 as default version.


| PR | Author | Title |
| --- | --- | --- |
| [#1092](https://github.com/elastic/helm-charts/pull/1092) | [@jmlrt](https://github.com/jmlrt) | [6.8] [apm-server] Add  option loadBalancerIP to service (#1075)  |
| [#1080](https://github.com/elastic/helm-charts/pull/1080) | [@jmlrt](https://github.com/jmlrt) | [6.8] [meta] bump helm support to 3.5.2 (#1065)  |
| [#952](https://github.com/elastic/helm-charts/pull/952) | [@jmlrt](https://github.com/jmlrt) | [6.8] [meta] enable filebeat and metricbeat upgrade test  |
| [#1077](https://github.com/elastic/helm-charts/pull/1077) | [@jmlrt](https://github.com/jmlrt) | [6.8] [logstash] Add support to use pattern files (#883)  |
| [#1068](https://github.com/elastic/helm-charts/pull/1068) | [@elasticmachine](https://github.com/elasticmachine) | Bump 6.8 branch to 6.8.15-SNAPSHOT  |

