### PR TITLE
[6.8] [meta] add support for K8S 1.21 and remove 1.18 (#1410)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -40,6 +40,6 @@ APM_SERVER_SUITE:
   - security
   - upgrade
 KUBERNETES_VERSION:
-  - "1.18"
   - "1.19"
   - "1.20"
+  - "1.21"


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [meta] add support for K8S 1.21 and remove 1.18 (#1410)