### PR TITLE
[7.17] [metricbeat] bump kube-state-metrics to version 4.7.0 (#1524)

### DIFF
--- a/helpers/helm-tester/Dockerfile
+++ b/helpers/helm-tester/Dockerfile
@@ -3,11 +3,11 @@ FROM python:3.7
 ENV HELM_VERSION=3.8.0
 
 RUN wget --no-verbose https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
-    tar xfv helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /usr/local/bin/ && \
-    mkdir --parents --mode=777 /.config/helm && \
-    HOME=/ helm repo add stable https://charts.helm.sh/stable && \
-    rm -rf helm-v${HELM_VERSION}-linux-amd64.tar.gz linux-amd64
+  tar xfv helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+  mv linux-amd64/helm /usr/local/bin/ && \
+  mkdir --parents --mode=777 /.config/helm && \
+  HOME=/ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts && \
+  rm -rf helm-v${HELM_VERSION}-linux-amd64.tar.gz linux-amd64
 
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -49,9 +49,9 @@ This chart is tested with the latest 7.17.0-SNAPSHOT version.
 `helm repo add elastic https://helm.elastic.co`
 
 * Install it:
-  - Add the Elastic Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add stable https://charts.helm.sh/stable`
-  - with Helm 3: `helm install metricbeat --version <version> elastic/metricbeat`
-  - with Helm 2 (deprecated): `helm install --name metricbeat --version <version> elastic/metricbeat`
+  - Add the Prometheus community Helm charts repo (required for kube-state-metrics chart dependency): `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
+  - with Helm 3: `helm install metricbeat elastic/metricbeat`
+  - with Helm 2 (deprecated): `helm install --name metricbeat elastic/metricbeat`
 
 ### Install development version from a branch
 
@@ -133,7 +133,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `imagePullSecrets`             | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                                                 | `[]`                                 |
 | `imageTag`                     | The Metricbeat Docker image tag                                                                                                                                              | `7.17.0-SNAPSHOT`                    |
 | `image`                        | The Metricbeat Docker image                                                                                                                                                  | `docker.elastic.co/beats/metricbeat` |
-| `kube_state_metrics.enabled`   | Install [kube-state-metrics](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) as a dependency                                                           | `true`                               |
+| `kube_state_metrics.enabled`   | Install [kube-state-metrics][] chart as a dependency                                                                                                                         | `true`                               |
 | `kube_state_metrics.host`      | Define kube-state-metrics endpoint for an existing deployment. Works only if `kube_state_metrics.enabled: false`                                                             | `""`                                 |
 | `livenessProbe`                | Parameters to pass to liveness [probe][] checks for values such as timeouts and thresholds                                                                                   | see [values.yaml][]                  |
 | `managedServiceAccount`        | Whether the `serviceAccount` should be managed by this helm chart. Set this to `false` in order to manage your own service account and related roles                         | `true`                               |
@@ -243,7 +243,7 @@ about our development and testing process.
 [hostNetwork]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
 [imagePullPolicy]: https://kubernetes.io/docs/concepts/containers/images/#updating-images
 [imagePullSecrets]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
-[kube-state-metrics]: https://github.com/helm/charts/tree/7.17/stable/kube-state-metrics
+[kube-state-metrics]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [metricbeat docker image]: https://www.elastic.co/guide/en/beats/metricbeat/7.17/running-on-docker.html

--- a/metricbeat/examples/default/Makefile
+++ b/metricbeat/examples/default/Makefile
@@ -6,7 +6,7 @@ RELEASE = helm-metricbeat-default
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-default-metricbeat
 
 install:
-	helm repo add stable https://charts.helm.sh/stable
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm dependency update ../../
 	helm upgrade --wait --timeout=$(TIMEOUT) --install $(RELEASE) ../../
 

--- a/metricbeat/examples/oss/Makefile
+++ b/metricbeat/examples/oss/Makefile
@@ -6,7 +6,7 @@ RELEASE := helm-metricbeat-oss
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-oss-metricbeat
 
 install:
-	helm repo add stable https://charts.helm.sh/stable
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm dependency update ../../
 	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 

--- a/metricbeat/examples/security/Makefile
+++ b/metricbeat/examples/security/Makefile
@@ -6,7 +6,7 @@ RELEASE := helm-metricbeat-security
 GOSS_SELECTOR = release=$(RELEASE),app=helm-metricbeat-security-metricbeat
 
 install:
-	helm repo add stable https://charts.helm.sh/stable
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm dependency update ../../
 	helm upgrade --wait --timeout=$(TIMEOUT) --install --values values.yaml $(RELEASE) ../../
 

--- a/metricbeat/examples/upgrade/Makefile
+++ b/metricbeat/examples/upgrade/Makefile
@@ -8,7 +8,7 @@ FROM := 7.10.0	# upgrade from version < 7.10.0 is failing due to selector
 								# breaking change in https://github.com/elastic/helm-charts/pull/516
 
 install:
-	helm repo add stable https://charts.helm.sh/stable
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm dependency update ../../
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)
 	kubectl rollout status daemonset $(RELEASE)-metricbeat

--- a/metricbeat/requirements.lock
+++ b/metricbeat/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://charts.helm.sh/stable
-  version: 2.4.1
-digest: sha256:948dca129bc7c16b138ed8bcbdf666c324d812e43af59d475b8bb74a53e99778
-generated: "2020-10-30T18:58:57.381827+01:00"
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.7.0
+digest: sha256:60ae66494279193461b5b392e040520aa2d9b048eca98a4d9208a38d0e252b3d
+generated: "2022-03-01T10:35:09.802732087Z"

--- a/metricbeat/requirements.yaml
+++ b/metricbeat/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  - name: 'kube-state-metrics'
-    version: '2.4.1'
-    repository: '@stable'
+  - name: "kube-state-metrics"
+    version: "4.7.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
     condition: kube_state_metrics.enabled


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [metricbeat] bump kube-state-metrics to version 4.7.0 (#1524)