### PR TITLE
[7.x] [meta] download goss outside of pods (#1460)

### DIFF
--- a/helpers/examples.mk
+++ b/helpers/examples.mk
@@ -13,6 +13,7 @@ help: ## Display this help
 goss: ## Run goss tests
 	set -e; \
 	for i in $$(seq 1 5); do \
+		curl -s -L "https://github.com/aelsabbahy/goss/releases/download/v0.3.6/goss-linux-amd64" -o /tmp/goss; \
 		if [ -z "$$GOSS_CONTAINER" ]; then \
 			sleep 5; \
 			echo "Retrieving pod ($$i/5)"; \
@@ -20,7 +21,8 @@ goss: ## Run goss tests
 		else \
 			echo "Testing with pod: $$GOSS_CONTAINER" && \
 			kubectl cp "test/$(GOSS_FILE)" "$$GOSS_CONTAINER:/tmp/$(GOSS_FILE)" && \
-			kubectl exec "$$GOSS_CONTAINER" -- sh -c "cd /tmp/ && curl -s -L \"https://github.com/aelsabbahy/goss/releases/download/$(GOSS_VERSION)/goss-linux-amd64\" -o goss && chmod +rx ./goss && ./goss --gossfile \"$(GOSS_FILE)\" validate --retry-timeout 300s --sleep 5s --color --format documentation"; \
+			kubectl cp "/tmp/goss" "$$GOSS_CONTAINER:/tmp/goss" && \
+			kubectl exec "$$GOSS_CONTAINER" -- sh -c "chmod +rx /tmp/goss && /tmp/goss --gossfile \"/tmp/$(GOSS_FILE)\" validate --retry-timeout 300s --sleep 5s --color --format documentation"; \
 			break; \
 		fi; \
 	done


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [meta] download goss outside of pods (#1460)