### PR TITLE
[metricbeat] remove es metricset search query for oss example

### DIFF
--- a/metricbeat/examples/oss/test/goss.yaml
+++ b/metricbeat/examples/oss/test/goss.yaml
@@ -28,13 +28,6 @@ http:
     password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
     body:
       - "metricbeat-oss-8.0.0"
-  http://elasticsearch-master:9200/_search?q=metricset.name:container:
-    status: 200
-    timeout: 2000
-    username: "{{ .Env.ELASTICSEARCH_USERNAME }}"
-    password: "{{ .Env.ELASTICSEARCH_PASSWORD }}"
-    body:
-      - "metricbeat-oss-8.0.0"
 
 file:
   /usr/share/metricbeat/metricbeat.yml:


### PR DESCRIPTION
This commit removes the goss test in charge of querying Elasticsearch
search API for container metricset in Metricbeat oss example.

This is because the default Elasticsearch used in this test is also used
by the default Metricbeat and so the search API usually return indices
for default Metricbeat for this query in the test environment.
