### PR TITLE
fix: add apm-server labels to pods

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -19,8 +19,12 @@ spec:
   template:
     metadata:
       labels:
-        app: apm-server
         release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}"
+        app: apm-server
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Labels for APM Server chart are applied to the deployment, but not
to the individual pods. This does not align with practice on other
Elastic helm charts, and creates issues in environments which validate
pods with utilities, such as [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper).

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
