### PR TITLE
[meta] set jenkins workers to ubuntu

### DIFF
--- a/.ci/jobs/elastic+helm-charts+main+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+main+cluster-cleanup.yml
@@ -4,32 +4,32 @@
     display-name: elastic / helm-charts - main - cluster cleanup
     description: Main - cluster cleanup
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          cd helpers/terraform/
+          ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+main+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+main+cluster-creation.yml
@@ -4,32 +4,32 @@
     display-name: elastic / helm-charts - main - cluster creation
     description: Main - cluster creation
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          cd helpers/terraform/
+          ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+main+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+main+integration-apm-server.yml
@@ -4,36 +4,36 @@
     display-name: elastic / helm-charts - main - integration apm-server
     description: Main - integration apm-server
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: APM_SERVER_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: APM_SERVER_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs/elastic+helm-charts+main+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+main+integration-elasticsearch.yml
@@ -4,36 +4,36 @@
     display-name: elastic / helm-charts - main - integration elasticsearch
     description: Main - integration elasticsearch
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: ES_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: ES_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs/elastic+helm-charts+main+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+main+integration-filebeat.yml
@@ -4,36 +4,36 @@
     display-name: elastic / helm-charts - main - integration filebeat
     description: Main - integration filebeat
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: FILEBEAT_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: FILEBEAT_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs/elastic+helm-charts+main+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+main+integration-kibana.yml
@@ -4,36 +4,36 @@
     display-name: elastic / helm-charts - main - integration kibana
     description: Main - integration kibana
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KIBANA_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KIBANA_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs/elastic+helm-charts+main+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+main+integration-logstash.yml
@@ -4,36 +4,36 @@
     display-name: elastic / helm-charts - main - integration logstash
     description: Main - integration logstash
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: LOGSTASH_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: LOGSTASH_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash

--- a/.ci/jobs/elastic+helm-charts+main+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+main+integration-metricbeat.yml
@@ -4,36 +4,36 @@
     display-name: elastic / helm-charts - main - integration metricbeat
     description: Main - integration metricbeat
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: METRICBEAT_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: METRICBEAT_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat

--- a/.ci/jobs/elastic+helm-charts+main+template-lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+main+template-lint-python.yml
@@ -4,19 +4,19 @@
     display-name: elastic / helm-charts - main - lint python
     description: Main - lint python
     scm:
-    - git:
-        wipe-workspace: 'True'
+      - git:
+          wipe-workspace: "True"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual&&ubuntu-18.04
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu&&ubuntu-18.04
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        virtualenv -p python3 venv && source venv/bin/activate
-        pip install -r requirements.txt
-        make lint-python
+          virtualenv -p python3 venv && source venv/bin/activate
+          pip install -r requirements.txt
+          make lint-python

--- a/.ci/jobs/elastic+helm-charts+main+template-testing.yml
+++ b/.ci/jobs/elastic+helm-charts+main+template-testing.yml
@@ -11,7 +11,7 @@
           type: slave
           name: label
           values:
-            - docker&&virtual
+            - ubuntu
       - axis:
           type: yaml
           name: CHART

--- a/.ci/jobs/elastic+helm-charts+pull-request+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+cluster-cleanup.yml
@@ -5,32 +5,32 @@
     description: Pull request - cluster cleanup
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          cd helpers/terraform/
+          ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+pull-request+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+cluster-creation.yml
@@ -5,32 +5,32 @@
     description: Pull request - cluster creation
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          cd helpers/terraform/
+          ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-apm-server.yml
@@ -5,36 +5,36 @@
     description: Pull request - integration apm-server
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: APM_SERVER_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: APM_SERVER_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-elasticsearch.yml
@@ -5,36 +5,36 @@
     description: Pull request - integration elasticsearch
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: ES_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: ES_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-filebeat.yml
@@ -5,36 +5,36 @@
     description: Pull request - integration filebeat
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: FILEBEAT_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: FILEBEAT_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-kibana.yml
@@ -5,36 +5,36 @@
     description: Pull request - integration kibana
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KIBANA_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KIBANA_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-logstash.yml
@@ -5,36 +5,36 @@
     description: Pull request - integration logstash
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: LOGSTASH_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: LOGSTASH_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash

--- a/.ci/jobs/elastic+helm-charts+pull-request+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+integration-metricbeat.yml
@@ -5,36 +5,36 @@
     description: Pull request - integration metricbeat
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: METRICBEAT_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: METRICBEAT_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${branch_specifier:0:10}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat

--- a/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+lint-python.yml
@@ -5,19 +5,19 @@
     description: Pull request - lint python
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual&&ubuntu-18.04
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu-18.04
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        virtualenv -p python3 venv && source venv/bin/activate
-        pip install -r requirements.txt
-        make lint-python
+          virtualenv -p python3 venv && source venv/bin/activate
+          pip install -r requirements.txt
+          make lint-python

--- a/.ci/jobs/elastic+helm-charts+pull-request+template-testing.yml
+++ b/.ci/jobs/elastic+helm-charts+pull-request+template-testing.yml
@@ -5,22 +5,22 @@
     description: Pull request - template testing
     concurrent: true
     scm:
-    - git:
-        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: CHART
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: CHART
+          filename: helpers/matrix.yml
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        cd ${CHART}
-        make build test
+          cd ${CHART}
+          make build test

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-cleanup.yml
@@ -5,36 +5,36 @@
     description: staging - cluster cleanup
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          cd helpers/terraform/
+          ./in-docker make destroy KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+cluster-creation.yml
@@ -5,37 +5,37 @@
     description: staging - cluster creation
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
-        ./in-docker make k8s-staging-registry KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          cd helpers/terraform/
+          ./in-docker make up KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}
+          ./in-docker make k8s-staging-registry KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name}

--- a/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-apm-server.yml
@@ -5,42 +5,42 @@
     description: staging - integration apm-server
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: APM_SERVER_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: APM_SERVER_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+          env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${APM_SERVER_SUITE} CHART=apm-server

--- a/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-elasticsearch.yml
@@ -5,51 +5,51 @@
     description: staging - integration elasticsearch
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: ES_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: ES_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
 
-        DOCKER_PASSWORD=$(retry 5 vault read -field password secret/devops-ci/docker.elastic.co/devops-ci)
-        retry 5 docker login -u devops-ci -p $DOCKER_PASSWORD docker.elastic.co
-        unset DOCKER_PASSWORD
-        set -x
+          DOCKER_PASSWORD=$(retry 5 vault read -field password secret/devops-ci/docker.elastic.co/devops-ci)
+          retry 5 docker login -u devops-ci -p $DOCKER_PASSWORD docker.elastic.co
+          unset DOCKER_PASSWORD
+          set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+          env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
+          cd helpers/terraform/
 
-        # pull private images while we have the hosts docker daemon authenticated
-        make pull-private-images
+          # pull private images while we have the hosts docker daemon authenticated
+          make pull-private-images
 
-        # the private images will be used in here
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch
+          # the private images will be used in here
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${ES_SUITE} CHART=elasticsearch

--- a/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-filebeat.yml
@@ -5,42 +5,42 @@
     description: staging - integration filebeat
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: FILEBEAT_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: FILEBEAT_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+          env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${FILEBEAT_SUITE} CHART=filebeat

--- a/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-kibana.yml
@@ -5,42 +5,42 @@
     description: staging - integration kibana
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: KIBANA_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: KIBANA_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+          env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${KIBANA_SUITE} CHART=kibana

--- a/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-logstash.yml
@@ -5,42 +5,42 @@
     description: staging - integration logstash
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: LOGSTASH_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: LOGSTASH_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+          env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${LOGSTASH_SUITE} CHART=logstash

--- a/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
+++ b/.ci/jobs/elastic+helm-charts+staging+integration-metricbeat.yml
@@ -5,42 +5,42 @@
     description: staging - integration metricbeat
     concurrent: true
     parameters:
-    - string:
-        name: BUILD_ID
-        description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
+      - string:
+          name: BUILD_ID
+          description: "The buildId for the staging images. (Example: 7.8.1-abcdabcd)"
     axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - docker&&virtual
-    - axis:
-        type: yaml
-        name: METRICBEAT_SUITE
-        filename: helpers/matrix.yml
-    - axis:
-        type: yaml
-        name: KUBERNETES_VERSION
-        filename: helpers/matrix.yml
+      - axis:
+          type: slave
+          name: label
+          values:
+            - ubuntu
+      - axis:
+          type: yaml
+          name: METRICBEAT_SUITE
+          filename: helpers/matrix.yml
+      - axis:
+          type: yaml
+          name: KUBERNETES_VERSION
+          filename: helpers/matrix.yml
     wrappers:
-    - build-name:
-        name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
+      - build-name:
+          name: "${BUILD_NUMBER} - ${branch_specifier} - ${BUILD_ID}"
     builders:
-    - shell: |-
-        #!/usr/local/bin/runbld
-        set -euo pipefail
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -euo pipefail
 
-        source /usr/local/bin/bash_standard_lib.sh
+          source /usr/local/bin/bash_standard_lib.sh
 
-        set +x
-        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-        export VAULT_TOKEN
-        unset VAULT_ROLE_ID VAULT_SECRET_ID
-        set -x
+          set +x
+          VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          set -x
 
-        env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
+          env BUMPER_VERSION_7="$BUILD_ID" BUMPER_USE_STAGING_IMAGES="true" ./helpers/bumper.py
 
-        cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
+          cluster_name="helm-${KUBERNETES_VERSION//./}-${BUILD_ID//./-}"
 
-        cd helpers/terraform/
-        ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat
+          cd helpers/terraform/
+          ./in-docker make integration KUBERNETES_VERSION=${KUBERNETES_VERSION} CLUSTER_NAME=${cluster_name} SUITE=${METRICBEAT_SUITE} CHART=metricbeat


### PR DESCRIPTION
This commit is updating the helm-charts Jenkins jobs configuration to
use Ubuntu nodes only. This change is mostly to fix a bug with the ampersands
(`&`) in the node labels.

The only real change here is replacing every occurrence of `docker&&virtual`
by `ubuntu`. All other changes are simply yaml formatting done by VS Code.
