### PR TITLE
[filebeat] add missing rolebinding and cluster role rules

### DIFF
--- a/filebeat/templates/rolebinding.yaml
+++ b/filebeat/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "filebeat.serviceAccount" . }}-role-binding
+  labels:
+    app: "{{ template "filebeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+roleRef:
+  kind: Role
+  name: {{ template "filebeat.serviceAccount" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "filebeat.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -211,6 +211,14 @@ clusterRoleRules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
 
 podAnnotations: {}
 # iam.amazonaws.com/role: es-cluster


### PR DESCRIPTION
This commits add a rolebinding and cluster role rules to match
https://github.com/elastic/beats/blob/main/deploy/kubernetes/filebeat-kubernetes.yaml

Follow-up of #1422 