### PR TITLE
[kibana] update the upgrade test

### DIFF
--- a/kibana/examples/upgrade/Makefile
+++ b/kibana/examples/upgrade/Makefile
@@ -8,6 +8,9 @@ ES_RELEASE := helm-kibana-upgrade-es
 RELEASE := helm-kibana-upgrade-kb
 FROM := 7.17.1
 
+repo:
+	helm repo add elastic https://helm.elastic.co
+
 install-es:
 	helm install $(ES_RELEASE) elastic/elasticsearch --wait --version $(FROM) --set clusterName=$(ES_CLUSTER)
 
@@ -23,7 +26,7 @@ upgrade-kb:
 	helm upgrade $(RELEASE) ../../ --wait --values values.yaml
 	kubectl rollout status deployment $(RELEASE)-kibana
 
-install: install-es install-kb upgrade-es upgrade-kb
+install: repo install-es install-kb upgrade-es upgrade-kb
 
 test: install goss
 

--- a/kibana/examples/upgrade/Makefile
+++ b/kibana/examples/upgrade/Makefile
@@ -4,8 +4,7 @@ include ../../../helpers/examples.mk
 
 CHART := kibana
 RELEASE := helm-kibana-upgrade
-FROM := 7.4.0	# versions before 7.4.O aren't compatible with Kubernetes >= 1.16.0
-TO := 7.10.0	# required to use with Elasticsearch 7.10.0
+FROM := 7.17.1	# same version as Elasticsearch chart
 
 install:
 	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM) --to $(TO)

--- a/kibana/examples/upgrade/Makefile
+++ b/kibana/examples/upgrade/Makefile
@@ -3,14 +3,31 @@ default: test
 include ../../../helpers/examples.mk
 
 CHART := kibana
-RELEASE := helm-kibana-upgrade
-FROM := 7.17.1	# same version as Elasticsearch chart
+ES_CLUSTER := kibana-upgrade
+ES_RELEASE := helm-kibana-upgrade-es
+RELEASE := helm-kibana-upgrade-kb
+FROM := 7.17.1
 
-install:
-	../../../helpers/upgrade.sh --chart $(CHART) --release $(RELEASE) --from $(FROM) --to $(TO)
+install-es:
+	helm install $(ES_RELEASE) elastic/elasticsearch --wait --version $(FROM) --set clusterName=$(ES_CLUSTER)
+
+install-kb:
+	helm install $(RELEASE) elastic/kibana --wait --version $(FROM) --set elasticsearchHosts="http://$(ES_CLUSTER)-master:9200"
+
+upgrade-es:
+	helm upgrade $(ES_RELEASE) ../../../elasticsearch/ --wait --set clusterName=$(ES_CLUSTER) --set updateStrategy=OnDelete
+	# Rollout ES pods
+	kubectl delete pod --selector=app=$(ES_CLUSTER)-master
+
+upgrade-kb:
+	helm upgrade $(RELEASE) ../../ --wait --values values.yaml
 	kubectl rollout status deployment $(RELEASE)-kibana
+
+install: install-es install-kb upgrade-es upgrade-kb
 
 test: install goss
 
 purge:
-	helm del $(RELEASE)
+	helm delete $(RELEASE)
+	helm delete $(ES_RELEASE)
+	kubectl delete $$(kubectl get pvc -o name | grep $(ES_CLUSTER))

--- a/kibana/examples/upgrade/test/goss.yaml
+++ b/kibana/examples/upgrade/test/goss.yaml
@@ -2,13 +2,15 @@ http:
   http://localhost:5601/api/status:
     status: 200
     timeout: 2000
+    request-headers:
+      - "Authorization: Bearer {{ .Env.ELASTICSEARCH_SERVICEACCOUNTTOKEN}}"
     body:
-      - '"number":"7.10.0"'
+      - '"number":"8.4.1"'
 
   http://localhost:5601/app/kibana:
     status: 200
     timeout: 2000
 
-  http://helm-kibana-upgrade-kibana:5601/app/kibana:
+  http://helm-kibana-upgrade-kb-kibana:5601/app/kibana:
     status: 200
     timeout: 2000

--- a/kibana/examples/upgrade/values.yaml
+++ b/kibana/examples/upgrade/values.yaml
@@ -1,2 +1,5 @@
 ---
-elasticsearchHosts: "http://upgrade-master:9200"
+elasticsearchHosts: "https://upgrade-master:9200"
+elasticsearchCertificateSecret: upgrade-master-certs
+elasticsearchCertificateAuthoritiesFile: ca.crt
+elasticsearchCredentialSecret: upgrade-master-credentials

--- a/kibana/examples/upgrade/values.yaml
+++ b/kibana/examples/upgrade/values.yaml
@@ -1,5 +1,5 @@
 ---
-elasticsearchHosts: "https://upgrade-master:9200"
-elasticsearchCertificateSecret: upgrade-master-certs
+elasticsearchHosts: "https://kibana-upgrade-master:9200"
+elasticsearchCertificateSecret: kibana-upgrade-master-certs
 elasticsearchCertificateAuthoritiesFile: ca.crt
-elasticsearchCredentialSecret: upgrade-master-credentials
+elasticsearchCredentialSecret: kibana-upgrade-master-credentials

--- a/kibana/templates/job.yaml
+++ b/kibana/templates/job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "kibana.fullname" . }}-post-delete
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-delete,post-upgrade
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
@@ -22,7 +22,6 @@ spec:
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           command: ["curl"]
           args:
-            - --fail
             - -XDELETE
             - --cacert
             - {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}


### PR DESCRIPTION
Fix the kibana upgrade test by installing Elasticsearch and Kibana 7.17.1 first, before upgrading them to 8.4.1 (because Kibana 7.17.1 can't connect to Elasticsearch 8.4.1).

Also fix the post-delete hook that was deleting kibana token during the upgrade, making impossible for the new kibana pod to connect to Elasticsearch.
