### PR TITLE
[6.8] [meta] remove support matrix + nit doc changes (#1337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,68 +8,40 @@
 
 - [Charts](#charts)
 - [Supported Configurations](#supported-configurations)
-  - [Support Matrix](#support-matrix)
+  - [Stack Versions](#stack-versions)
   - [Kubernetes Versions](#kubernetes-versions)
-  - [Helm versions](#helm-versions)
+  - [Helm Versions](#helm-versions)
 - [ECK](#eck)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto-update -->
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 ## Charts
 
-These Helm charts are designed to be a lightweight way to configure our official
-Docker images. Links to the relevant Docker image documentation have also been
-added below.
+These Helm charts are designed to be a lightweight way to configure Elastic
+official Docker images.
 
-We recommend that the Helm chart version is aligned to the version of the product
-you want to deploy. This will ensure that you using a chart version that has been
-tested against the corresponding production version.
-This will also ensure that the documentation and examples for the chart will work
-with the version of the product, you are installing.
+## Supported Configurations
+
+We recommend that the Helm chart version is aligned to the version of the
+product you want to deploy. This will ensure that you are using a chart version
+that has been tested against the corresponding production version.
+This will also ensure that the documentation and examples for the chart will
+work with the version of the product, you are installing.
 
 For example, if you want to deploy an Elasticsearch `7.7.1` cluster, use the
 corresponding `7.7.1` [tag][elasticsearch-771].
 
-The `master` version of these charts are intended to support the latest pre-release
-versions of our products, and therefore may or may not work with current released
-versions.
-
-| Chart                                      | Docker documentation                                                            | Latest 7 Version            | Latest 6 Version            |
-|--------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-----------------------------|
-| [APM-Server](./apm-server/README.md)       | https://www.elastic.co/guide/en/apm/server/current/running-on-docker.html       | [`7.13.3`][apm-7]           | [`6.8.18`][apm-6]           |
-| [Elasticsearch](./elasticsearch/README.md) | https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html     | [`7.13.3`][elasticsearch-7] | [`6.8.18`][elasticsearch-6] |
-| [Filebeat](./filebeat/README.md)           | https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html   | [`7.13.3`][filebeat-7]      | [`6.8.18`][filebeat-6]      |
-| [Kibana](./kibana/README.md)               | https://www.elastic.co/guide/en/kibana/current/docker.html                      | [`7.13.3`][kibana-7]        | [`6.8.18`][kibana-6]        |
-| [Logstash](./logstash/README.md)           | https://www.elastic.co/guide/en/logstash/current/docker.html                    | [`7.13.3`][logstash-7]      | [`6.8.18`][logstash-6]      |
-| [Metricbeat](./metricbeat/README.md)       | https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html | [`7.13.3`][metricbeat-7]    | [`6.8.18`][metricbeat-6]    |
-
-## Supported Configurations
-
-Starting with the `7.7.0` release, some charts are reaching GA.
-
+The `master` version of these charts is intended to support the latest
+pre-release versions of our products, and therefore may or may not work with
+current released versions.
 Note that only the released charts coming from [Elastic Helm repo][] or
 [GitHub releases][] are supported.
 
-### Support Matrix
 
-|      | Elasticsearch | Kibana | Logstash | Filebeat | Metricbeat | APM Server |
-|------|---------------|--------|----------|----------|------------|------------|
-| 6.8  | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
-| 7.0  | Alpha         | Alpha  | /        | /        | /          | /          |
-| 7.1  | Beta          | Beta   | /        | Beta     | /          | /          |
-| 7.2  | Beta          | Beta   | /        | Beta     | Beta       | /          |
-| 7.3  | Beta          | Beta   | /        | Beta     | Beta       | /          |
-| 7.4  | Beta          | Beta   | /        | Beta     | Beta       | /          |
-| 7.5  | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
-| 7.6  | Beta          | Beta   | Beta     | Beta     | Beta       | Alpha      |
-| 7.7  | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.8  | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.9  | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.10 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.11 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.12 | GA            | GA     | Beta     | GA       | GA         | Beta       |
-| 7.13 | GA            | GA     | Beta     | GA       | GA         | Beta       |
+### Stack Versions
+
+Look at [Stack Versions table on master branch][stack-versions-master].
 
 ### Kubernetes Versions
 
@@ -77,7 +49,7 @@ The charts are [currently tested][] against all GKE versions available. The
 exact versions are defined under `KUBERNETES_VERSIONS` in
 [helpers/matrix.yml][].
 
-### Helm versions
+### Helm Versions
 
 While we are checking backward compatibility, the charts are only tested with
 Helm version mentioned in [helm-tester Dockerfile][] (currently 3.5.3).
@@ -97,21 +69,9 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 [eck-chart-doc]: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html
 [elastic cloud on kubernetes]: https://github.com/elastic/cloud-on-k8s
 [elastic helm repo]: https://helm.elastic.co
+[elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 [github releases]: https://github.com/elastic/helm-charts/releases
 [helm-tester Dockerfile]: https://github.com/elastic/helm-charts/blob/6.8/helpers/helm-tester/Dockerfile
 [helpers/matrix.yml]: https://github.com/elastic/helm-charts/blob/6.8/helpers/matrix.yml
 [operator pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
-[elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
-
-[apm-7]: https://github.com/elastic/helm-charts/tree/7.13.3/apm-server/README.md
-[apm-6]: https://github.com/elastic/helm-charts/tree/6.8.18/apm-server/README.md
-[elasticsearch-7]: https://github.com/elastic/helm-charts/tree/7.13.3/elasticsearch/README.md
-[elasticsearch-6]: https://github.com/elastic/helm-charts/tree/6.8.18/elasticsearch/README.md
-[filebeat-7]: https://github.com/elastic/helm-charts/tree/7.13.3/filebeat/README.md
-[filebeat-6]: https://github.com/elastic/helm-charts/tree/6.8.18/filebeat/README.md
-[kibana-7]: https://github.com/elastic/helm-charts/tree/7.13.3/kibana/README.md
-[kibana-6]: https://github.com/elastic/helm-charts/tree/6.8.18/kibana/README.md
-[logstash-7]: https://github.com/elastic/helm-charts/tree/7.13.3/logstash/README.md
-[logstash-6]: https://github.com/elastic/helm-charts/tree/6.8.18/logstash/README.md
-[metricbeat-7]: https://github.com/elastic/helm-charts/tree/7.13.3/metricbeat/README.md
-[metricbeat-6]: https://github.com/elastic/helm-charts/tree/6.8.18/metricbeat/README.md
+[stack-versions-master]: https://github.com/elastic/helm-charts/blob/master/README.md#stack-versions


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [meta] remove support matrix + nit doc changes (#1337)