### PR TITLE
6.8.18 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 6.8.18
+
+* 6.8.18 as default version.
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#1269](https://github.com/elastic/helm-charts/pull/1269) | [@jmlrt](https://github.com/jmlrt) | [6.8] [meta] add tests for k8s 1.19 (#1231)  |
+| [#1306](https://github.com/elastic/helm-charts/pull/1306) | [@jmlrt](https://github.com/jmlrt) | [meta] update support matrix (#1305)  |
+| [#1292](https://github.com/elastic/helm-charts/pull/1292) | [@elasticmachine](https://github.com/elasticmachine) | Bump version to 6.8.18-SNAPSHOT  |
+
+
 ## 7.13.4
 
 * 7.13.4 as default version.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ versions.
 
 | Chart                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
 |--------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.13.4`][apm-7]           | [`6.8.17`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.13.4`][elasticsearch-7] | [`6.8.17`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.13.4`][filebeat-7]      | [`6.8.17`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.13.4`][kibana-7]        | [`6.8.17`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.13.4`][logstash-7]      | [`6.8.17`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.13.4`][metricbeat-7]    | [`6.8.17`][metricbeat-6]    |
+| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.13.4`][apm-7]           | [`6.8.18`][apm-6]           |
+| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.13.4`][elasticsearch-7] | [`6.8.18`][elasticsearch-6] |
+| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.13.4`][filebeat-7]      | [`6.8.18`][filebeat-6]      |
+| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.13.4`][kibana-7]        | [`6.8.18`][kibana-6]        |
+| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.13.4`][logstash-7]      | [`6.8.18`][logstash-6]      |
+| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.13.4`][metricbeat-7]    | [`6.8.18`][metricbeat-6]    |
 
 ## Supported Configurations
 
@@ -103,14 +103,14 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 [apm-7]: https://github.com/elastic/helm-charts/tree/7.13.4/apm-server/README.md
-[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.17/apm-server/README.md
+[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.18/apm-server/README.md
 [elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.13.4/elasticsearch/README.md
-[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.17/elasticsearch/README.md
+[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.18/elasticsearch/README.md
 [filebeat-7]: https://github.com/elastic/helm-charts/tree/7.13.4/filebeat/README.md
-[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.17/filebeat/README.md
+[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.18/filebeat/README.md
 [kibana-7]: https://github.com/elastic/helm-charts/tree/7.13.4/kibana/README.md
-[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.17/kibana/README.md
+[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.18/kibana/README.md
 [logstash-7]: https://github.com/elastic/helm-charts/tree/7.13.4/logstash/README.md
-[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.17/logstash/README.md
+[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.18/logstash/README.md
 [metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.13.4/metricbeat/README.md
-[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.17/metricbeat/README.md
+[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.18/metricbeat/README.md


### PR DESCRIPTION

## 6.8.18

* 6.8.18 as default version.


| PR | Author | Title |
| --- | --- | --- |
| [#1269](https://github.com/elastic/helm-charts/pull/1269) | [@jmlrt](https://github.com/jmlrt) | [6.8] [meta] add tests for k8s 1.19 (#1231)  |
| [#1306](https://github.com/elastic/helm-charts/pull/1306) | [@jmlrt](https://github.com/jmlrt) | [meta] update support matrix (#1305)  |
| [#1292](https://github.com/elastic/helm-charts/pull/1292) | [@elasticmachine](https://github.com/elasticmachine) | Bump version to 6.8.18-SNAPSHOT  |

