### PR TITLE
Feature/digest support

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
       {{- end }}
       containers:
       - name: apm-server
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}{{- if .Values.imageDigest -}}@{{ .Values.imageDigest }}{{ else }}:{{  .Values.imageTag }}{{- end -}}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         {{- with .Values.extraEnvs }}
         env:

--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
       {{- end }}
       containers:
       - name: apm-server
-        image: "{{ .Values.image }}{{- if .Values.imageDigest -}}@{{ .Values.imageDigest }}{{ else }}:{{  .Values.imageTag }}{{- end -}}"
+        image: "{{ .Values.image }}{{- if .Values.imageDigest -}}@{{ .Values.imageDigest }}{{ else }}:{{ .Values.imageTag }}{{- end -}}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         {{- with .Values.extraEnvs }}
         env:

--- a/apm-server/values.yaml
+++ b/apm-server/values.yaml
@@ -67,6 +67,7 @@ hostAliases: []
 
 image: "docker.elastic.co/apm/apm-server"
 imageTag: "8.1.0"
+imageDigest: ""
 imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 

--- a/apm-server/values.yaml
+++ b/apm-server/values.yaml
@@ -190,4 +190,3 @@ lifecycle: {}
 # postStart:
 #   exec:
 #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
-

--- a/apm-server/values.yaml
+++ b/apm-server/values.yaml
@@ -190,3 +190,4 @@ lifecycle: {}
 # postStart:
 #   exec:
 #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+


### PR DESCRIPTION
Support for deploy apm-server by digest in case enabled binary authorization in GCP GKE.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
