### PR TITLE
[meta] add support for K8S 1.21 and remove 1.18

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -38,6 +38,6 @@ APM_SERVER_SUITE:
   - security
   - upgrade
 KUBERNETES_VERSION:
-  - "1.18"
   - "1.19"
   - "1.20"
+  - "1.21"


### PR DESCRIPTION
This commit adds CI tests on GKE K8S 1.21 and removes the tests for 1.18.

Relates to #1380

Should be rebased after #1375 is fixed.