### PR TITLE
fix: headless service as ingress backend

### DIFF
--- a/logstash/templates/ingress.yaml
+++ b/logstash/templates/ingress.yaml
@@ -44,7 +44,7 @@ spec:
         pathType: {{ $pathtype }}
         backend:
           service:
-            name: {{ $fullName }}
+            name: {{ $fullName }}-headless
             port:
               number: {{ $httpPort }}
     {{- end }}

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -940,7 +940,7 @@ ingress:
     assert s["spec"]["rules"][0]["host"] == "logstash.local"
     assert s["spec"]["rules"][0]["http"]["paths"][0]["path"] == "/logs"
     assert (
-        s["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"] == name
+        s["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"] == name + "-headless"
     )
     assert (
         s["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["port"][


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [.] README.md updated with any new values or changes
  n.a.
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [.] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
  n.a. (doesn't exist for ingress)
  
Hi all,

I wanted to expose the httpPort of the headless service via ingress, but ran into a bug.

For the ingress backend, the port and service do not match:

- Ingress backend port is the httpPort (which is also the port of the headless service)
- Ingress backend service is "logstash.fullname" (which equal the name of the ClusterIP service)

In order to expose the httpPort 9600, I needed to change the ingress backend service into:
"logstash.fullname"-headless


Cheers,
Dirc
