### PR TITLE
[7.12] Bump py from 1.8.0 to 1.10.0 in /helpers/helm-tester (#1154)

### DIFF
--- a/helpers/helm-tester/requirements.txt
+++ b/helpers/helm-tester/requirements.txt
@@ -3,7 +3,7 @@ attrs==19.1.0
 importlib-metadata==0.23
 more-itertools==7.2.0
 pluggy==0.13.0
-py==1.8.0
+py==1.10.0
 pytest==4.1.0
 PyYAML==5.4
 six==1.12.0


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Bump py from 1.8.0 to 1.10.0 in /helpers/helm-tester (#1154)