### PR TITLE
[apm-server] fix service could not bind to pod

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -14,12 +14,12 @@ spec:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   selector:
     matchLabels:
-      app: apm-server
+      app: {{ .Chart.Name }}
       release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        app: apm-server
+        app: {{ .Chart.Name }}
         release: {{ .Release.Name | quote }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}


### PR DESCRIPTION
Fix https://github.com/elastic/helm-charts/issues/1138

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
