### PR TITLE
add ingress option to redirect to https

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -257,6 +257,8 @@ ingress:
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
+  ## Enable backend protocol when security is enabled to ensure that nginx redirect to https instead of http
+  # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   className: "nginx"
   pathtype: ImplementationSpecific
   hosts:


### PR DESCRIPTION
when elasticsearch runs in secure mode, the internal service runs on https.
without nginx.ingress.kubernetes.io/backend-protocol: "HTTPS" , ingress would forward requests to http://service:9200 instead of the correct https://service:9200

- [x ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
