### PR TITLE
[meta] download goss outside of pods

### DIFF
--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -13,6 +13,7 @@ help: ## Display this help
 goss: ## Run goss tests
 	set -e; \
 	for i in $$(seq 1 5); do \
+		curl -s -L "https://github.com/aelsabbahy/goss/releases/download/v0.3.6/goss-linux-amd64" -o /tmp/goss; \
 		if [ -z "$$GOSS_CONTAINER" ]; then \
 			sleep 5; \
 			echo "Retrieving pod ($$i/5)"; \
@@ -20,7 +21,8 @@ goss: ## Run goss tests
 		else \
 			echo "Testing with pod: $$GOSS_CONTAINER" && \
 			kubectl cp "test/$(GOSS_FILE)" "$$GOSS_CONTAINER:/tmp/$(GOSS_FILE)" && \
-			kubectl exec "$$GOSS_CONTAINER" -- sh -c "cd /tmp/ && curl -s -L \"https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64\" -o goss && chmod +rx ./goss && ./goss --gossfile \"$(GOSS_FILE)\" validate --retry-timeout 300s --sleep 5s --color --format documentation"; \
+			kubectl cp "/tmp/goss" "$$GOSS_CONTAINER:/tmp/goss" && \
+			kubectl exec "$$GOSS_CONTAINER" -- sh -c "chmod +rx /tmp/goss && /tmp/goss --gossfile \"/tmp/$(GOSS_FILE)\" validate --retry-timeout 300s --sleep 5s --color --format documentation"; \
 			break; \
 		fi; \
 	done


### PR DESCRIPTION
This commit update the way goss binary is retrieved in the
tests/examples. The goss binary is now downloaded locally then copied
inside the pod.

This is needed because the Elasticsearch Ubuntu based Docker images is
missing the ca-certificates package, and so the curl https command is
failling with `curl: (77) error setting certificate verify locations`
error.

Follow-up of https://github.com/elastic/helm-charts/pull/1458
Relates to https://github.com/elastic/helm-charts/pull/1459#issuecomment-989987927
