### PR TITLE
[7.16] [tests] fix yaml load warning (#1522)

### DIFF
--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -10,7 +10,7 @@ def helm_template(config):
         with open(temp.name, "w") as values:
             values.write(config)
         helm_cmd = "helm template release-name -f {0} ./".format(temp.name)
-        result = yaml.load_all(check_output(helm_cmd.split()))
+        result = yaml.load_all(check_output(helm_cmd.split()), Loader=yaml.FullLoader)
 
         results = {}
         for r in result:


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [tests] fix yaml load warning (#1522)