### PR TITLE
[metricbeat] add missing rolebinding and cluster role rules

### DIFF
--- a/metricbeat/templates/rolebinding.yaml
+++ b/metricbeat/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metricbeat.serviceAccount" . }}-role-binding
+  labels:
+    app: "{{ template "metricbeat.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "metricbeat.serviceAccount" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metricbeat.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -244,6 +244,7 @@ clusterRoleRules:
       - namespaces
       - events
       - pods
+      - services
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions"]
     resources:
@@ -259,10 +260,16 @@ clusterRoleRules:
     resources:
       - nodes/stats
     verbs: ["get"]
-  - apiGroups: ["coordination.k8s.io"]
+  - apiGroups:
+    - ""
     resources:
-      - leases
-    verbs: ["create", "get", "list", "update"]
+    - nodes/stats
+    verbs:
+    - get
+  - nonResourceURLs:
+    - "/metrics"
+    verbs:
+    - get
 
 podAnnotations: {}
 # iam.amazonaws.com/role: es-cluster


### PR DESCRIPTION
This commits add a rolebinding and cluster role rules to match
https://github.com/elastic/beats/blob/main/deploy/kubernetes/metricbeat-kubernetes.yaml

Follow-up of #1422
