### PR TITLE
Make ServiceAccount optional for APM

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -40,7 +40,9 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
+{{- if or (.Values.managedServiceAccount) (ne .Values.serviceAccount "") }}
       serviceAccountName: {{ template "apm.serviceAccount" . }}
+{{- end }}
       {{- if .Values.hostAliases }}
       hostAliases: {{ toYaml .Values.hostAliases | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Deployment will fail if `managedServiceAccount = false` and `serviceAccount = ""` (default) is provided.
* UseCase: Cluster run in RBAC mode and no ClusterRoles are allowed to be created by users.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
