### PR TITLE
Add extraPort and service to expose Filebeat ports

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -148,6 +148,8 @@ as a reference. They are also used in the automated testing of this chart.
 | `serviceAccountAnnotations`    | Annotations to be added to the ServiceAccount that is created by this chart.                                                                                                 | `{}`                               |
 | `terminationGracePeriod`       | Termination period (in seconds) to wait before killing filebeat pod process on pod shutdown                                                                                  | `30`                               |
 | `updateStrategy`               | The [updateStrategy][] for the DaemonSet By default Kubernetes will kill and recreate pods on updates. Setting this to `OnDelete` will require that pods be deleted manually | `RollingUpdate`                    |
+| `service`                 | Configurable [service][] to expose the Filebeat service. 
+| `extraPorts`              | An array of extra ports to open on the pod
 
 ### Deprecated
 

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -138,6 +138,10 @@ spec:
         - "-e"
         - "-E"
         - "http.enabled=true"
+      {{- if .Values.extraPorts }}
+        ports:
+        {{- toYaml .Values.extraPorts | nindent 8 }}
+      {{- end }}
         livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:

--- a/filebeat/templates/deployment.yaml
+++ b/filebeat/templates/deployment.yaml
@@ -112,6 +112,10 @@ spec:
           - "-e"
           - "-E"
           - "http.enabled=true"
+      {{- if .Values.extraPorts }}
+        ports:
+        {{- toYaml .Values.extraPorts | nindent 8 }}
+      {{- end }}
         livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:

--- a/filebeat/templates/service.yaml
+++ b/filebeat/templates/service.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.service }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: "{{ template "filebeat.fullname" . }}"
+  labels:
+    app: "{{ template "filebeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  selector:
+    app: "{{ template "filebeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}"
+    release: {{ .Release.Name | quote }}
+  ports:
+{{ toYaml .Values.service.ports | indent 4 }}
+{{- end }}

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -218,6 +218,23 @@ updateStrategy: RollingUpdate
 nameOverride: ""
 fullnameOverride: ""
 
+
+# Custom ports to add to filebeat
+extraPorts:
+  []
+  # - name: syslog
+  #   containerPort: 5141
+
+service: {}
+#  annotations: {}
+#  type: ClusterIP
+#  loadBalancerIP: ""
+#  ports:
+#    - name: syslog
+#      port: 5141
+#      protocol: TCP
+#      targetPort: 5141
+
 # DEPRECATED
 affinity: {}
 envFrom: []


### PR DESCRIPTION
Signed-off-by: disaster37 <linuxworkgroup@hotmail.com>

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X ] Updated template tests in `${CHART}/tests/*.py` 
- [X] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

This feature allow to expose extra port on Filbeat container to the outside over service. It's usefull when use filebeat input like Syslog or TCP.
We use the same think that is doing on Logstash helm template.