### PR TITLE
[elasticsearch] Move the yaml separator inside the condition

### DIFF
--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.maxUnavailable }}
+---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.service.enabled -}}
+---
 kind: Service
 apiVersion: v1
 metadata:

--- a/elasticsearch/templates/test/test-elasticsearch-health.yaml
+++ b/elasticsearch/templates/test/test-elasticsearch-health.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.tests.enabled -}}
+---
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
The chomp "{{-" removes newline also - so we end up with a resource yaml which looks like:

```
---kind: Service
apiVersion: v1
...
```
This causes errors in ArgoCD: "error unmarshaling JSON: while decoding JSON: Object 'Kind' is missing in ..."

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Fix #1418