### PR TITLE
[meta] remove 7.x branch from backport config

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,16 +1,15 @@
 {
-  "upstream": "elastic/helm-charts",
-  "targetBranchChoices": [
-    "6.8",
-    "7.17",
-    "7.x"
-  ],
   "all": true,
   "prFilter": "label:need-backport",
+  "sourcePRLabels": [
+    "backported"
+  ],
+  "targetBranchChoices": [
+    "6.8",
+    "7.17"
+  ],
   "targetPRLabels": [
     "backport"
   ],
-  "sourcePRLabels": [
-    "backported"
-  ]
+  "upstream": "elastic/helm-charts"
 }


### PR DESCRIPTION
7.x branch has been removed has there won't be any 7.18 minor version.
