### PR TITLE
chore(elastisearch): update resources' apiVersion to v1

### DIFF
--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if .Values.maxUnavailable }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "elasticsearch.uname" . }}-pdb"

--- a/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}


### PR DESCRIPTION
Both `PodDisruptionBudget` and `PodSecurityPolicy` resources are unavailable on **apiVersion** `v1beta1` since Kubernetes 1.25+. Upgrading them to `v1` solves the issue.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
  - [x] Not applicable
- [x] Updated template tests in `${CHART}/tests/*.py` 
  - [x] Not applicable
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
  - [x] Not applicable
