### PR TITLE
[elasticsearch] do not regenerate certs when they already exists

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -28,15 +28,22 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Generate certificates
+Generate certificates when the secret doesn't exist
 */}}
 {{- define "elasticsearch.gen-certs" -}}
+{{- $certs := lookup "v1" "Secret" .Release.Namespace ( printf "%s-certs" (include "elasticsearch.uname" . ) ) -}}
+{{- if $certs -}}
+tls.crt: {{ index $certs.data "tls.crt" }}
+tls.key: {{ index $certs.data "tls.key" }}
+ca.crt: {{ index $certs.data "ca.crt" }}
+{{- else -}}
 {{- $altNames := list ( include "elasticsearch.masterService" . ) ( printf "%s.%s" (include "elasticsearch.masterService" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "elasticsearch.masterService" .) .Release.Namespace ) -}}
 {{- $ca := genCA "elasticsearch-ca" 365 -}}
 {{- $cert := genSignedCert ( include "elasticsearch.masterService" . ) nil $altNames 365 $ca -}}
 tls.crt: {{ $cert.Cert | toString | b64enc }}
 tls.key: {{ $cert.Key | toString | b64enc }}
 ca.crt: {{ $ca.Cert | toString | b64enc }}
+{{- end -}}
 {{- end -}}
 
 {{- define "elasticsearch.masterService" -}}

--- a/elasticsearch/templates/secret-cert.yaml
+++ b/elasticsearch/templates/secret-cert.yaml
@@ -9,9 +9,6 @@ metadata:
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
 {{ ( include "elasticsearch.gen-certs" . ) | indent 2 }}
 {{- end }}


### PR DESCRIPTION
This commit update the way we generate the Elasticsearch certs to lookup
if the certs secret already exists and reuse the secrets instead of regenerate
the certs.

This fix the issue when upgrading from a previous version of the chart
that doesn't include the certs secret by ensuring that the certs secret
is created if it doesn't exists.

This method also add more flexibility than charts hooks by ensuring that
the certs won't be rotated each time we upgrade the chart.

Found in https://stackoverflow.com/a/61715870
