### PR TITLE
[elasticsearch] use bash for readiness script

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -227,7 +227,7 @@ spec:
         readinessProbe:
           exec:
             command:
-              - sh
+              - bash
               - -c
               - |
                 #!/usr/bin/env bash -e


### PR DESCRIPTION
This commit set the readiness probe to use bash instead of sh. This is
required for Elasticsearch > 7.16.0 because the Docker image is now
based on Ubuntu instead of CentOS 8, and sh on Ubuntu isn't compatible
with the `if [[ ... -eq .... ]]` statements used in the readiness probe.

cc @elastic/es-delivery 