### PR TITLE
[6.8] [elasticsearch] fix network policies http additional rules (#1111)

### DIFF
--- a/elasticsearch/examples/networkpolicy/Makefile
+++ b/elasticsearch/examples/networkpolicy/Makefile
@@ -1,13 +1,14 @@
 default: test
+
 include ../../../helpers/examples.mk
 
 RELEASE := helm-es-networkpolicy
+TIMEOUT := 1200s
 
 install:
-	helm upgrade --wait --timeout=600s --install $(RELEASE) --values ./values.yaml ../../ ; \
+	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 
-restart:
-	helm upgrade --set terminationGracePeriod=121 --wait --timeout=600s --install $(RELEASE) --values ./values.yaml ../../ ; \
+test: install goss
 
 purge:
-	helm del --purge $(RELEASE)
+	helm del $(RELEASE)

--- a/elasticsearch/examples/networkpolicy/values.yaml
+++ b/elasticsearch/examples/networkpolicy/values.yaml
@@ -4,34 +4,34 @@ networkPolicy:
     explicitNamespacesSelector:
       # Accept from namespaces with all those different rules (from whitelisted Pods)
       matchLabels:
-        role: frontend
+        role: frontend-http
       matchExpressions:
-        - {key: role, operator: In, values: [frontend]}
+        - {key: role, operator: In, values: [frontend-http]}
     additionalRules:
       - podSelector:
           matchLabels:
-            role: frontend
+            role: frontend-http
       - podSelector:
           matchExpressions:
             - key: role
               operator: In
               values:
-                - frontend
+                - frontend-http
   transport:
     enabled: true
     allowExternal: true
     explicitNamespacesSelector:
       matchLabels:
-        role: frontend
+        role: frontend-transport
       matchExpressions:
-        - {key: role, operator: In, values: [frontend]}
+        - {key: role, operator: In, values: [frontend-transport]}
     additionalRules:
       - podSelector:
           matchLabels:
-            role: frontend
+            role: frontend-transport
       - podSelector:
           matchExpressions:
             - key: role
               operator: In
               values:
-                - frontend
+                - frontend-transport

--- a/elasticsearch/templates/networkpolicy.yaml
+++ b/elasticsearch/templates/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
           namespaceSelector:
 {{ toYaml . | indent 12 }}
 {{- end }}
-{{- with .Values.networkPolicy.transport.additionalRules }}
+{{- with .Values.networkPolicy.http.additionalRules }}
             # Or from custom additional rules
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -1357,37 +1357,37 @@ networkPolicy:
     explicitNamespacesSelector:
       # Accept from namespaces with all those different rules (from whitelisted Pods)
       matchLabels:
-        role: frontend
+        role: frontend-http
       matchExpressions:
-        - {key: role, operator: In, values: [frontend]}
+        - {key: role, operator: In, values: [frontend-http]}
     additionalRules:
       - podSelector:
           matchLabels:
-            role: frontend
+            role: frontend-http
       - podSelector:
           matchExpressions:
             - key: role
               operator: In
               values:
-                - frontend
+                - frontend-http
   transport:
     enabled: true
     allowExternal: true
     explicitNamespacesSelector:
       matchLabels:
-        role: frontend
+        role: frontend-transport
       matchExpressions:
-        - {key: role, operator: In, values: [frontend]}
+        - {key: role, operator: In, values: [frontend-transport]}
     additionalRules:
       - podSelector:
           matchLabels:
-            role: frontend
+            role: frontend-transport
       - podSelector:
           matchExpressions:
             - key: role
               operator: In
               values:
-                - frontend
+                - frontend-transport
 
 """
     r = helm_template(config)
@@ -1402,16 +1402,16 @@ networkPolicy:
             },
             "namespaceSelector": {
                 "matchExpressions": [
-                    {"key": "role", "operator": "In", "values": ["frontend"]}
+                    {"key": "role", "operator": "In", "values": ["frontend-http"]}
                 ],
-                "matchLabels": {"role": "frontend"},
+                "matchLabels": {"role": "frontend-http"},
             },
         },
-        {"podSelector": {"matchLabels": {"role": "frontend"}}},
+        {"podSelector": {"matchLabels": {"role": "frontend-http"}}},
         {
             "podSelector": {
                 "matchExpressions": [
-                    {"key": "role", "operator": "In", "values": ["frontend"]}
+                    {"key": "role", "operator": "In", "values": ["frontend-http"]}
                 ]
             }
         },
@@ -1424,16 +1424,16 @@ networkPolicy:
             },
             "namespaceSelector": {
                 "matchExpressions": [
-                    {"key": "role", "operator": "In", "values": ["frontend"]}
+                    {"key": "role", "operator": "In", "values": ["frontend-transport"]}
                 ],
-                "matchLabels": {"role": "frontend"},
+                "matchLabels": {"role": "frontend-transport"},
             },
         },
-        {"podSelector": {"matchLabels": {"role": "frontend"}}},
+        {"podSelector": {"matchLabels": {"role": "frontend-transport"}}},
         {
             "podSelector": {
                 "matchExpressions": [
-                    {"key": "role", "operator": "In", "values": ["frontend"]}
+                    {"key": "role", "operator": "In", "values": ["frontend-transport"]}
                 ]
             }
         },


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [elasticsearch] fix network policies http additional rules (#1111)