### PR TITLE
[7.x] [metricbeat] remove es metricset search query for oss example (#1469)

### DIFF
--- a/metricbeat/examples/oss/test/goss.yaml
+++ b/metricbeat/examples/oss/test/goss.yaml
@@ -26,11 +26,6 @@ http:
     timeout: 2000
     body:
       - "metricbeat-oss-7.16.0"
-  http://elasticsearch-master:9200/_search?q=metricset.name:container:
-    status: 200
-    timeout: 2000
-    body:
-      - "metricbeat-oss-7.16.0"
 
 file:
   /usr/share/metricbeat/metricbeat.yml:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [metricbeat] remove es metricset search query for oss example (#1469)