### PR TITLE
[7.15] [elasticsearch] Add namespace to helm test command in NOTES.txt (#1105)

### DIFF
--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Watch all cluster members come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "elasticsearch.uname" . }} -w
 2. Test cluster health using Helm test.
-  $ helm test {{ .Release.Name }}
+  $ helm --namespace={{ .Release.Namespace }} test {{ .Release.Name }}


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [elasticsearch] Add namespace to helm test command in NOTES.txt (#1105)