### PR TITLE
[meta] update upgrade tests base version

### DIFF
--- a/apm-server/examples/upgrade/Makefile
+++ b/apm-server/examples/upgrade/Makefile
@@ -4,7 +4,8 @@ include ../../../helpers/examples.mk
 
 CHART := apm-server
 RELEASE := helm-apm-server-upgrade
-FROM := 7.6.0	# 7.6.0 is the first release for apm-server
+# K8S 1.22 doesn't support anymore rbac.authorization.k8s.io/v1beta1 used in 7.9.0
+FROM := 7.10.0
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)

--- a/filebeat/examples/upgrade/Makefile
+++ b/filebeat/examples/upgrade/Makefile
@@ -4,7 +4,8 @@ include ../../../helpers/examples.mk
 
 CHART := filebeat
 RELEASE := helm-filebeat-upgrade
-FROM := 7.9.0 # registry file version 1 not supported error with previous version
+# K8S 1.22 doesn't support anymore rbac.authorization.k8s.io/v1beta1 used in 7.9.0
+FROM := 7.10.0
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM)


### PR DESCRIPTION
This commit updates the upgrade tests for apm-server and filebeat
to use 7.10.0 base version before trying an upgrade.
This is required because the previous versions used
`rbac.authorization.k8s.io/v1beta1` K8S API which isn't supported
anymore in K8S 1.22.
