### PR TITLE
[7.x] [meta] add support for K8S 1.21 and remove 1.18 (#1410)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -38,6 +38,6 @@ APM_SERVER_SUITE:
   - security
   - upgrade
 KUBERNETES_VERSION:
-  - "1.18"
   - "1.19"
   - "1.20"
+  - "1.21"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [meta] add support for K8S 1.21 and remove 1.18 (#1410)