### PR TITLE
[elasticsearch] Replace apiVersion networking.k8s.io on ingress.yaml

### DIFF
--- a/elasticsearch/templates/ingress.yaml
+++ b/elasticsearch/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "elasticsearch.uname" . -}}
 {{- $httpPort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
The networking.k8s.io API version of IngressClass is no longer served as of v1.22.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
