### PR TITLE
6.8.22 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 6.8.22
+
+* 6.8.22 as default version.
+
+
+| PR | Author | Title |
+| --- | --- | --- |
+| [#1508](https://github.com/elastic/helm-charts/pull/1508) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] remove usage of ELASTIC_USERNAME (#1506)  |
+| [#1498](https://github.com/elastic/helm-charts/pull/1498) | [@elasticmachine](https://github.com/elasticmachine) | Bump version to 6.8.22-SNAPSHOT  |
+
+
 ## 7.16.1
 
 * 7.16.1 as default version.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Note that only the released charts coming from [Elastic Helm repo][] or
 
 | Chart                                      | Latest 7 Version                             | Latest 6 Version                   |
 |--------------------------------------------|----------------------------------------------|------------------------------------|
-| [APM-Server](./apm-server/README.md)       | [`7.16.1`][apm-7] (Beta since 7.7.0)         | [`6.8.21`][apm-6] (Alpha)          |
-| [Elasticsearch](./elasticsearch/README.md) | [`7.16.1`][elasticsearch-7] (GA since 7.7.0) | [`6.8.21`][elasticsearch-6] (Beta) |
-| [Filebeat](./filebeat/README.md)           | [`7.16.1`][filebeat-7] (GA since 7.7.0)      | [`6.8.21`][filebeat-6] (Beta)      |
-| [Kibana](./kibana/README.md)               | [`7.16.1`][kibana-7] (GA since 7.7.0)        | [`6.8.21`][kibana-6] (Beta)        |
-| [Logstash](./logstash/README.md)           | [`7.16.1`][logstash-7] (Beta since 7.5.0)    | [`6.8.21`][logstash-6] (Beta)      |
-| [Metricbeat](./metricbeat/README.md)       | [`7.16.1`][metricbeat-7] (GA since 7.7.0)    | [`6.8.21`][metricbeat-6] (Beta)    |
+| [APM-Server](./apm-server/README.md)       | [`7.16.1`][apm-7] (Beta since 7.7.0)         | [`6.8.22`][apm-6] (Alpha)          |
+| [Elasticsearch](./elasticsearch/README.md) | [`7.16.1`][elasticsearch-7] (GA since 7.7.0) | [`6.8.22`][elasticsearch-6] (Beta) |
+| [Filebeat](./filebeat/README.md)           | [`7.16.1`][filebeat-7] (GA since 7.7.0)      | [`6.8.22`][filebeat-6] (Beta)      |
+| [Kibana](./kibana/README.md)               | [`7.16.1`][kibana-7] (GA since 7.7.0)        | [`6.8.22`][kibana-6] (Beta)        |
+| [Logstash](./logstash/README.md)           | [`7.16.1`][logstash-7] (Beta since 7.5.0)    | [`6.8.22`][logstash-6] (Beta)      |
+| [Metricbeat](./metricbeat/README.md)       | [`7.16.1`][metricbeat-7] (GA since 7.7.0)    | [`6.8.22`][metricbeat-6] (Beta)    |
 
 ### Kubernetes Versions
 


### PR DESCRIPTION

## 6.8.22

* 6.8.22 as default version.


| PR | Author | Title |
| --- | --- | --- |
| [#1508](https://github.com/elastic/helm-charts/pull/1508) | [@jmlrt](https://github.com/jmlrt) | [elasticsearch] remove usage of ELASTIC_USERNAME (#1506)  |
| [#1498](https://github.com/elastic/helm-charts/pull/1498) | [@elasticmachine](https://github.com/elasticmachine) | Bump version to 6.8.22-SNAPSHOT  |

