### PR TITLE
[metricbeat] helm dep update

### DIFF
--- a/metricbeat/requirements.lock
+++ b/metricbeat/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://charts.helm.sh/stable
-  version: 2.4.1
-digest: sha256:948dca129bc7c16b138ed8bcbdf666c324d812e43af59d475b8bb74a53e99778
-generated: "2020-10-30T18:58:57.381827+01:00"
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.5.0
+digest: sha256:a3af8e4c05526934f03b0e441eb50e0886b462a7a4978b067cd1ac8eb6ff48bd
+generated: "2022-02-16T17:37:31.963561593+01:00"

--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: 'kube-state-metrics'
-    version: '2.4.1'
-    repository: '@stable'
+    version: '4.5.0'
+    repository: 'https://prometheus-community.github.io/helm-charts'
     condition: kube_state_metrics.enabled


### PR DESCRIPTION
updates kube-state-metrics to chart version 4.5.0 from prometheus-community

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

Addresses Issue: #1576 