### PR TITLE
[kibana] use new elasticsearch credentials

### DIFF
--- a/kibana/examples/default/test/goss.yaml
+++ b/kibana/examples/default/test/goss.yaml
@@ -2,13 +2,19 @@ http:
   http://localhost:5601/api/status:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
       - '"number":"8.0.0"'
 
   http://localhost:5601/app/kibana:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
 
   http://helm-kibana-default-kibana:5601/app/kibana:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"

--- a/kibana/examples/security/values.yaml
+++ b/kibana/examples/security/values.yaml
@@ -1,23 +1,22 @@
 ---
-
 elasticsearchHosts: "https://security-master:9200"
 
 extraEnvs:
-  - name: 'ELASTICSEARCH_USERNAME'
-    valueFrom:
-      secretKeyRef:
-        name: elastic-credentials
-        key: username
-  - name: 'ELASTICSEARCH_PASSWORD'
-    valueFrom:
-      secretKeyRef:
-        name: elastic-credentials
-        key: password
-  - name: 'KIBANA_ENCRYPTION_KEY'
+  - name: "KIBANA_ENCRYPTION_KEY"
     valueFrom:
       secretKeyRef:
         name: kibana
         key: encryptionkey
+  - name: "ELASTICSEARCH_USERNAME"
+    valueFrom:
+      secretKeyRef:
+        name: security-master-credentials
+        key: username
+  - name: "ELASTICSEARCH_PASSWORD"
+    valueFrom:
+      secretKeyRef:
+        name: security-master-credentials
+        key: password
 
 kibanaConfig:
   kibana.yml: |

--- a/kibana/examples/upgrade/values.yaml
+++ b/kibana/examples/upgrade/values.yaml
@@ -1,2 +1,14 @@
 ---
 elasticsearchHosts: "http://upgrade-master:9200"
+
+extraEnvs:
+  - name: "ELASTICSEARCH_USERNAME"
+    valueFrom:
+      secretKeyRef:
+        name: upgrade-master-credentials
+        key: username
+  - name: "ELASTICSEARCH_PASSWORD"
+    valueFrom:
+      secretKeyRef:
+        name: upgrade-master-credentials
+        key: password

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -9,6 +9,16 @@ replicas: 1
 extraEnvs:
   - name: "NODE_OPTIONS"
     value: "--max-old-space-size=1800"
+  - name: "ELASTICSEARCH_USERNAME"
+    valueFrom:
+      secretKeyRef:
+        name: elasticsearch-master-credentials
+        key: username
+  - name: "ELASTICSEARCH_PASSWORD"
+    valueFrom:
+      secretKeyRef:
+        name: elasticsearch-master-credentials
+        key: password
 #  - name: MY_ENVIRONMENT_VAR
 #    value: the_value_goes_here
 
@@ -42,7 +52,7 @@ imagePullPolicy: "IfNotPresent"
 labels: {}
 
 podAnnotations: {}
-  # iam.amazonaws.com/role: es-cluster
+# iam.amazonaws.com/role: es-cluster
 
 resources:
   requests:
@@ -73,7 +83,7 @@ podSecurityContext:
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   # readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
@@ -117,20 +127,20 @@ service:
   nodePort: ""
   labels: {}
   annotations: {}
-    # cloud.google.com/load-balancer-type: "Internal"
-    # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-    # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    # service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
-    # service.beta.kubernetes.io/cce-load-balancer-internal-vpc: "true"
+  # cloud.google.com/load-balancer-type: "Internal"
+  # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+  # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  # service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+  # service.beta.kubernetes.io/cce-load-balancer-internal-vpc: "true"
   loadBalancerSourceRanges: []
-    # 0.0.0.0/0
+  # 0.0.0.0/0
   httpPortName: http
 
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -156,12 +166,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 lifecycle: {}
-  # preStop:
-  #   exec:
-  #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
-  # postStart:
-  #   exec:
-  #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+# preStop:
+#   exec:
+#     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+# postStart:
+#   exec:
+#     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
 
 # Deprecated - use only with versions < 6.6
 elasticsearchURL: "" # "http://elasticsearch-master:9200"


### PR DESCRIPTION
This commit updates kibana values to use the new Elasticsearch     
credentials from https://github.com/elastic/helm-charts/pull/1384.     
                                                                       
Relates to https://github.com/elastic/helm-charts/issues/1375