### PR TITLE
[7.17] [elasticsearch] Move the yaml separator inside the condition (#1538)

### DIFF
--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.maxUnavailable }}
+---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.service.enabled -}}
+---
 kind: Service
 apiVersion: v1
 metadata:

--- a/elasticsearch/templates/test/test-elasticsearch-health.yaml
+++ b/elasticsearch/templates/test/test-elasticsearch-health.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.tests.enabled -}}
+---
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [elasticsearch] Move the yaml separator inside the condition (#1538)