### PR TITLE
[7.17] [elasticsearch] add keystore container securityContext (#1494)

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -175,6 +175,8 @@ spec:
       {{- end }}
 {{ if .Values.keystore }}
       - name: keystore
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [elasticsearch] add keystore container securityContext (#1494)