### PR TITLE
[7.x] [elasticsearch] use bash for readiness script (#1458)

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -227,7 +227,7 @@ spec:
         readinessProbe:
           exec:
             command:
-              - sh
+              - bash
               - -c
               - |
                 #!/usr/bin/env bash -e


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [elasticsearch] use bash for readiness script (#1458)