### PR TITLE
[elasticsearch] remove usage of ELASTIC_USERNAME (#1506)

### DIFF
--- a/elasticsearch/examples/config/test/goss.yaml
+++ b/elasticsearch/examples/config/test/goss.yaml
@@ -2,7 +2,7 @@ http:
   http://localhost:9200/_cluster/health:
     status: 200
     timeout: 2000
-    username: "{{ .Env.ELASTIC_USERNAME }}"
+    username: elastic
     password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - "green"
@@ -12,7 +12,7 @@ http:
   http://localhost:9200:
     status: 200
     timeout: 2000
-    username: "{{ .Env.ELASTIC_USERNAME }}"
+    username: elastic
     password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - '"cluster_name" : "config"'

--- a/elasticsearch/examples/config/values.yaml
+++ b/elasticsearch/examples/config/values.yaml
@@ -9,11 +9,6 @@ extraEnvs:
       secretKeyRef:
         name: elastic-config-credentials
         key: password
-  - name: ELASTIC_USERNAME
-    valueFrom:
-      secretKeyRef:
-        name: elastic-config-credentials
-        key: username
 
 # This is just a dummy file to make sure that
 # the keystore can be mounted at the same time

--- a/elasticsearch/examples/security/test/goss.yaml
+++ b/elasticsearch/examples/security/test/goss.yaml
@@ -3,7 +3,7 @@ http:
     status: 200
     timeout: 2000
     allow-insecure: true
-    username: "{{ .Env.ELASTIC_USERNAME }}"
+    username: elastic
     password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - "green"
@@ -14,7 +14,7 @@ http:
     status: 200
     timeout: 2000
     allow-insecure: true
-    username: "{{ .Env.ELASTIC_USERNAME }}"
+    username: elastic
     password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - '"cluster_name" : "security"'
@@ -24,7 +24,7 @@ http:
     status: 200
     timeout: 2000
     allow-insecure: true
-    username: "{{ .Env.ELASTIC_USERNAME }}"
+    username: elastic
     password: "{{ .Env.ELASTIC_PASSWORD }}"
     body:
       - "active"

--- a/elasticsearch/examples/security/values.yaml
+++ b/elasticsearch/examples/security/values.yaml
@@ -26,11 +26,6 @@ extraEnvs:
       secretKeyRef:
         name: elastic-credentials
         key: password
-  - name: ELASTIC_USERNAME
-    valueFrom:
-      secretKeyRef:
-        name: elastic-credentials
-        key: username
 
 secretMounts:
   - name: elastic-certificates

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -247,8 +247,8 @@ spec:
                     set -- "$@" $args
                   fi
 
-                  if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
-                    set -- "$@" -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+                  if [ -n "${ELASTIC_PASSWORD}" ]; then
+                    set -- "$@" -u "elastic:${ELASTIC_PASSWORD}"
                   fi
 
                   curl --output /dev/null -k "$@" "{{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}${path}"


### PR DESCRIPTION
This commit remove the usage of ELASTIC_USERNAME and replace it by
hardcoded "elastic" username.

This is required because ELASTIC_USERNAME don't seem to be supported
anymore supported by Elasticsearch (I couldn't find the exact version
where support was stopped).

Backport of #1506