### PR TITLE
[elasticsearch] Add first class support for authentication

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -110,6 +110,12 @@ support multiple versions with minimal changes.
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
 | `antiAffinityTopologyKey`          | The [anti-affinity][] topology key. By default this will prevent multiple Elasticsearch nodes from running on the same Kubernetes node                                                                                                                                                                            | `kubernetes.io/hostname`                         |
 | `antiAffinity`                     | Setting this to hard enforces the [anti-affinity][] rules. If it is set to soft it will be done "best effort". Other values will be ignored                                                                                                                                                                       | `hard`                                           |
+| `auth.enabled`                     | Enable authentication                                                                                                                                                                                                                                                                                             | `false`                                          |
+| `auth.password`                    | Configure the authentication password                                                                                                                                                                                                                                                                             | `""`                                             |
+| `auth.username`                    | Configure the authentication username                                                                                                                                                                                                                                                                             | `elastic`                                        |
+| `auth.existingSecret`              | Configure the authentication password using an existing secret                                                                                                                                                                                                                                                    | `{}`                                             |
+| `auth.existingSecret.name`         | Set the name of the secret providing the authentication password                                                                                                                                                                                                                                                  | `""`                                             |
+| `auth.existingSecret.key`          | Set the key of the secret providing the authentication password                                                                                                                                                                                                                                                   | `""`                                             |
 | `clusterHealthCheckParams`         | The [Elasticsearch cluster health status params][] that will be used by readiness [probe][] command                                                                                                                                                                                                               | `wait_for_status=green&timeout=1s`               |
 | `clusterName`                      | This will be used as the Elasticsearch [cluster.name][] and should be unique per cluster in the namespace                                                                                                                                                                                                         | `elasticsearch`                                  |
 | `enableServiceLinks`               | Set to false to disabling service links, which can cause slow pod startup times when there are many services in the current namespace.                                                                                                                                                                            | `true`                                           |
@@ -260,12 +266,19 @@ sufficient.
 
 ### How to deploy clusters with security (authentication and TLS) enabled?
 
-This Helm chart can use existing [Kubernetes secrets][] to setup
-credentials or certificates for examples. These secrets should be created
-outside of this chart and accessed using [environment variables][] and volumes.
-
 An example of Elasticsearch cluster using security can be found in
 [examples/security][].
+
+#### Authentication
+
+Enable authentication for the cluster using the `auth.enabled` value.
+See the [Configuration](#configuration) section for more details on how to configure authentication.
+
+#### TLS
+
+This Helm chart can use existing [Kubernetes secrets][] to setup
+certificates for examples. These secrets should be created
+outside of this chart and accessed using volumes.
 
 ### How to migrate from helm/charts stable chart?
 

--- a/elasticsearch/examples/security/Makefile
+++ b/elasticsearch/examples/security/Makefile
@@ -34,5 +34,5 @@ secrets:
 	kubectl create secret generic elastic-certificates --from-file=elastic-certificates.p12 && \
 	kubectl create secret generic elastic-certificate-pem --from-file=elastic-certificate.pem && \
 	kubectl create secret generic elastic-certificate-crt --from-file=elastic-certificate.crt && \
-	kubectl create secret generic elastic-credentials --from-literal=password=$$password --from-literal=username=elastic && \
+	kubectl create secret generic elastic-credentials --from-literal=password=$$password && \
 	rm -f elastic-certificates.p12 elastic-certificate.pem elastic-certificate.crt elastic-stack-ca.p12

--- a/elasticsearch/examples/security/values.yaml
+++ b/elasticsearch/examples/security/values.yaml
@@ -20,17 +20,11 @@ esConfig:
     xpack.security.http.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
     xpack.security.http.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
 
-extraEnvs:
-  - name: ELASTIC_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: elastic-credentials
-        key: password
-  - name: ELASTIC_USERNAME
-    valueFrom:
-      secretKeyRef:
-        name: elastic-credentials
-        key: username
+auth:
+  enabled: true
+  existingSecret:
+    name: elastic-credentials
+    key: password
 
 secretMounts:
   - name: elastic-certificates

--- a/elasticsearch/templates/secret.yaml
+++ b/elasticsearch/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+data:
+  {{- if .Values.auth.password }}
+  elastic-password: {{ .Values.auth.password | b64enc | quote }}
+  {{- else }}
+  elastic-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- end }}
+{{- end -}}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -316,6 +316,15 @@ spec:
           - name: ES_JAVA_OPTS
             value: "{{ .Values.esJavaOpts }}"
           {{- end }}
+          {{- if .Values.auth.enabled }}
+          - name: ELASTIC_USERNAME
+            value: {{ required "Username cannot be empty!" .Values.auth.username }}
+          - name: ELASTIC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ ternary (include "elasticsearch.uname" .) .Values.auth.existingSecret.name (empty .Values.auth.existingSecret) }}
+                key: {{ ternary "elastic-password" .Values.auth.existingSecret.key (empty .Values.auth.existingSecret) }}
+          {{- end }}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}
 {{- end }}

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -35,6 +35,15 @@ esConfig: {}
 #  log4j2.properties: |
 #    key = value
 
+# Configure auth and credentials
+auth:
+  enabled: false
+  username: elastic
+  password: ""
+  existingSecret: {}
+#    name: secretName
+#    key: secretKeyForPassword
+
 # Extra environment variables to append to this nodeGroup
 # This will be appended to the current 'env:' key. You can use any of the kubernetes env
 # syntax here


### PR DESCRIPTION
In order to support easier integration with clients, the helm chart now generates a secret based on values that are configured in the values.yaml file. Clients can be configured with a reference to this secret to obtain connection credentials.

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [X] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
