### PR TITLE
[7.x] [kibana] use bash for readiness script (#1530)

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
 {{ toYaml .Values.readinessProbe | indent 10 }}
           exec:
             command:
-              - sh
+              - bash
               - -c
               - |
                 #!/usr/bin/env bash -e


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [kibana] use bash for readiness script (#1530)