### PR TITLE
elasticsearch: fix labels "chart". Closes #1615

### DIFF
--- a/elasticsearch/templates/role.yaml
+++ b/elasticsearch/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name | quote }}
     app: {{ $fullName | quote }}
 rules:
   - apiGroups:

--- a/elasticsearch/templates/rolebinding.yaml
+++ b/elasticsearch/templates/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name | quote }}
     app: {{ $fullName | quote }}
 subjects:
   - kind: ServiceAccount

--- a/elasticsearch/templates/serviceaccount.yaml
+++ b/elasticsearch/templates/serviceaccount.yaml
@@ -11,6 +11,6 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name | quote }}
     app: {{ $fullName | quote }}
 {{- end -}}


### PR DESCRIPTION
A possible fix for #1615 

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
