### PR TITLE
[7.14] [meta] add tests for k8s 1.20 (#1294)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -40,3 +40,4 @@ APM_SERVER_SUITE:
 KUBERNETES_VERSION:
   - "1.18"
   - "1.19"
+  - "1.20"


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [meta] add tests for k8s 1.20 (#1294)