### PR TITLE
[7.17] fix(APM): add pod labels (#1527)

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         app: apm-server
         release: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Backports the following commits to 7.17:
 - fix(APM): add pod labels (#1527)