### PR TITLE
[elasticsearch] fix a typo in 4e31e0cf3d025f9ce877ac52d218f49d72e26447

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -229,7 +229,7 @@ spec:
               - bash
               - -c
               - |
-                #!set -e
+                set -e
 
                 # Exit if ELASTIC_PASSWORD in unset
                 if [ -z "${ELASTIC_PASSWORD}" ]; then


### PR DESCRIPTION
This commit fixes a typo in 4e31e0cf3d025f9ce877ac52d218f49d72e26447.
