### PR TITLE
(ElasticSearch) Add override for initial_master_nodes and seed_hosts

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -312,16 +312,16 @@ spec:
                 fieldPath: metadata.name
           {{- if has "master" .Values.roles }}
           - name: cluster.initial_master_nodes
-            value: "{{ template "elasticsearch.endpoints" . }}"
+            value: "{{- tpl .Values.initialMasterNodes . -}}"
           {{- end }}
           - name: node.roles
             value: "{{ template "elasticsearch.roles" . }}"
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts
-            value: "{{ template "elasticsearch.masterService" . }}-headless"
+            value: "{{- tpl .Values.seedHosts . -}}"
           {{- else }}
           - name: discovery.seed_hosts
-            value: "{{ template "elasticsearch.masterService" . }}-headless"
+            value: "{{- tpl .Values.seedHosts . -}}"
           {{- end }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"

--- a/elasticsearch/tests/elasticsearch_test.py
+++ b/elasticsearch/tests/elasticsearch_test.py
@@ -218,6 +218,20 @@ roles:
         assert e["name"] != "discovery.zen.ping.unicast.hosts"
 
 
+def test_override_seed_hosts_template():
+    config = """
+seedHosts: "customHost"
+"""
+    r = helm_template(config)
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["env"]
+    assert {
+        "name": "cluster.seed_hosts",
+        "value": "customHost",
+    } in env
+
+
 def test_adding_extra_env_vars():
     config = """
 extraEnvs:
@@ -1364,6 +1378,20 @@ fullnameOverride: "customfullName"
     assert {
         "name": "cluster.initial_master_nodes",
         "value": "customfullName-0," + "customfullName-1," + "customfullName-2,",
+    } in env
+
+
+def test_override_initial_master_node_template():
+    config = """
+initialMasterNodes: "customNode"
+"""
+    r = helm_template(config)
+    env = r["statefulset"][uname]["spec"]["template"]["spec"]["containers"][
+        0
+    ]["env"]
+    assert {
+        "name": "cluster.initial_master_nodes",
+        "value": "customNode",
     } in env
 
 

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -35,6 +35,12 @@ esConfig: {}
 #  log4j2.properties: |
 #    key = value
 
+# Initial_master_nodes and seed_hosts can be overridden to allow custom multiple clusters setup
+initialMasterNodes: |-
+  {{ template "elasticsearch.endpoints" . }}
+seedHosts: |-
+  {{ template "elasticsearch.masterService" . }}-headless
+
 createCert: true
 
 esJvmOptions: {}


### PR DESCRIPTION
Signed-off-by: Tuan Anh Nguyen <tuananh.nguyen-ext@commercetools.de>

This reopens https://github.com/elastic/helm-charts/pull/1573 to fix https://github.com/elastic/helm-charts/issues/1268

Use case: we want to setup one ElasticSearch cluster spanning multiple k8s clusters, so customizing seed_hosts is required.

How can we get this change backported to 7.17?

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] Updated template tests in `${CHART}/tests/*.py` 
