### PR TITLE
[apm-server] fix podLabels

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         app: apm-server
         release: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/apm-server/tests/apmserver_test.py
+++ b/apm-server/tests/apmserver_test.py
@@ -268,7 +268,7 @@ labels:
 """
     r = helm_template(config)
     assert (
-        r["deployment"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        r["deployment"][name]["spec"]["template"]["metadata"]["labels"]["app.kubernetes.io/name"]
         == "apm-server"
     )
 

--- a/apm-server/tests/apmserver_test.py
+++ b/apm-server/tests/apmserver_test.py
@@ -268,7 +268,9 @@ labels:
 """
     r = helm_template(config)
     assert (
-        r["deployment"][name]["spec"]["template"]["metadata"]["labels"]["app.kubernetes.io/name"]
+        r["deployment"][name]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
         == "apm-server"
     )
 


### PR DESCRIPTION
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [X] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

pod labels were missing from APM template.