### PR TITLE
7.13.0 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 7.13.0
+
+* 7.13.0 as default version.
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#1205](https://github.com/elastic/helm-charts/pull/1205) | [@jmlrt](https://github.com/jmlrt) | [meta] update backport config for 7.13 branch (#1198)  |
+| [#1197](https://github.com/elastic/helm-charts/pull/1197) | [@jmlrt](https://github.com/jmlrt) |  [meta] Initiate 7.13 branch  |
+| [#1194](https://github.com/elastic/helm-charts/pull/1194) | [@jmlrt](https://github.com/jmlrt) | [meta] remove gke 1.16 tests (#1184)  |
+| [#1175](https://github.com/elastic/helm-charts/pull/1175) | [@nittyy](https://github.com/nittyy) | [7.x][logstash] Add option loadBalancerIP to service (#1099)  |
+| [#1174](https://github.com/elastic/helm-charts/pull/1174) | [@jmlrt](https://github.com/jmlrt) | [7.x] Bump py from 1.8.0 to 1.10.0 (#1155)  |
+| [#1171](https://github.com/elastic/helm-charts/pull/1171) | [@jmlrt](https://github.com/jmlrt) | [7.x] Bump py from 1.8.0 to 1.10.0 in /helpers/helm-tester (#1154)  |
+| [#1162](https://github.com/elastic/helm-charts/pull/1162) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] add helm 3.5.3 support (#1128)  |
+| [#1168](https://github.com/elastic/helm-charts/pull/1168) | [@jmlrt](https://github.com/jmlrt) | [7.x] [elasticsearch] Mark esMajorVersion as deprecated (#1109)  |
+| [#1165](https://github.com/elastic/helm-charts/pull/1165) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] update backport config for 7.12 branch (#1112)  |
+| [#1159](https://github.com/elastic/helm-charts/pull/1159) | [@jmlrt](https://github.com/jmlrt) | [7.x] [elasticsearch] heap size is no longer defaulted to 1g (#1135)  |
+| [#1147](https://github.com/elastic/helm-charts/pull/1147) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] update PyYAML dependencies (#1140)  |
+| [#1144](https://github.com/elastic/helm-charts/pull/1144) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] add tests for k8s 1.18 and remove 1.15 (#1141)  |
+|  | Conky5 | Remove slack notification |
+| [#1114](https://github.com/elastic/helm-charts/pull/1114) | [@jmlrt](https://github.com/jmlrt) | [meta] bump 7.x branch to 7.13.0-SNAPSHOT  |
+
+
 ## 7.12.1
 
 * 7.12.1 as default version.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ versions.
 
 | Chart                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
 |--------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.12.1`][apm-7]           | [`6.8.15`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.12.1`][elasticsearch-7] | [`6.8.15`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.12.1`][filebeat-7]      | [`6.8.15`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.12.1`][kibana-7]        | [`6.8.15`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.12.1`][logstash-7]      | [`6.8.15`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.12.1`][metricbeat-7]    | [`6.8.15`][metricbeat-6]    |
+| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.13.0`][apm-7]           | [`6.8.15`][apm-6]           |
+| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.13.0`][elasticsearch-7] | [`6.8.15`][elasticsearch-6] |
+| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.13.0`][filebeat-7]      | [`6.8.15`][filebeat-6]      |
+| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.13.0`][kibana-7]        | [`6.8.15`][kibana-6]        |
+| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.13.0`][logstash-7]      | [`6.8.15`][logstash-6]      |
+| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.13.0`][metricbeat-7]    | [`6.8.15`][metricbeat-6]    |
 
 ## Supported Configurations
 
@@ -100,15 +100,15 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 [helpers/matrix.yml]: https://github.com/elastic/helm-charts/blob/master/helpers/matrix.yml
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
-[apm-7]: https://github.com/elastic/helm-charts/tree/7.12.1/apm-server/README.md
+[apm-7]: https://github.com/elastic/helm-charts/tree/7.13.0/apm-server/README.md
 [apm-6]: https://github.com/elastic/helm-charts/tree/6.8.15/apm-server/README.md
-[elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.12.1/elasticsearch/README.md
+[elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.13.0/elasticsearch/README.md
 [elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.15/elasticsearch/README.md
-[filebeat-7]: https://github.com/elastic/helm-charts/tree/7.12.1/filebeat/README.md
+[filebeat-7]: https://github.com/elastic/helm-charts/tree/7.13.0/filebeat/README.md
 [filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.15/filebeat/README.md
-[kibana-7]: https://github.com/elastic/helm-charts/tree/7.12.1/kibana/README.md
+[kibana-7]: https://github.com/elastic/helm-charts/tree/7.13.0/kibana/README.md
 [kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.15/kibana/README.md
-[logstash-7]: https://github.com/elastic/helm-charts/tree/7.12.1/logstash/README.md
+[logstash-7]: https://github.com/elastic/helm-charts/tree/7.13.0/logstash/README.md
 [logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.15/logstash/README.md
-[metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.12.1/metricbeat/README.md
+[metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.13.0/metricbeat/README.md
 [metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.15/metricbeat/README.md


### PR DESCRIPTION

## 7.13.0

* 7.13.0 as default version.


| PR | Author | Title |
| --- | --- | --- |
| [#1205](https://github.com/elastic/helm-charts/pull/1205) | [@jmlrt](https://github.com/jmlrt) | [meta] update backport config for 7.13 branch (#1198)  |
| [#1197](https://github.com/elastic/helm-charts/pull/1197) | [@jmlrt](https://github.com/jmlrt) |  [meta] Initiate 7.13 branch  |
| [#1194](https://github.com/elastic/helm-charts/pull/1194) | [@jmlrt](https://github.com/jmlrt) | [meta] remove gke 1.16 tests (#1184)  |
| [#1175](https://github.com/elastic/helm-charts/pull/1175) | [@nittyy](https://github.com/nittyy) | [7.x][logstash] Add option loadBalancerIP to service (#1099)  |
| [#1174](https://github.com/elastic/helm-charts/pull/1174) | [@jmlrt](https://github.com/jmlrt) | [7.x] Bump py from 1.8.0 to 1.10.0 (#1155)  |
| [#1171](https://github.com/elastic/helm-charts/pull/1171) | [@jmlrt](https://github.com/jmlrt) | [7.x] Bump py from 1.8.0 to 1.10.0 in /helpers/helm-tester (#1154)  |
| [#1162](https://github.com/elastic/helm-charts/pull/1162) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] add helm 3.5.3 support (#1128)  |
| [#1168](https://github.com/elastic/helm-charts/pull/1168) | [@jmlrt](https://github.com/jmlrt) | [7.x] [elasticsearch] Mark esMajorVersion as deprecated (#1109)  |
| [#1165](https://github.com/elastic/helm-charts/pull/1165) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] update backport config for 7.12 branch (#1112)  |
| [#1159](https://github.com/elastic/helm-charts/pull/1159) | [@jmlrt](https://github.com/jmlrt) | [7.x] [elasticsearch] heap size is no longer defaulted to 1g (#1135)  |
| [#1147](https://github.com/elastic/helm-charts/pull/1147) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] update PyYAML dependencies (#1140)  |
| [#1144](https://github.com/elastic/helm-charts/pull/1144) | [@jmlrt](https://github.com/jmlrt) | [7.x] [meta] add tests for k8s 1.18 and remove 1.15 (#1141)  |
|  | Conky5 | Remove slack notification |
| [#1114](https://github.com/elastic/helm-charts/pull/1114) | [@jmlrt](https://github.com/jmlrt) | [meta] bump 7.x branch to 7.13.0-SNAPSHOT  |

