### PR TITLE
Refactoring labels for Elasticsearch

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -89,8 +89,8 @@ helm.sh/chart: {{ template "elasticsearch.chart" . }}
 {{- end }}
 {{- end -}}
 
-{{/* matchLabels */}}
-{{- define "elasticsearch.matchLabels" -}}
+{{/* selectorLabels */}}
+{{- define "elasticsearch.selectorLabels" -}}
 app.kubernetes.io/name: {{ template "elasticsearch.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -69,3 +69,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "elasticsearch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Helm required labels */}}
+{{- define "elasticsearch.labels" -}}
+app.kubernetes.io/component: elasticsearch
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "elasticsearch.name" . }}
+app.kubernetes.io/part-of: {{ template "elasticsearch.name" . }}
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ template "elasticsearch.chart" . }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end -}}
+
+{{/* matchLabels */}}
+{{- define "elasticsearch.matchLabels" -}}
+app.kubernetes.io/name: {{ template "elasticsearch.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/elasticsearch/templates/configmap.yaml
+++ b/elasticsearch/templates/configmap.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "elasticsearch.uname" . }}-config
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 data:
 {{- range $path, $config := .Values.esConfig }}
   {{ $path }}: |

--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -7,9 +7,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/elasticsearch/templates/networkpolicy.yaml
+++ b/elasticsearch/templates/networkpolicy.yaml
@@ -4,10 +4,7 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ template "elasticsearch.uname" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -4,6 +4,8 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "elasticsearch.uname" . }}-pdb"
+  labels:
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.maxUnavailable }}
   selector:

--- a/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/elasticsearch/templates/podsecuritypolicy.yaml
@@ -5,10 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 spec:
 {{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
 {{- end -}}

--- a/elasticsearch/templates/role.yaml
+++ b/elasticsearch/templates/role.yaml
@@ -5,10 +5,7 @@ kind: Role
 metadata:
   name: {{ $fullName | quote }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - extensions

--- a/elasticsearch/templates/rolebinding.yaml
+++ b/elasticsearch/templates/rolebinding.yaml
@@ -5,10 +5,7 @@ kind: RoleBinding
 metadata:
   name: {{ $fullName | quote }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     {{- if eq .Values.rbac.serviceAccountName "" }}

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -9,10 +9,7 @@ metadata:
   name: {{ template "elasticsearch.uname" . }}
 {{- end }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4}}
 {{- end }}
@@ -55,10 +52,7 @@ metadata:
   name: {{ template "elasticsearch.uname" . }}-headless
 {{- end }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 {{- if .Values.service.labelsHeadless }}
 {{ toYaml .Values.service.labelsHeadless | indent 4 }}
 {{- end }}

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -18,9 +18,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    {{- include "elasticsearch.selectorLabels" . | nindent 4 }}
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     protocol: TCP
@@ -63,7 +61,7 @@ spec:
   # Create endpoints also if the related pod isn't ready
   publishNotReadyAddresses: true
   selector:
-    app: "{{ template "elasticsearch.uname" . }}"
+    {{- include "elasticsearch.selectorLabels" . | nindent 4 }}
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     port: {{ .Values.httpPort }}

--- a/elasticsearch/templates/serviceaccount.yaml
+++ b/elasticsearch/templates/serviceaccount.yaml
@@ -13,8 +13,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+    {{- include "elasticsearch.labels" . | nindent 4 }}
 {{- end -}}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -4,13 +4,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "elasticsearch.uname" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
-    {{- range $key, $value := .Values.labels }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
     esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"
 spec:
@@ -26,15 +20,13 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: {{ template "elasticsearch.uname" . }}
-    {{- if .Values.persistence.labels.enabled }}
       labels:
-        release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}"
-        app: "{{ template "elasticsearch.uname" . }}"
+        {{- include "elasticsearch.labels" . | nindent 8 }}
+        {{- if .Values.persistence.labels.enabled }}
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-    {{- end }}
+        {{- end }}
     {{- with .Values.persistence.annotations  }}
       annotations:
 {{ toYaml . | indent 8 }}
@@ -46,12 +38,7 @@ spec:
     metadata:
       name: "{{ template "elasticsearch.uname" . }}"
       labels:
-        release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}"
-        app: "{{ template "elasticsearch.uname" . }}"
-        {{- range $key, $value := .Values.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        {{- include "elasticsearch.labels" . | nindent 8 }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   serviceName: {{ template "elasticsearch.uname" . }}-headless
   selector:
     matchLabels:
-      app: "{{ template "elasticsearch.uname" . }}"
+      {{- include "elasticsearch.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:

--- a/elasticsearch/templates/test/test-elasticsearch-health.yaml
+++ b/elasticsearch/templates/test/test-elasticsearch-health.yaml
@@ -8,6 +8,8 @@ metadata:
 {{- else }}
   name: "{{ .Release.Name }}-{{ randAlpha 5 | lower }}-test"
 {{- end }}
+  labels:
+    {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -72,7 +72,8 @@ podAnnotations: {}
   # iam.amazonaws.com/role: es-cluster
 
 # additionals labels
-labels: {}
+labels: #{}
+  app: elasticsearch
 
 esJavaOpts: "" # example: "-Xmx1g -Xms1g"
 

--- a/kibana/templates/_helpers.tpl
+++ b/kibana/templates/_helpers.tpl
@@ -19,14 +19,27 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{/*
-Common labels
-*/}}
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "kibana.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Helm required labels */}}
 {{- define "kibana.labels" -}}
-app: {{ .Chart.Name }}
-release: {{ .Release.Name | quote }}
-heritage: {{ .Release.Service }}
+app.kubernetes.io/component: kibana
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "kibana.name" . }}
+app.kubernetes.io/part-of: {{ template "kibana.name" . }}
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ template "kibana.chart" . }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels }}
 {{- end }}
+{{- end -}}
+
+{{/* selectorLabels */}}
+{{- define "kibana.selectorLabels" -}}
+app.kubernetes.io/name: {{ template "kibana.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -9,16 +9,11 @@ spec:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}
-      release: {{ .Release.Name | quote }}
+      {{- include "kibana.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}
-        release: {{ .Release.Name | quote }}
-        {{- range $key, $value := .Values.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        {{- include "kibana.labels" . | nindent 8 }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/kibana/templates/service.yaml
+++ b/kibana/templates/service.yaml
@@ -29,5 +29,4 @@ spec:
       name: {{ .Values.service.httpPortName | default "http" }}
       targetPort: {{ .Values.httpPort }}
   selector:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name | quote }}
+    {{- include "kibana.selectorLabels" . | nindent 4 }}

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -40,6 +40,7 @@ imagePullPolicy: "IfNotPresent"
 
 # additionals labels
 labels: {}
+  # app: kibana
 
 podAnnotations: {}
   # iam.amazonaws.com/role: es-cluster


### PR DESCRIPTION
Ex:

```yaml
# additionals labels
labels:
  app: elasticsearch
```

```yaml
---
# Source: elasticsearch/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: elasticsearch-master
  labels:
    app.kubernetes.io/component: elasticsearch
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: elasticsearch
    app.kubernetes.io/part-of: elasticsearch
    app.kubernetes.io/version: "8.0.0-SNAPSHOT"
    helm.sh/chart: elasticsearch-8.0.0-SNAPSHOT
    app: elasticsearch
  annotations:
    {}
spec:
  type: ClusterIP
  selector:
    release: "RELEASE-NAME"
    chart: "elasticsearch"
    app: "elasticsearch-master"
  ports:
  - name: http
    protocol: TCP
    port: 9200
  - name: transport
    protocol: TCP
    port: 9300

```

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
