### PR TITLE
[metricbeat] Fix podSecurityContext bug

### DIFF
--- a/metricbeat/templates/deployment.yaml
+++ b/metricbeat/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
       {{- if .Values.extraVolumes | default .Values.deployment.extraVolumes }}
 {{ toYaml ( .Values.extraVolumes | default .Values.deployment.extraVolumes ) | indent 6 }}
       {{- end }}
+{{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+{{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -126,7 +130,7 @@ spec:
 {{ toYaml ( .Values.extraEnvs | default .Values.deployment.extraEnvs ) | indent 8 }}
 {{- end }}
         envFrom: {{ toYaml ( .Values.envFrom | default .Values.deployment.envFrom ) | nindent 10 }}
-        securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.deployment.securityContext ) | nindent 10 }}
+        securityContext: {{ toYaml .Values.deployment.securityContext | nindent 10 }}
         volumeMounts:
         {{- range .Values.secretMounts | default .Values.deployment.secretMounts }}
         - name: {{ .name }}


### PR DESCRIPTION
- Fix issue #1226  the `podSecurityContext` value to be compliant with all the other Helm chart about its signification (and also with the README.md that clearly specify this value set the **pod execution security context** and not the container's one)

Note: I tried to fix the tests but I just couldn't make it. I do the PR now so people can use this branch if they absolutely need to set the `podSecurityContext` like me. If anybody else wants to fix the tests, they are welcome to add a commit to this branch.