### PR TITLE
[6.8] [elasticsearch] fix statefulset to rollout in upgrade test (#1189)

### DIFF
--- a/elasticsearch/examples/upgrade/Makefile
+++ b/elasticsearch/examples/upgrade/Makefile
@@ -8,7 +8,7 @@ FROM := 6.8.9 # this is the first 6.x release
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)
-	kubectl rollout status statefulset elasticsearch-master
+	kubectl rollout status statefulset upgrade-master
 
 test: install goss
 


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [elasticsearch] fix statefulset to rollout in upgrade test (#1189)