### PR TITLE
feat: upgrade PodDisruptionBudget apiVersion to v1 and keep backward compatibility

### DIFF
--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.maxUnavailable }}
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "elasticsearch.uname" . }}-pdb"

--- a/logstash/templates/poddisruptionbudget.yaml
+++ b/logstash/templates/poddisruptionbudget.yaml
@@ -1,6 +1,10 @@
 ---
 {{- if .Values.maxUnavailable }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "logstash.fullname" . }}-pdb"


### PR DESCRIPTION
Upgrade PodDisruptionBudget apiVersion to v1 and keep backward compatibility using Helm `Capabilities.APIVersions.Has`.

Note: this is a duplicate of https://github.com/elastic/helm-charts/pull/1453, but there is not activity from the author since November..

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
