### PR TITLE
[6.8] [meta] add tests for k8s 1.20 (#1294)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -42,3 +42,4 @@ APM_SERVER_SUITE:
 KUBERNETES_VERSION:
   - "1.18"
   - "1.19"
+  - "1.20"


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [meta] add tests for k8s 1.20 (#1294)