### PR TITLE
Workaround helm template bug when testing for APIVersions

### DIFF
--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.maxUnavailable }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
 {{- else}}
 apiVersion: policy/v1beta1

--- a/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
 apiVersion: policy/v1
 {{- else}}
 apiVersion: policy/v1beta1

--- a/logstash/templates/poddisruptionbudget.yaml
+++ b/logstash/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.maxUnavailable }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
 {{- else}}
 apiVersion: policy/v1beta1

--- a/logstash/templates/podsecuritypolicy.yaml
+++ b/logstash/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.create -}}
 {{- $fullName := include "logstash.fullname" . -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
 apiVersion: policy/v1
 {{- else}}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it:**

https://github.com/elastic/helm-charts/pull/1420 kinda broke chart deployment with ArgoCD on older K8S versions ( < 1.21 )

Issue is related to https://github.com/argoproj/argo-cd/issues/7291

I hope they'll find a fix there but a workaround suggested in the linked issue was to set up more precise `APIVersions.Has` in helm charts.
That's the point of this PR

It mirror this PR https://github.com/elastic/helm-charts/commit/7a54fb15cdd28ca9a4a8ba63eff800c4b245b3f5 ; adding the Kind to `APIVersions.Has` function

Thx