### PR TITLE
Remove slack notification

### DIFF
--- a/.ci/jobs/elastic+helm-charts+master.yml
+++ b/.ci/jobs/elastic+helm-charts+master.yml
@@ -46,10 +46,3 @@
       - project: elastic+helm-charts+master+cluster-cleanup
         current-parameters: true
         trigger-with-no-params: false
-    - slack:
-        notify-back-to-normal: True
-        notify-every-failure: True
-        room: infra-release-notify
-        team-domain: elastic
-        auth-token-id: release-slack-integration-token
-        auth-token-credential-id: release-slack-integration-token


### PR DESCRIPTION
Remove the CI slack notification, these tests are too flaky and create a
lot of non-actionable noise in this notification room.

- ~[ ] Chart version *not* bumped (the versions are all bumped and released at the same time)~
- ~[ ] README.md updated with any new values or changes~
- ~[ ] Updated template tests in `${CHART}/tests/*.py`~
- ~[ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`~
