### PR TITLE
[7.12] [meta] add tests for k8s 1.18 and remove 1.15 (#1141)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -38,6 +38,6 @@ APM_SERVER_SUITE:
   - security
   - upgrade
 KUBERNETES_VERSION:
-  - "1.15"
   - "1.16"
   - "1.17"
+  - "1.18"

--- a/helpers/terraform/Makefile
+++ b/helpers/terraform/Makefile
@@ -1,6 +1,6 @@
 GOOGLE_PROJECT := elastic-ci-prod
 CLUSTER_NAME := helm-elasticsearch-test
-KUBERNETES_VERSION := 1.15
+KUBERNETES_VERSION := 1.16
 CHART := elasticsearch
 SUITE := default
 NAMESPACE := helm-charts-testing


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [meta] add tests for k8s 1.18 and remove 1.15 (#1141)