### PR TITLE
[elasticsearch] add subject dn to cert alternative names

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -31,7 +31,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Generate certificates
 */}}
 {{- define "elasticsearch.gen-certs" -}}
-{{- $altNames := list ( printf "%s.%s" (include "elasticsearch.masterService" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "elasticsearch.masterService" .) .Release.Namespace ) -}}
+{{- $altNames := list ( include "elasticsearch.masterService" . ) ( printf "%s.%s" (include "elasticsearch.masterService" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "elasticsearch.masterService" .) .Release.Namespace ) -}}
 {{- $ca := genCA "elasticsearch-ca" 365 -}}
 {{- $cert := genSignedCert ( include "elasticsearch.masterService" . ) nil $altNames 365 $ca -}}
 tls.crt: {{ $cert.Cert | toString | b64enc }}


### PR DESCRIPTION
This also seem to be required to Logstash can reuse the Elasticsearch
certificates to connect to Elasticsearch Service.

Follow-up of #1624
Required for #1623
