### PR TITLE
(ElasticSearch) Add override for initial_master_nodes and seed_hosts

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -312,16 +312,16 @@ spec:
                 fieldPath: metadata.name
           {{- if has "master" .Values.roles }}
           - name: cluster.initial_master_nodes
-            value: "{{ template "elasticsearch.endpoints" . }}"
+            value: "{{- tpl .Values.initial_master_nodes . -}}"
           {{- end }}
           - name: node.roles
             value: "{{ template "elasticsearch.roles" . }}"
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts
-            value: "{{ template "elasticsearch.masterService" . }}-headless"
+            value: "{{- tpl .Values.seed_hosts . -}}"
           {{- else }}
           - name: discovery.seed_hosts
-            value: "{{ template "elasticsearch.masterService" . }}-headless"
+            value: "{{- tpl .Values.seed_hosts . -}}"
           {{- end }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -312,16 +312,16 @@ spec:
                 fieldPath: metadata.name
           {{- if has "master" .Values.roles }}
           - name: cluster.initial_master_nodes
-            value: "{{- tpl .Values.initial_master_nodes . -}}"
+            value: "{{- tpl .Values.initialMasterNodes . -}}"
           {{- end }}
           - name: node.roles
             value: "{{ template "elasticsearch.roles" . }}"
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts
-            value: "{{- tpl .Values.seed_hosts . -}}"
+            value: "{{- tpl .Values.seedHosts . -}}"
           {{- else }}
           - name: discovery.seed_hosts
-            value: "{{- tpl .Values.seed_hosts . -}}"
+            value: "{{- tpl .Values.seedHosts . -}}"
           {{- end }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -217,6 +217,19 @@ roles:
     for e in env:
         assert e["name"] != "discovery.zen.ping.unicast.hosts"
 
+def test_override_seed_hosts_template():
+    config = """
+seedHosts: "customHost"
+"""
+    r = helm_template(config)
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["env"]
+    assert {
+        "name": "cluster.seed_hosts",
+        "value": "customHost",
+    } in env
+
 
 def test_adding_extra_env_vars():
     config = """
@@ -1366,6 +1379,19 @@ fullnameOverride: "customfullName"
         "value": "customfullName-0," + "customfullName-1," + "customfullName-2,",
     } in env
 
+
+def test_override_initial_master_node_template():
+    config = """
+initialMasterNodes: "customNode"
+"""
+    r = helm_template(config)
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["env"]
+    assert {
+        "name": "cluster.initial_master_nodes",
+        "value": "customNode",
+    } in env
 
 def test_hostaliases():
     config = """

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -39,10 +39,10 @@ esConfig: {}
 # This is an advanced setup.
 # It is advised to create a master setup in one cluster and a non-master cluster connecting to this one
 # using "masterService".
-initial_master_nodes: |-
+initialMasterNodes: |-
   {{ template "elasticsearch.endpoints" . }}
 
-seed_hosts: |-
+seedHosts: |-
   {{ template "elasticsearch.masterService" . }}-headless
 
 

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -35,6 +35,17 @@ esConfig: {}
 #  log4j2.properties: |
 #    key = value
 
+# Initial_master_nodes and seed_hosts can be overridden to allow multi-master multi-cluster setup.
+# This is an advanced setup.
+# It is advised to create a master setup in one cluster and a non-master cluster connecting to this one
+# using "masterService".
+initial_master_nodes: |-
+  {{ template "elasticsearch.endpoints" . }}
+
+seed_hosts: |-
+  {{ template "elasticsearch.masterService" . }}-headless
+
+
 createCert: true
 
 esJvmOptions: {}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes


Hi Elasticsearch.
This short PR introduce an override of template values.
This would close #1268 by enabling full override of `cluster.initial_master_nodes`.
