### PR TITLE
[kibana] #1239 readiness workaround example

### DIFF
--- a/kibana/examples/security/values.yaml
+++ b/kibana/examples/security/values.yaml
@@ -31,6 +31,8 @@ kibanaConfig:
 
 protocol: https
 
+healthCheckPath: /api/status
+
 secretMounts:
   - name: elastic-certificate-pem
     secretName: elastic-certificate-pem


### PR DESCRIPTION
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [X] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
