### PR TITLE
[apm-server] add labels at pod level, as well as deployment level

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -19,8 +19,12 @@ spec:
   template:
     metadata:
       labels:
-        app: apm-server
         release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}"
+        app: apm-server
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}"
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         app: apm-server
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
APM Server labels are applied at the deployment level only, not at the pod level. This does not align with the behavior of other Elastic helm charts in this collection. Additionally, it creates issues when using tools, which require specific labels to be applied to pods (i.e., validation tools, such as [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper)).

Add labels defined under the `labels: {}` tag in `values.yml` to correct this issue.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
