### PR TITLE
[7.x] [elasticsearch] use bash for keystore init container (#1464)

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -175,10 +175,9 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
-        - sh
+        - bash
         - -c
         - |
-          #!/usr/bin/env bash
           set -euo pipefail
 
           elasticsearch-keystore create
@@ -230,7 +229,7 @@ spec:
               - bash
               - -c
               - |
-                #!/usr/bin/env bash -e
+                set -e
                 # If the node is starting up wait for the cluster to be ready (request params: "{{ .Values.clusterHealthCheckParams }}" )
                 # Once it has started only check that the node itself is responding
                 START_FILE=/tmp/.es_start_file


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [elasticsearch] use bash for keystore init container (#1464)