### PR TITLE
[elasticsearch] fix statefulset to rollout in upgrade test

### DIFF
--- a/elasticsearch/examples/upgrade/Makefile
+++ b/elasticsearch/examples/upgrade/Makefile
@@ -5,11 +5,11 @@ include ../../../helpers/examples.mk
 CHART := elasticsearch
 RELEASE := helm-es-upgrade
 FROM := 7.4.0	# versions before 7.4.O aren't compatible with Kubernetes >= 1.16.0
-TO := 7.10.0	# upgrade from 7.x to 8.0.0-SNAPSHOT currently doesn't work
+TO := 7.12.1	# upgrade from 7.x to 8.0.0-SNAPSHOT currently doesn't work
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM) --to $(TO)
-	kubectl rollout status statefulset elasticsearch-master
+	kubectl rollout status statefulset upgrade-master
 
 test: install goss
 

--- a/elasticsearch/examples/upgrade/test/goss.yaml
+++ b/elasticsearch/examples/upgrade/test/goss.yaml
@@ -11,6 +11,6 @@ http:
     status: 200
     timeout: 2000
     body:
-      - '"number" : "7.10.0"'
+      - '"number" : "7.12.1"'
       - '"cluster_name" : "upgrade"'
       - "You Know, for Search"


### PR DESCRIPTION
This commit fix the elasticsearch statefulset to rollout.

Also update the target version to the last released version
