### PR TITLE
[elasticsearch] do not regenerate certs during upgrade

### DIFF
--- a/elasticsearch/templates/secret-cert.yaml
+++ b/elasticsearch/templates/secret-cert.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
 {{ ( include "elasticsearch.gen-certs" . ) | indent 2 }}


### PR DESCRIPTION
This commit remove the `pre-upgrade` hook for the certificate secret to
ensure that the certificate isn't regenerate each time we run the
`helm upgrade` command.
