### PR TITLE
[kibana] add emptyDir volume for kibana data

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
       hostAliases: {{ toYaml .Values.hostAliases | nindent 6 }}
       {{- end }}
       volumes:
+        - name: kibana-data
+          emptyDir: {}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
@@ -140,6 +142,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+          - name: kibana-data
+            mountPath: /usr/share/kibana/data
           {{- range .Values.secretMounts }}
           - name: {{ .name }}
             mountPath: {{ .path }}


### PR DESCRIPTION
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Use an emptyDir to store Kibana data instead of Docker overlay, this is a good practice, by setting security context  ``readOnlyRootFilesystem`` : true .

User can set securityContext via ``value.yaml`` file.

(we do that for every Helm releases, elasticsearch/APM/logstash and Kibana, so I can create PR for each if this is a good idea of course).