### PR TITLE
chore: bump the Elastic Stack to 8.2.3

### DIFF
--- a/apm-server/Chart.yaml
+++ b/apm-server/Chart.yaml
@@ -5,8 +5,8 @@ maintainers:
 - email: helm-charts@elastic.co
   name: Elastic
 name: apm-server
-version: 8.1.0
-appVersion: 8.1.0
+version: 8.2.3
+appVersion: 8.2.3
 sources:
   - https://github.com/elastic/apm
 icon: https://helm.elastic.co/icons/apm.png

--- a/apm-server/README.md
+++ b/apm-server/README.md
@@ -58,8 +58,8 @@ See [supported configurations][] for more details.
 * Clone the git repo: `git clone git@github.com:elastic/helm-charts.git`
 
 * Install it:
-  - with Helm 3: `helm install apm-server ./helm-charts/apm-server --set imageTag=8.1.0`
-  - with Helm 2 (deprecated): `helm install --name apm-server ./helm-charts/apm-server --set imageTag=8.1.0`
+  - with Helm 3: `helm install apm-server ./helm-charts/apm-server --set imageTag=8.2.3`
+  - with Helm 2 (deprecated): `helm install --name apm-server ./helm-charts/apm-server --set imageTag=8.2.3`
 
 
 ## Upgrading
@@ -98,7 +98,7 @@ as a reference. They are also used in the automated testing of this chart.
 | `hostAliases`               | Configurable [hostAliases][]                                                                                                                               | `[]`                               |
 | `imagePullPolicy`           | The Kubernetes [imagePullPolicy][] value                                                                                                                   | `IfNotPresent`                     |
 | `imagePullSecrets`          | Configuration for [imagePullSecrets][] so that you can use a private registry for your image                                                               | `[]`                               |
-| `imageTag`                  | The APM Server Docker image tag                                                                                                                            | `8.1.0`                            |
+| `imageTag`                  | The APM Server Docker image tag                                                                                                                            | `8.2.3`                            |
 | `image`                     | The APM Server Docker image                                                                                                                                | `docker.elastic.co/apm/apm-server` |
 | `ingress`                   | Configurable [ingress][] to expose the APM Server service                                                                                                  | see [values.yaml][]                |
 | `labels`                    | Configurable [labels][] applied to all APM server pods                                                                                                     | `{}`                               |

--- a/apm-server/examples/default/README.md
+++ b/apm-server/examples/default/README.md
@@ -1,6 +1,6 @@
 # Default
 
-This example deploy APM Server 8.1.0 using [default values][].
+This example deploy APM Server 8.2.3 using [default values][].
 
 
 ## Usage

--- a/apm-server/examples/default/test/goss.yaml
+++ b/apm-server/examples/default/test/goss.yaml
@@ -3,4 +3,4 @@ http:
     status: 200
     timeout: 2000
     body:
-      - "8.1.0"
+      - "8.2.3"

--- a/apm-server/examples/security/README.md
+++ b/apm-server/examples/security/README.md
@@ -1,6 +1,6 @@
 # Security
 
-This example deploy APM Server 8.1.0 using authentication and TLS to connect to
+This example deploy APM Server 8.2.3 using authentication and TLS to connect to
 Elasticsearch (see [values][]).
 
 

--- a/apm-server/examples/security/test/goss.yaml
+++ b/apm-server/examples/security/test/goss.yaml
@@ -3,4 +3,4 @@ http:
     status: 200
     timeout: 2000
     body:
-      - "8.1.0"
+      - "8.2.3"

--- a/apm-server/examples/upgrade/test/goss.yaml
+++ b/apm-server/examples/upgrade/test/goss.yaml
@@ -3,4 +3,4 @@ http:
     status: 200
     timeout: 2000
     body:
-      - "8.1.0"
+      - "8.2.3"

--- a/apm-server/values.yaml
+++ b/apm-server/values.yaml
@@ -66,7 +66,7 @@ hostAliases: []
 #  - "bar.local"
 
 image: "docker.elastic.co/apm/apm-server"
-imageTag: "8.1.0"
+imageTag: "8.2.3"
 imagePullPolicy: "IfNotPresent"
 imagePullSecrets: []
 


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
