### PR TITLE
[7.x][logstash] Add option loadBalancerIP to service (#1099)

### DIFF
--- a/logstash/templates/service.yaml
+++ b/logstash/templates/service.yaml
@@ -13,6 +13,13 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml . | indent 4 }}
+{{- end }}
   selector:
     app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -881,6 +881,8 @@ service:
         "protocol": "TCP",
         "targetPort": 5044,
     }
+    # Make sure that the default 'loadBalancerIP' string is empty
+    assert "loadBalancerIP" not in s["spec"]
 
 
 def test_setting_fullnameOverride():
@@ -935,3 +937,13 @@ hostAliases:
     r = helm_template(config)
     hostAliases = r["statefulset"][name]["spec"]["template"]["spec"]["hostAliases"]
     assert {"ip": "127.0.0.1", "hostnames": ["foo.local", "bar.local"]} in hostAliases
+
+def test_adding_loadBalancerIP():
+    config = """
+    service:
+      loadBalancerIP: 12.5.11.79
+    """
+
+    r = helm_template(config)
+
+    assert r["service"][name]["spec"]["loadBalancerIP"] == "12.5.11.79"

--- a/logstash/values.yaml
+++ b/logstash/values.yaml
@@ -253,6 +253,7 @@ lifecycle: {}
 service: {}
 #  annotations: {}
 #  type: ClusterIP
+#  loadBalancerIP: ""
 #  ports:
 #    - name: beats
 #      port: 5044


### PR DESCRIPTION
Backports the following commits to 7.x:

[logstash] Add option loadBalancerIP to service (#1099)
