### PR TITLE
[7.x] [meta] fail make test on error (#1386)

### DIFF
--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 GOSS_VERSION := v0.3.6
 GOSS_FILE ?= goss.yaml
 GOSS_SELECTOR ?= release=$(RELEASE)
@@ -10,6 +11,7 @@ help: ## Display this help
 
 .PHONY: goss
 goss: ## Run goss tests
+	set -e; \
 	for i in $$(seq 1 5); do \
 		if [ -z "$$GOSS_CONTAINER" ]; then \
 			sleep 5; \


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [meta] fail make test on error (#1386)