### PR TITLE
[filebeat] fix default cluster roles

### DIFF
--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -180,16 +180,19 @@ readinessProbe:
 managedServiceAccount: true
 
 clusterRoleRules:
-- apiGroups:
-  - ""
+- apiGroups: [""]
   resources:
-  - namespaces
   - nodes
+  - namespaces
   - pods
-  verbs:
-  - get
-  - list
-  - watch
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  - daemonsets
+  verbs: ["get", "list", "watch"]
 
 podAnnotations: {}
   # iam.amazonaws.com/role: es-cluster


### PR DESCRIPTION
Fixes missing deployment, statefulset and replicaset. daemonset added as it is referenced in beats source file libbeat/common/kubernetes/metadata/resource.go

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
