### PR TITLE
[7.12] Bump py from 1.8.0 to 1.10.0 (#1155)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ black==19.10b0
 importlib-metadata==0.23
 more-itertools==7.2.0
 pluggy==0.13.0
-py==1.8.0
+py==1.10.0
 pytest==4.1.0
 PyYAML==5.4
 six==1.12.0


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Bump py from 1.8.0 to 1.10.0 (#1155)