### PR TITLE
[elasticsearch] upgrade test from 7.17.1 to 8.x

### DIFF
--- a/elasticsearch/examples/upgrade/Makefile
+++ b/elasticsearch/examples/upgrade/Makefile
@@ -4,7 +4,7 @@ include ../../../helpers/examples.mk
 
 CHART := elasticsearch
 RELEASE := helm-es-upgrade
-FROM := 7.4.0	# versions before 7.4.O aren't compatible with Kubernetes >= 1.16.0
+FROM := 7.17.1	# upgrade from versions before 7.17.1 isn't compatible with 8.x
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)


### PR DESCRIPTION
This commit update the upgrade test to upgrade Elasticsearch chart from
7.17.1 to 8.x instead of from 7.4.0.

This is because Elasticsearch requires upgrading to the last minor 7.x
version (7.17.x) before proceding to 8.x major upgrade.
