### PR TITLE
[7.13] [elasticsearch] fix statefulset to rollout in upgrade test (#1189)

### DIFF
--- a/elasticsearch/examples/upgrade/Makefile
+++ b/elasticsearch/examples/upgrade/Makefile
@@ -8,7 +8,7 @@ FROM := 7.4.0	# versions before 7.4.O aren't compatible with Kubernetes >= 1.16.
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)
-	kubectl rollout status statefulset elasticsearch-master
+	kubectl rollout status statefulset upgrade-master
 
 test: install goss
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [elasticsearch] fix statefulset to rollout in upgrade test (#1189)