### PR TITLE
make ELASTIC_PASSWORD env var optional

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -241,12 +241,6 @@ spec:
               - |
                 set -e
 
-                # Exit if ELASTIC_PASSWORD in unset
-                if [ -z "${ELASTIC_PASSWORD}" ]; then
-                  echo "ELASTIC_PASSWORD variable is missing, exiting"
-                  exit 1
-                fi
-
                 # If the node is starting up wait for the cluster to be ready (request params: "{{ .Values.clusterHealthCheckParams }}" )
                 # Once it has started only check that the node itself is responding
                 START_FILE=/tmp/.es_start_file
@@ -264,7 +258,10 @@ spec:
                     set -- "$@" $args
                   fi
 
-                  set -- "$@" -u "elastic:${ELASTIC_PASSWORD}"
+                  if [ ! -z "${ELASTIC_PASSWORD}" ]; then
+                    set -- "$@" -u "elastic:${ELASTIC_PASSWORD}"
+                  fi
+
 
                   curl --output /dev/null -k "$@" "{{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}${path}"
                 }


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

With the following values I am able to deploy elasticsearch 8.1.0 with security disabled, with one exception.
```
--set createCert=false \
--set protocol="http" \
--set secret.enabled=false \
--set extraEnvs[0].name="xpack.security.enabled" \
--set-string extraEnvs[0].value="false" \
```
The `readinessProbe` has an explicit requirement for `ELASTIC_PASSWORD` being set which needs to be optional in this case. 

Hoping I'm going down the right road here, maybe there is something I missed but if not it would be nice if you could merge :smiley: 