### PR TITLE
6.8.17 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 6.8.17
+
+* 6.8.17 as default version.
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#1278](https://github.com/elastic/helm-charts/pull/1278) | [@jmlrt](https://github.com/jmlrt) | [kibana] adding extra volumes and extra volume mounts (#557) (#1264)  |
+| [#1275](https://github.com/elastic/helm-charts/pull/1275) | [@jmlrt](https://github.com/jmlrt) | [logstash] feat: add podAffinity settings (#1257)  |
+| [#1272](https://github.com/elastic/helm-charts/pull/1272) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] Added health pod name override for compatability (#1058)  |
+| [#1216](https://github.com/elastic/helm-charts/pull/1216) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] fix statefulset to rollout in upgrade test (#1189)  |
+| [#1227](https://github.com/elastic/helm-charts/pull/1227) | [@elasticmachine](https://github.com/elasticmachine) | Bump version to 6.8.17-SNAPSHOT  |
+| [#1210](https://github.com/elastic/helm-charts/pull/1210) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] only configure ES_JAVA_OPTS when value is set (#1089)  |
+| [#1207](https://github.com/elastic/helm-charts/pull/1207) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] fix network policies http additional rules (#1111)  |
+
+
 ## 7.13.2
 
 * 7.13.2 as default version.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ versions.
 
 | Chart                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
 |--------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.13.2`][apm-7]           | [`6.8.16`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.13.2`][elasticsearch-7] | [`6.8.16`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.13.2`][filebeat-7]      | [`6.8.16`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.13.2`][kibana-7]        | [`6.8.16`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.13.2`][logstash-7]      | [`6.8.16`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.13.2`][metricbeat-7]    | [`6.8.16`][metricbeat-6]    |
+| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.13.2`][apm-7]           | [`6.8.17`][apm-6]           |
+| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.13.2`][elasticsearch-7] | [`6.8.17`][elasticsearch-6] |
+| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.13.2`][filebeat-7]      | [`6.8.17`][filebeat-6]      |
+| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.13.2`][kibana-7]        | [`6.8.17`][kibana-6]        |
+| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.13.2`][logstash-7]      | [`6.8.17`][logstash-6]      |
+| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.13.2`][metricbeat-7]    | [`6.8.17`][metricbeat-6]    |
 
 ## Supported Configurations
 
@@ -101,14 +101,14 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 [apm-7]: https://github.com/elastic/helm-charts/tree/7.13.2/apm-server/README.md
-[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.16/apm-server/README.md
+[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.17/apm-server/README.md
 [elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.13.2/elasticsearch/README.md
-[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.16/elasticsearch/README.md
+[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.17/elasticsearch/README.md
 [filebeat-7]: https://github.com/elastic/helm-charts/tree/7.13.2/filebeat/README.md
-[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.16/filebeat/README.md
+[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.17/filebeat/README.md
 [kibana-7]: https://github.com/elastic/helm-charts/tree/7.13.2/kibana/README.md
-[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.16/kibana/README.md
+[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.17/kibana/README.md
 [logstash-7]: https://github.com/elastic/helm-charts/tree/7.13.2/logstash/README.md
-[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.16/logstash/README.md
+[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.17/logstash/README.md
 [metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.13.2/metricbeat/README.md
-[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.16/metricbeat/README.md
+[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.17/metricbeat/README.md


### PR DESCRIPTION

## 6.8.17

* 6.8.17 as default version.


| PR | Author | Title |
| --- | --- | --- |
| [#1278](https://github.com/elastic/helm-charts/pull/1278) | [@jmlrt](https://github.com/jmlrt) | [kibana] adding extra volumes and extra volume mounts (#557) (#1264)  |
| [#1275](https://github.com/elastic/helm-charts/pull/1275) | [@jmlrt](https://github.com/jmlrt) | [logstash] feat: add podAffinity settings (#1257)  |
| [#1272](https://github.com/elastic/helm-charts/pull/1272) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] Added health pod name override for compatability (#1058)  |
| [#1216](https://github.com/elastic/helm-charts/pull/1216) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] fix statefulset to rollout in upgrade test (#1189)  |
| [#1227](https://github.com/elastic/helm-charts/pull/1227) | [@elasticmachine](https://github.com/elasticmachine) | Bump version to 6.8.17-SNAPSHOT  |
| [#1210](https://github.com/elastic/helm-charts/pull/1210) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] only configure ES_JAVA_OPTS when value is set (#1089)  |
| [#1207](https://github.com/elastic/helm-charts/pull/1207) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] fix network policies http additional rules (#1111)  |

