### PR TITLE
[metricbeat] use new elasticsearch credentials

### DIFF
--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -72,9 +72,11 @@ upgrading to a new chart version.
 * The default Metricbeat configuration file for this chart is configured to use
 an Elasticsearch endpoint. Without any additional changes, Metricbeat will send
 documents to the service URL that the Elasticsearch Helm chart sets up by
-default. You may either set the `ELASTICSEARCH_HOSTS` environment variable in
-`extraEnvs` to override this endpoint or modify the default `metricbeatConfig`
-to change this behavior.
+default. The Elasticsearch credentials are also retrieved from
+`elasticsearch-master-credentials` Secret from Elasticsearch chart by default.
+You may either set the `ELASTICSEARCH_HOSTS`, `ELASTICSEARCH_USER` and
+`ELASTICSEARCH_PASSWORD` environment variables in `extraEnvs` to override this
+or modify the default `metricbeatConfig` to change this behavior.
 * This chart disables the [HostNetwork][] setting by default for compatibility
 reasons with the majority of kubernetes providers and scenarios. Some kubernetes
 providers may not allow enabling `hostNetwork` and deploying multiple Metricbeat
@@ -96,7 +98,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `daemonset.affinity`           | Configurable [affinity][] for Metricbeat daemonset                                                                                                                           | `{}`                                 |
 | `daemonset.enabled`            | If true, enable daemonset                                                                                                                                                    | `true`                               |
 | `daemonset.envFrom`            | Templatable string of `envFrom` to be passed to the  [environment from variables][] which will be appended to Metricbeat container for DaemonSet                             | `[]`                                 |
-| `daemonset.extraEnvs`          | Extra [environment variables][] which will be appended to Metricbeat container for DaemonSet                                                                                 | `[]`                                 |
+| `daemonset.extraEnvs`          | Extra [environment variables][] which will be appended to Metricbeat container for DaemonSet                                                                                 | see [values.yaml][]                  |
 | `daemonset.extraVolumeMounts`  | Templatable string of additional `volumeMounts` to be passed to the `tpl` function or DaemonSet                                                                              | `[]`                                 |
 | `daemonset.extraVolumes`       | Templatable string of additional `volumes` to be passed to the `tpl` function or DaemonSet                                                                                   | `[]`                                 |
 | `daemonset.hostAliases`        | Configurable [hostAliases][] for Metricbeat DaemonSet                                                                                                                        | `[]`                                 |
@@ -112,7 +114,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `deployment.affinity`          | Configurable [affinity][] for Metricbeat Deployment                                                                                                                          | `{}`                                 |
 | `deployment.enabled`           | If true, enable deployment                                                                                                                                                   | `true`                               |
 | `deployment.envFrom`           | Templatable string of `envFrom` to be passed to the  [environment from variables][] which will be appended to Metricbeat container for Deployment                            | `[]`                                 |
-| `deployment.extraEnvs`         | Extra [environment variables][] which will be appended to Metricbeat container for Deployment                                                                                | `[]`                                 |
+| `deployment.extraEnvs`         | Extra [environment variables][] which will be appended to Metricbeat container for Deployment                                                                                | see [values.yaml][]                  |
 | `deployment.extraVolumeMounts` | Templatable string of additional `volumeMounts` to be passed to the `tpl` function or DaemonSet                                                                              | `[]`                                 |
 | `deployment.extraVolumes`      | Templatable string of additional `volumes` to be passed to the `tpl` function or Deployment                                                                                  | `[]`                                 |
 | `deployment.hostAliases`       | Configurable [hostAliases][] for Metricbeat Deployment                                                                                                                       | `[]`                                 |

--- a/metricbeat/examples/default/test/goss-metrics.yaml
+++ b/metricbeat/examples/default/test/goss-metrics.yaml
@@ -2,7 +2,7 @@ port:
   tcp:5066:
     listening: true
     ip:
-    - '127.0.0.1'
+      - "127.0.0.1"
 
 mount:
   /usr/share/metricbeat/metricbeat.yml:
@@ -20,24 +20,28 @@ http:
   http://elasticsearch-master:9200/_cat/indices:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-8.0.0'
+      - "metricbeat-8.0.0"
 
-  'http://elasticsearch-master:9200/_search?q=metricset.name:state_container%20AND%20kubernetes.container.name:metricbeat':
-    status: 200
+  ? "http://elasticsearch-master:9200/_search?q=metricset.name:state_container%20AND%20kubernetes.container.name:metricbeat"
+  : status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-8.0.0'
+      - "metricbeat-8.0.0"
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
     exists: true
     contains:
-      - 'output.elasticsearch'
-      - 'elasticsearch-master:9200'
+      - "output.elasticsearch"
+      - "elasticsearch-master:9200"
 
 command:
   cd /usr/share/metricbeat && metricbeat test output:
     exit-status: 0
     stdout:
-      - 'elasticsearch: http://elasticsearch-master:9200'
+      - "elasticsearch: http://elasticsearch-master:9200"

--- a/metricbeat/examples/default/test/goss.yaml
+++ b/metricbeat/examples/default/test/goss.yaml
@@ -2,7 +2,7 @@ port:
   tcp:5066:
     listening: true
     ip:
-    - '127.0.0.1'
+      - "127.0.0.1"
 
 mount:
   /usr/share/metricbeat/data:
@@ -24,24 +24,28 @@ http:
   http://elasticsearch-master:9200/_cat/indices:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-8.0.0'
-  'http://elasticsearch-master:9200/_search?q=metricset.name:container%20AND%20kubernetes.container.name:metricbeat':
-    status: 200
+      - "metricbeat-8.0.0"
+  ? "http://elasticsearch-master:9200/_search?q=metricset.name:container%20AND%20kubernetes.container.name:metricbeat"
+  : status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-8.0.0'
+      - "metricbeat-8.0.0"
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
     exists: true
     contains:
-      - 'add_kubernetes_metadata'
-      - 'output.elasticsearch'
-      - 'elasticsearch-master:9200'
+      - "add_kubernetes_metadata"
+      - "output.elasticsearch"
+      - "elasticsearch-master:9200"
 
 command:
   cd /usr/share/metricbeat && metricbeat test output:
     exit-status: 0
     stdout:
-      - 'elasticsearch: http://elasticsearch-master:9200'
+      - "elasticsearch: http://elasticsearch-master:9200"

--- a/metricbeat/examples/oss/test/goss-metrics.yaml
+++ b/metricbeat/examples/oss/test/goss-metrics.yaml
@@ -2,7 +2,7 @@ port:
   tcp:5066:
     listening: true
     ip:
-    - '127.0.0.1'
+      - "127.0.0.1"
 
 mount:
   /usr/share/metricbeat/metricbeat.yml:
@@ -20,22 +20,26 @@ http:
   http://elasticsearch-master:9200/_cat/indices:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-oss-8.0.0'
+      - "metricbeat-oss-8.0.0"
   http://elasticsearch-master:9200/_search?q=metricset.name:state_deployment:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-oss-8.0.0'
+      - "metricbeat-oss-8.0.0"
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
     exists: true
     contains:
-      - 'output.elasticsearch'
+      - "output.elasticsearch"
 
 command:
   cd /usr/share/metricbeat && metricbeat test output:
     exit-status: 0
     stdout:
-      - 'elasticsearch: http://elasticsearch-master:9200'
+      - "elasticsearch: http://elasticsearch-master:9200"

--- a/metricbeat/examples/oss/test/goss.yaml
+++ b/metricbeat/examples/oss/test/goss.yaml
@@ -2,7 +2,7 @@ port:
   tcp:5066:
     listening: true
     ip:
-    - '127.0.0.1'
+      - "127.0.0.1"
 
 mount:
   /usr/share/metricbeat/data:
@@ -24,23 +24,27 @@ http:
   http://elasticsearch-master:9200/_cat/indices:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-oss-8.0.0'
+      - "metricbeat-oss-8.0.0"
   http://elasticsearch-master:9200/_search?q=metricset.name:container:
     status: 200
     timeout: 2000
+    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
+    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
-      - 'metricbeat-oss-8.0.0'
+      - "metricbeat-oss-8.0.0"
 
 file:
   /usr/share/metricbeat/metricbeat.yml:
     exists: true
     contains:
-      - 'add_kubernetes_metadata'
-      - 'output.elasticsearch'
+      - "add_kubernetes_metadata"
+      - "output.elasticsearch"
 
 command:
   cd /usr/share/metricbeat && metricbeat test output:
     exit-status: 0
     stdout:
-      - 'elasticsearch: http://elasticsearch-master:9200'
+      - "elasticsearch: http://elasticsearch-master:9200"

--- a/metricbeat/examples/oss/values.yaml
+++ b/metricbeat/examples/oss/values.yaml
@@ -49,6 +49,8 @@ daemonset:
             system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
       output.elasticsearch:
         hosts: "elasticsearch-master:9200"
+        username: '${ELASTICSEARCH_USERNAME}'
+        password: '${ELASTICSEARCH_PASSWORD}'
         index: "metricbeat-oss-%{[agent.version]}-%{+yyyy.MM.dd}"
       setup.ilm.enabled: false
       setup.template.name: "metricbeat"
@@ -70,6 +72,8 @@ deployment:
         hosts: ["${KUBE_STATE_METRICS_HOSTS}"]
       output.elasticsearch:
         hosts: "elasticsearch-master:9200"
+        username: '${ELASTICSEARCH_USERNAME}'
+        password: '${ELASTICSEARCH_PASSWORD}'
         index: "metricbeat-oss-%{[agent.version]}-%{+yyyy.MM.dd}"
       setup.ilm.enabled: false
       setup.template.name: "metricbeat"

--- a/metricbeat/examples/security/values.yaml
+++ b/metricbeat/examples/security/values.yaml
@@ -1,17 +1,15 @@
 daemonset:
   extraEnvs:
-    - name: 'ELASTICSEARCH_USERNAME'
+    - name: "ELASTICSEARCH_USERNAME"
       valueFrom:
         secretKeyRef:
-          name: elastic-credentials
+          name: security-master-credentials
           key: username
-    - name: 'ELASTICSEARCH_PASSWORD'
+    - name: "ELASTICSEARCH_PASSWORD"
       valueFrom:
         secretKeyRef:
-          name: elastic-credentials
+          name: security-master-credentials
           key: password
-  # Allows you to add any config files in /usr/share/metricbeat
-  # such as metricbeat.yml for daemonset
   metricbeatConfig:
     metricbeat.yml: |
       metricbeat.modules:
@@ -66,24 +64,22 @@ daemonset:
         ssl.certificate_authorities:
           - /usr/share/metricbeat/config/certs/elastic-certificate.pem
   secretMounts:
-  - name: elastic-certificate-pem
-    secretName: elastic-certificate-pem
-    path: /usr/share/metricbeat/config/certs
+    - name: elastic-certificate-pem
+      secretName: elastic-certificate-pem
+      path: /usr/share/metricbeat/config/certs
 
 deployment:
   extraEnvs:
-    - name: 'ELASTICSEARCH_USERNAME'
+    - name: "ELASTICSEARCH_USERNAME"
       valueFrom:
         secretKeyRef:
-          name: elastic-credentials
+          name: security-master-credentials
           key: username
-    - name: 'ELASTICSEARCH_PASSWORD'
+    - name: "ELASTICSEARCH_PASSWORD"
       valueFrom:
         secretKeyRef:
-          name: elastic-credentials
+          name: security-master-credentials
           key: password
-  # Allows you to add any config files in /usr/share/metricbeat
-  # such as metricbeat.yml for deployment
   metricbeatConfig:
     metricbeat.yml: |
       metricbeat.modules:
@@ -105,6 +101,6 @@ deployment:
         ssl.certificate_authorities:
           - /usr/share/metricbeat/config/certs/elastic-certificate.pem
   secretMounts:
-  - name: elastic-certificate-pem
-    secretName: elastic-certificate-pem
-    path: /usr/share/metricbeat/config/certs
+    - name: elastic-certificate-pem
+      secretName: elastic-certificate-pem
+      path: /usr/share/metricbeat/config/certs

--- a/metricbeat/examples/upgrade/values.yaml
+++ b/metricbeat/examples/upgrade/values.yaml
@@ -2,3 +2,13 @@
 extraEnvs:
   - name: ELASTICSEARCH_HOSTS
     value: upgrade-master:9200
+  - name: "ELASTICSEARCH_USERNAME"
+    valueFrom:
+      secretKeyRef:
+        name: upgrade-master-credentials
+        key: username
+  - name: "ELASTICSEARCH_PASSWORD"
+    valueFrom:
+      secretKeyRef:
+        name: upgrade-master-credentials
+        key: password

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -1,5 +1,4 @@
 ---
-
 daemonset:
   # Annotations to apply to the daemonset
   annotations: {}
@@ -12,7 +11,17 @@ daemonset:
   envFrom: []
   # - configMapRef:
   #     name: config-secret
-  extraEnvs: []
+  extraEnvs:
+    - name: "ELASTICSEARCH_USERNAME"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: username
+    - name: "ELASTICSEARCH_PASSWORD"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: password
   #  - name: MY_ENVIRONMENT_VAR
   #    value: the_value_goes_here
   extraVolumes: []
@@ -78,6 +87,8 @@ daemonset:
             system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
       output.elasticsearch:
         hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
+        username: '${ELASTICSEARCH_USERNAME}'
+        password: '${ELASTICSEARCH_PASSWORD}'
   nodeSelector: {}
   # A list of secrets and their paths to mount inside the pod
   # This is useful for mounting certificates for security other sensitive values
@@ -113,7 +124,17 @@ deployment:
   envFrom: []
   # - configMapRef:
   #     name: config-secret
-  extraEnvs: []
+  extraEnvs:
+    - name: "ELASTICSEARCH_USERNAME"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: username
+    - name: "ELASTICSEARCH_PASSWORD"
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: password
   #  - name: MY_ENVIRONMENT_VAR
   #    value: the_value_goes_here
   # Allows you to add any config files in /usr/share/metricbeat
@@ -145,6 +166,8 @@ deployment:
         hosts: ["${KUBE_STATE_METRICS_HOSTS}"]
       output.elasticsearch:
         hosts: '${ELASTICSEARCH_HOSTS:elasticsearch-master:9200}'
+        username: '${ELASTICSEARCH_USERNAME}'
+        password: '${ELASTICSEARCH_PASSWORD}'
   nodeSelector: {}
   # A list of secrets and their paths to mount inside the pod
   # This is useful for mounting certificates for security other sensitive values
@@ -215,37 +238,37 @@ readinessProbe:
 managedServiceAccount: true
 
 clusterRoleRules:
-- apiGroups: [""]
-  resources:
-  - nodes
-  - namespaces
-  - events
-  - pods
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions"]
-  resources:
-  - replicasets
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources:
-  - nodes/stats
-  verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - nodes/stats
+    verbs: ["get"]
 
 podAnnotations: {}
-  # iam.amazonaws.com/role: es-cluster
+# iam.amazonaws.com/role: es-cluster
 
 # Custom service account override that the pod will use
 serviceAccount: ""
 
 # Annotations to add to the ServiceAccount that is created if the serviceAccount value isn't set.
 serviceAccountAnnotations: {}
-  # eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/k8s.clustername.namespace.serviceaccount
+# eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/k8s.clustername.namespace.serviceaccount
 
 # How long to wait for metricbeat pods to stop gracefully
 terminationGracePeriod: 30


### PR DESCRIPTION
This commit updates metricbeat values to use the new Elasticsearch    
credentials from https://github.com/elastic/helm-charts/pull/1384.    
                                                                       
Relates to https://github.com/elastic/helm-charts/issues/1375