### PR TITLE
[kibana] use bash for readiness script

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
 {{ toYaml .Values.readinessProbe | indent 10 }}
           exec:
             command:
-              - sh
+              - bash
               - -c
               - |
                 #!/usr/bin/env bash -e


### PR DESCRIPTION
This commit set the readiness probe to use bash instead of sh. This is
required for Kibana > 7.17.0 because the Docker image is now
based on Ubuntu instead of CentOS 8, and sh on Ubuntu isn't compatible
with the if [[ ... -eq .... ]] statements used in the readiness probe.

Fix #1529
