### PR TITLE
[Kibana] Closes #1574 Fix readinessProbe double brace notation error 

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
                     fi
 
                     STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "{{ .Values.protocol }}://localhost:{{ .Values.httpPort }}${path}")
-                    if [[ "${STATUS}" -eq 200 ]]; then
+                    if [ "${STATUS}" -eq 200 ]; then
                       exit 0
                     fi
 


### PR DESCRIPTION
The error was caused by an incorrect double brace notation inside the last readinessProbe condition, causing the condition to never be true 
Fixed by removing a couple of braces.