### PR TITLE
[7.17] [APM] fix podLabels (#1521)

### DIFF
--- a/apm-server/tests/apmserver_test.py
+++ b/apm-server/tests/apmserver_test.py
@@ -268,7 +268,9 @@ labels:
 """
     r = helm_template(config)
     assert (
-        r["deployment"][name]["metadata"]["labels"]["app.kubernetes.io/name"]
+        r["deployment"][name]["spec"]["template"]["metadata"]["labels"][
+            "app.kubernetes.io/name"
+        ]
         == "apm-server"
     )
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [APM] fix podLabels (#1521)