### PR TITLE
[elasticsearch] use bash for keystore init container

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -175,10 +175,9 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
-        - sh
+        - bash
         - -c
         - |
-          #!/usr/bin/env bash
           set -euo pipefail
 
           elasticsearch-keystore create
@@ -230,7 +229,7 @@ spec:
               - bash
               - -c
               - |
-                #!/usr/bin/env bash -e
+                #!set -e
 
                 # Exit if ELASTIC_PASSWORD in unset
                 if [ -z "${ELASTIC_PASSWORD}" ]; then


### PR DESCRIPTION
This commit is a follow up of 167278e2 and is updating the keystore
initContainer to also use bash instead of sh. This is required for
Elasticsearch > 7.16.0 because the Docker image is now based on Ubuntu
instead of CentOS 8, and sh on Ubuntu isn't compatible with the
`if [[... -eq ... ]]` statements.
