### PR TITLE
[7.17] [logstash] add externalTrafficPolicy support (#1570)

### DIFF
--- a/logstash/templates/service.yaml
+++ b/logstash/templates/service.yaml
@@ -20,6 +20,9 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
   selector:
     app: "{{ template "logstash.fullname" . }}"
     chart: "{{ .Chart.Name }}"

--- a/logstash/tests/logstash_test.py
+++ b/logstash/tests/logstash_test.py
@@ -964,6 +964,17 @@ service:
     assert "loadBalancerIP" not in s["spec"]
 
 
+def test_adding_an_externalTrafficPolicy():
+    config = """
+    service:
+      externalTrafficPolicy: Local
+    """
+
+    r = helm_template(config)
+
+    assert r["service"][name]["spec"]["externalTrafficPolicy"] == "Local"
+
+
 def test_setting_fullnameOverride():
     config = """
 fullnameOverride: 'logstash-custom'

--- a/logstash/values.yaml
+++ b/logstash/values.yaml
@@ -264,6 +264,7 @@ service: {}
 #  annotations: {}
 #  type: ClusterIP
 #  loadBalancerIP: ""
+#  externalTrafficPolicy: ""
 #  ports:
 #    - name: beats
 #      port: 5044


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [logstash] add externalTrafficPolicy support (#1570)