### PR TITLE
Remove replicas field from deployment when autoscaling is enabled

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if or (not .Values.autoscaling) (eq .Values.autoscaling.enabled false) }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   selector:


### PR DESCRIPTION
ARGOCD requires to omit replicas in deployment when using HPA autoscaling, otherwise Argocd app will always be out-of-sync. See here: https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness

- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
