### PR TITLE
[meta] add tests for k8s 1.19

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -40,3 +40,4 @@ APM_SERVER_SUITE:
 KUBERNETES_VERSION:
   - "1.17"
   - "1.18"
+  - "1.19"


### PR DESCRIPTION
This commit add tests on GKE 1.18 following new GKE version updates:

https://cloud.google.com/kubernetes-engine/docs/release-notes#May_19_2021
