### PR TITLE
[7.13] [elasticsearch] only configure ES_JAVA_OPTS when value is set (#1089)

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -315,8 +315,10 @@ spec:
             value: "{{ .Values.clusterName }}"
           - name: network.host
             value: "{{ .Values.networkHost }}"
+          {{- if .Values.esJavaOpts  }}
           - name: ES_JAVA_OPTS
             value: "{{ .Values.esJavaOpts }}"
+          {{- end }}
           {{- range $role, $enabled := .Values.roles }}
           - name: node.{{ $role }}
             value: "{{ $enabled }}"

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -45,7 +45,6 @@ def test_defaults():
         {"name": "discovery.seed_hosts", "value": uname + "-headless"},
         {"name": "network.host", "value": "0.0.0.0"},
         {"name": "cluster.name", "value": clusterName},
-        {"name": "ES_JAVA_OPTS", "value": "-Xmx1g -Xms1g"},
         {"name": "node.master", "value": "true"},
         {"name": "node.data", "value": "true"},
         {"name": "node.ingest", "value": "true"},

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -68,7 +68,7 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-esJavaOpts: "-Xmx1g -Xms1g"
+esJavaOpts: "" # example: "-Xmx1g -Xms1g"
 
 resources:
   requests:


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [elasticsearch] only configure ES_JAVA_OPTS when value is set (#1089)