### PR TITLE
Change StorageClassName to "standard".

### DIFF
--- a/elasticsearch/examples/kubernetes-kind/values.yaml
+++ b/elasticsearch/examples/kubernetes-kind/values.yaml
@@ -17,7 +17,7 @@ resources:
 # Request smaller persistent volumes.
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]
-  storageClassName: "local-path"
+  storageClassName: "standard"
   resources:
     requests:
       storage: 100M


### PR DESCRIPTION
Kind clusters now install local path provisioner with Storage class "standard" as default.

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
