### PR TITLE
[logstash] add loadBalancer externalTrafficPolicy option

### DIFF
--- a/logstash/templates/service.yaml
+++ b/logstash/templates/service.yaml
@@ -20,6 +20,9 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
   selector:
     app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -907,6 +907,27 @@ service:
     assert "loadBalancerIP" not in s["spec"]
 
 
+def test_adding_an_externalTrafficPolicy():
+    config = """
+    service:
+      ports: []
+    """
+
+    r = helm_template(config)
+
+    assert "externalTrafficPolicy" not in r["service"][name]["spec"]
+
+    config = """
+    service:
+      ports: []
+      externalTrafficPolicy: Local
+    """
+
+    r = helm_template(config)
+
+    assert r["service"][name]["spec"]["externalTrafficPolicy"] == "Local"
+
+
 def test_setting_fullnameOverride():
     config = """
 fullnameOverride: 'logstash-custom'

--- a/logstash/values.yaml
+++ b/logstash/values.yaml
@@ -258,6 +258,7 @@ service: {}
 #  annotations: {}
 #  type: ClusterIP
 #  loadBalancerIP: ""
+#  externalTrafficPolicy: ""
 #  ports:
 #    - name: beats
 #      port: 5044


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Hi,

This PR adds a new option in the logstash service spec in order to support configuration for externalTrafficPolicy if the service is a loadBalancer.

Reference: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip