### PR TITLE
[metricbeat] fix upgrade test

### DIFF
--- a/metricbeat/examples/upgrade/Makefile
+++ b/metricbeat/examples/upgrade/Makefile
@@ -4,8 +4,8 @@ include ../../../helpers/examples.mk
 
 CHART := metricbeat
 RELEASE := helm-metricbeat-upgrade
-FROM := 7.10.0	# upgrade from version < 7.10.0 is failing due to selector
-								# breaking change in https://github.com/elastic/helm-charts/pull/516
+FROM := 7.17.1	# upgrade from version < 7.17.1 is failing due to kube-state-metrics
+								# dependency upgrade in https://github.com/elastic/helm-charts/pull/1524
 
 install:
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
This commit fix the Metricbeat upgrade test by bumping the source
version to 7.17.1. This is required because
https://github.com/elastic/helm-charts/pull/1524 introduced a new
kube-state-metrics version that prevent upgrade from previous versions.
