### PR TITLE
[7.x] Fix typo (#1382)

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -318,7 +318,7 @@ networkPolicy:
     #             - frontend
 
   transport:
-    ## Note that all Elasticsearch Pods can talks to themselves using transport port even if enabled.
+    ## Note that all Elasticsearch Pods can talk to themselves using transport port even if enabled.
     enabled: false
     # explicitNamespacesSelector:
     #   matchLabels:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo (#1382)