### PR TITLE
[meta] fix yaml load warning in tests

### DIFF
--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -10,7 +10,7 @@ def helm_template(config):
         with open(temp.name, "w") as values:
             values.write(config)
         helm_cmd = "helm template release-name -f {0} ./".format(temp.name)
-        result = yaml.load_all(check_output(helm_cmd.split()))
+        result = yaml.load_all(check_output(helm_cmd.split()), Loader=yaml.FullLoader)
 
         results = {}
         for r in result:


### PR DESCRIPTION
According https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation , this fix python warnings when running tests.

Python 3.8
PyYaml 5.4

---

From PyYaml 6, Loader argument is required.