### PR TITLE
[logstash] fix ServiceAccount inconsistencies

### DIFF
--- a/logstash/templates/_helpers.tpl
+++ b/logstash/templates/_helpers.tpl
@@ -18,3 +18,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Use the fullname if the serviceAccount value is not set
+*/}}
+{{- define "logstash.serviceAccount" -}}
+{{- .Values.rbac.serviceAccountName | default (include "logstash.fullname" .) -}}
+{{- end -}}

--- a/logstash/templates/rolebinding.yaml
+++ b/logstash/templates/rolebinding.yaml
@@ -11,11 +11,7 @@ metadata:
     release: {{ .Release.Name | quote }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.rbac.serviceAccountName "" }}
-    name: {{ $fullName | quote }}
-    {{- else }}
-    name: {{ .Values.rbac.serviceAccountName | quote }}
-    {{- end }}
+    name: "{{ template "logstash.serviceAccount" . }}"
     namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: Role

--- a/logstash/templates/serviceaccount.yaml
+++ b/logstash/templates/serviceaccount.yaml
@@ -3,11 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if eq .Values.rbac.serviceAccountName "" }}
-  name: {{ $fullName | quote }}
-  {{- else }}
-  name: {{ .Values.rbac.serviceAccountName | quote }}
-  {{- end }}
+  name: "{{ template "logstash.serviceAccount" . }}"
   annotations:
     {{- with .Values.rbac.serviceAccountAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/logstash/templates/statefulset.yaml
+++ b/logstash/templates/statefulset.yaml
@@ -67,10 +67,8 @@ spec:
       {{- end }}
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
-      {{- if .Values.rbac.create }}
-      serviceAccountName: "{{ template "logstash.fullname" . }}"
-      {{- else if not (eq .Values.rbac.serviceAccountName "") }}
-      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- if or .Values.rbac.create .Values.rbac.serviceAccountName }}
+      serviceAccountName: "{{ template "logstash.serviceAccount" . }}"
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
This commit refactor the way we define the ServiceAccount name to fix an
issue where a ServiceAccount is created with a custom name but the
Statefulset is trying to use a different ServiceAccount.

Relates to #1455 and 1580
