### PR TITLE
[elasticsearch] fix node roles for clients nodes

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -314,8 +314,10 @@ spec:
           - name: cluster.initial_master_nodes
             value: "{{ template "elasticsearch.endpoints" . }}"
           {{- end }}
+          {{- if gt (len (include "elasticsearch.roles" .)) 0 }}
           - name: node.roles
             value: "{{ template "elasticsearch.roles" . }}"
+          {{- end }}
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts
             value: "{{ template "elasticsearch.masterService" . }}-headless"


### PR DESCRIPTION
This commit fix the node.roles variable for client role with
Elasticsearch version > 8.3.0.

As client nodes are nodes that don't have any other roles,
setting the client roles is done by configuring `node.roles: []`
(empty list).

Elasticsearch chart usually define `node.roles` as an environment
variable, however, for client nodes, setting an empty list as value of
an environment variable isn't recognized by Elasticsearch so we were
required to also add it to the `elasticsearch.yaml` config file (more
details in
https://github.com/elastic/helm-charts/pull/1186#discussion_r631225687).

Starting with Elasticsearch 8.3.0 this is not working anymore and
Elasticsearch fails to start is a `node.roles` environment variable is
defined with an empty list as value.

This commit define the `node.roles` environment variable only if the
`roles` list isn't empty.

Fixes also the tests for the `multi` example.

Relates to https://github.com/elastic/helm-charts/pull/1186
