### PR TITLE
[elasticsearch] fix ServiceAccount inconsistencies

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -28,7 +28,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Generate certificates 
+Generate certificates
 */}}
 {{- define "elasticsearch.gen-certs" -}}
 {{- $altNames := list ( printf "%s.%s" (include "elasticsearch.name" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "elasticsearch.name" .) .Release.Namespace ) -}}
@@ -80,4 +80,11 @@ ca.crt: {{ $ca.Cert | toString | b64enc }}
 8
   {{- end -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Use the fullname if the serviceAccount value is not set
+*/}}
+{{- define "elasticsearch.serviceAccount" -}}
+{{- .Values.rbac.serviceAccountName | default (include "elasticsearch.uname" .) -}}
 {{- end -}}

--- a/elasticsearch/templates/rolebinding.yaml
+++ b/elasticsearch/templates/rolebinding.yaml
@@ -11,11 +11,7 @@ metadata:
     app: {{ $fullName | quote }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.rbac.serviceAccountName "" }}
-    name: {{ $fullName | quote }}
-    {{- else }}
-    name: {{ .Values.rbac.serviceAccountName | quote }}
-    {{- end }}
+    name: "{{ template "elasticsearch.serviceAccount" . }}"
     namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: Role

--- a/elasticsearch/templates/serviceaccount.yaml
+++ b/elasticsearch/templates/serviceaccount.yaml
@@ -3,11 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if eq .Values.rbac.serviceAccountName "" }}
-  name: {{ $fullName | quote }}
-  {{- else }}
-  name: {{ .Values.rbac.serviceAccountName | quote }}
-  {{- end }}
+  name: "{{ template "elasticsearch.serviceAccount" . }}"
   annotations:
     {{- with .Values.rbac.serviceAccountAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -69,10 +69,8 @@ spec:
         {{- if .Values.fsGroup }}
         fsGroup: {{ .Values.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
         {{- end }}
-      {{- if .Values.rbac.create }}
-      serviceAccountName: "{{ template "elasticsearch.uname" . }}"
-      {{- else if not (eq .Values.rbac.serviceAccountName "") }}
-      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- if or .Values.rbac.create .Values.rbac.serviceAccountName }}
+      serviceAccountName: "{{ template "elasticsearch.serviceAccount" . }}"
       {{- end }}
       automountServiceAccountToken: {{ .Values.rbac.automountToken }}
       {{- with .Values.tolerations }}


### PR DESCRIPTION
This commit refactor the way we define the ServiceAccount name to fix an
issue where a ServiceAccount is created with a custom name but the
Statefulset is trying to use a different ServiceAccount.

Fix #1455
