### PR TITLE
[meta] remove support matrix + nit doc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,68 +8,47 @@
 
 - [Charts](#charts)
 - [Supported Configurations](#supported-configurations)
-  - [Support Matrix](#support-matrix)
+  - [Stack Versions](#stack-versions)
   - [Kubernetes Versions](#kubernetes-versions)
-  - [Helm versions](#helm-versions)
+  - [Helm Versions](#helm-versions)
 - [ECK](#eck)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto-update -->
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 ## Charts
 
-These Helm charts are designed to be a lightweight way to configure our official
-Docker images. Links to the relevant Docker image documentation have also been
-added below.
+These Helm charts are designed to be a lightweight way to configure Elastic
+official Docker images.
 
-We recommend that the Helm chart version is aligned to the version of the product
-you want to deploy. This will ensure that you using a chart version that has been
-tested against the corresponding production version.
-This will also ensure that the documentation and examples for the chart will work
-with the version of the product, you are installing.
+## Supported Configurations
+
+We recommend that the Helm chart version is aligned to the version of the
+product you want to deploy. This will ensure that you are using a chart version
+that has been tested against the corresponding production version.
+This will also ensure that the documentation and examples for the chart will
+work with the version of the product, you are installing.
 
 For example, if you want to deploy an Elasticsearch `7.7.1` cluster, use the
 corresponding `7.7.1` [tag][elasticsearch-771].
 
-The `master` version of these charts are intended to support the latest pre-release
-versions of our products, and therefore may or may not work with current released
-versions.
-
-| Chart                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
-|--------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.14.0`][apm-7]           | [`6.8.18`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.14.0`][elasticsearch-7] | [`6.8.18`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.14.0`][filebeat-7]      | [`6.8.18`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.14.0`][kibana-7]        | [`6.8.18`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.14.0`][logstash-7]      | [`6.8.18`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.14.0`][metricbeat-7]    | [`6.8.18`][metricbeat-6]    |
-
-## Supported Configurations
-
-Starting with the `7.7.0` release, some charts are reaching GA.
-
+The `master` version of these charts is intended to support the latest
+pre-release versions of our products, and therefore may or may not work with
+current released versions.
 Note that only the released charts coming from [Elastic Helm repo][] or
 [GitHub releases][] are supported.
 
-### Support Matrix
 
-|      | Elasticsearch | Kibana | Logstash | Filebeat | Metricbeat | APM Server |
-|------|---------------|--------|----------|----------|------------|------------|
-| 6.8  | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
-| 7.0  | Alpha         | Alpha  | /        | /        | /          | /          |
-| 7.1  | Beta          | Beta   | /        | Beta     | /          | /          |
-| 7.2  | Beta          | Beta   | /        | Beta     | Beta       | /          |
-| 7.3  | Beta          | Beta   | /        | Beta     | Beta       | /          |
-| 7.4  | Beta          | Beta   | /        | Beta     | Beta       | /          |
-| 7.5  | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
-| 7.6  | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
-| 7.7  | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.8  | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.9  | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.10 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.11 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.12 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.13 | GA            | GA     | Beta     | GA       | GA         | Beta       |
+### Stack Versions
+
+| Chart                                      | Latest 7 Version                             | Latest 6 Version                   |
+|--------------------------------------------|----------------------------------------------|------------------------------------|
+| [APM-Server](./apm-server/README.md)       | [`7.14.0`][apm-7] (Beta since 7.7.0)         | [`6.8.18`][apm-6] (Alpha)          |
+| [Elasticsearch](./elasticsearch/README.md) | [`7.14.0`][elasticsearch-7] (GA since 7.7.0) | [`6.8.18`][elasticsearch-6] (Beta) |
+| [Filebeat](./filebeat/README.md)           | [`7.14.0`][filebeat-7] (GA since 7.7.0)      | [`6.8.18`][filebeat-6] (Beta)      |
+| [Kibana](./kibana/README.md)               | [`7.14.0`][kibana-7] (GA since 7.7.0)        | [`6.8.18`][kibana-6] (Beta)        |
+| [Logstash](./logstash/README.md)           | [`7.14.0`][logstash-7] (Beta since 7.5.0)    | [`6.8.18`][logstash-6] (Beta)      |
+| [Metricbeat](./metricbeat/README.md)       | [`7.14.0`][metricbeat-7] (GA since 7.7.0)    | [`6.8.18`][metricbeat-6] (Beta)    |
 
 ### Kubernetes Versions
 
@@ -77,7 +56,7 @@ The charts are [currently tested][] against all GKE versions available. The
 exact versions are defined under `KUBERNETES_VERSIONS` in
 [helpers/matrix.yml][].
 
-### Helm versions
+### Helm Versions
 
 While we are checking backward compatibility, the charts are only tested with
 Helm version mentioned in [helm-tester Dockerfile][] (currently 3.6.2).


### PR DESCRIPTION
This commit removes the existing support matrix and replace it by a
mention of the charts status (alpha, beta, ga) in the stack version
table. This change will avoid issue where the support matrix isn't
updated during a release.

Also remove the links to stack product docker image doc which are
already present in each chart specific README.

Also reorganize informations related to supported configuration under
this title and format line length.
