### PR TITLE
Support networking.k8s.io/v1 ingress for k8s v1.22+

### DIFF
--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -26,7 +26,10 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
   {{- if .ingressPath }}
   {{- range .Values.ingress.tls }}

--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -2,7 +2,18 @@
 {{- $fullName := include "elasticsearch.uname" . -}}
 {{- $httpPort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -36,18 +47,38 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $httpPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $httpPort }}
+              {{- end }}
     {{- else }}
     - host: {{ .host }}
       http:
         paths:
         {{- range .paths }}
           - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .servicePort | default $httpPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ .servicePort | default $httpPort }}
+              {{- end }}
         {{- end }}
     {{- end }}
   {{- end }}

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -239,6 +239,7 @@ tolerations: []
 # Only enable this if you have security enabled on your cluster
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -246,6 +247,7 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/kibana/templates/ingress.yaml
+++ b/kibana/templates/ingress.yaml
@@ -2,7 +2,18 @@
 {{- $fullName := include "kibana.fullname" . -}}
 {{- $httpPort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -12,7 +23,10 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
   {{- if .ingressPath }}
   {{- range .Values.ingress.tls }}
@@ -33,18 +47,38 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $httpPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $httpPort }}
+              {{- end }}
     {{- else }}
     - host: {{ .host }}
       http:
         paths:
         {{- range .paths }}
           - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .servicePort | default $httpPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ .servicePort | default $httpPort }}
+              {{- end }}
         {{- end }}
     {{- end }}
   {{- end }}

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -128,6 +128,7 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -135,6 +136,7 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/logstash/templates/ingress.yaml
+++ b/logstash/templates/ingress.yaml
@@ -1,6 +1,17 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "logstash.fullname" . -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -9,15 +20,18 @@ metadata:
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-{{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-{{- end }}
+    {{ toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
   rules:
   {{- range $.Values.ingress.hosts }}
     - host: {{ .host }}
@@ -25,9 +39,19 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/logstash/values.yaml
+++ b/logstash/values.yaml
@@ -270,10 +270,15 @@ service: {}
 
 ingress:
   enabled: false
-#  annotations: {}
-#  hosts:
-#    - host: logstash.local
-#      paths:
-#        - path: /logs
-#          servicePort: 8080
-#  tls: []
+  className: ""
+  annotations: {}
+  hosts:
+    - host: logstash.local
+      paths:
+        - path: /logs
+          servicePort: 8080
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
Changes to ingress template to support k8s v1.22+ due to depreciation of `networking.k8s.io/v1beta1`.

* https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

Following the updated boilerplate template structure from helm to keep things consistent

* https://github.com/helm/helm/blob/d4cc130fa90027e8c1c69ad2a06c6dee4c31d29d/pkg/chartutil/create.go#L215-L275