### PR TITLE
[filebeat][metricbeat] increase memory limit for goss tests

### DIFF
--- a/filebeat/examples/default/test/goss.yaml
+++ b/filebeat/examples/default/test/goss.yaml
@@ -41,9 +41,3 @@ file:
       - "add_kubernetes_metadata"
       - "output.elasticsearch"
       - "elasticsearch-master:9200"
-
-command:
-  cd /usr/share/filebeat && filebeat test output:
-    exit-status: 0
-    stdout:
-      - "elasticsearch: https://elasticsearch-master:9200"

--- a/filebeat/examples/deployment/values.yaml
+++ b/filebeat/examples/deployment/values.yaml
@@ -1,5 +1,9 @@
 deployment:
   enabled: true
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"
 
 daemonset:
   enabled: false

--- a/filebeat/examples/oss/values.yaml
+++ b/filebeat/examples/oss/values.yaml
@@ -28,3 +28,7 @@ daemonset:
     - name: elasticsearch-master-certs
       secretName: elasticsearch-master-certs
       path: /usr/share/filebeat/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"

--- a/filebeat/examples/security/values.yaml
+++ b/filebeat/examples/security/values.yaml
@@ -37,3 +37,7 @@ daemonset:
     - name: elastic-certificate-pem
       secretName: elastic-certificate-pem
       path: /usr/share/filebeat/config/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"

--- a/filebeat/examples/upgrade/values.yaml
+++ b/filebeat/examples/upgrade/values.yaml
@@ -37,3 +37,7 @@ secretMounts:
   - name: upgrade-master-certs
     secretName: upgrade-master-certs
     path: /usr/share/filebeat/certs
+resources:
+  limits:
+    # Should avoid OOM (Error 137) when running goss tests into the pod
+    memory: "300Mi"

--- a/metricbeat/examples/default/test/goss-metrics.yaml
+++ b/metricbeat/examples/default/test/goss-metrics.yaml
@@ -37,9 +37,3 @@ file:
     exists: true
     contains:
       - "output.elasticsearch"
-
-command:
-  cd /usr/share/metricbeat && metricbeat test output:
-    exit-status: 0
-    stdout:
-      - "elasticsearch: https://elasticsearch-master:9200"

--- a/metricbeat/examples/default/test/goss.yaml
+++ b/metricbeat/examples/default/test/goss.yaml
@@ -45,9 +45,3 @@ file:
       - "add_kubernetes_metadata"
       - "output.elasticsearch"
       - "elasticsearch-master:9200"
-
-command:
-  cd /usr/share/metricbeat && metricbeat test output:
-    exit-status: 0
-    stdout:
-      - "elasticsearch: https://elasticsearch-master:9200"

--- a/metricbeat/examples/oss/values.yaml
+++ b/metricbeat/examples/oss/values.yaml
@@ -62,6 +62,10 @@ daemonset:
     - name: elasticsearch-master-certs
       secretName: elasticsearch-master-certs
       path: /usr/share/metricbeat/config/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"
 
 deployment:
   metricbeatConfig:
@@ -92,3 +96,7 @@ deployment:
     - name: elasticsearch-master-certs
       secretName: elasticsearch-master-certs
       path: /usr/share/metricbeat/config/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"

--- a/metricbeat/examples/security/values.yaml
+++ b/metricbeat/examples/security/values.yaml
@@ -67,6 +67,10 @@ daemonset:
     - name: elastic-certificate-pem
       secretName: elastic-certificate-pem
       path: /usr/share/metricbeat/config/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"
 
 deployment:
   extraEnvs:
@@ -104,3 +108,7 @@ deployment:
     - name: elastic-certificate-pem
       secretName: elastic-certificate-pem
       path: /usr/share/metricbeat/config/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"

--- a/metricbeat/examples/upgrade/values.yaml
+++ b/metricbeat/examples/upgrade/values.yaml
@@ -67,6 +67,10 @@ daemonset:
     - name: upgrade-master-certs
       secretName: upgrade-master-certs
       path: /usr/share/metricbeat/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"
 
 deployment:
   extraEnvs:
@@ -104,3 +108,7 @@ deployment:
     - name: upgrade-master-certs
       secretName: upgrade-master-certs
       path: /usr/share/metricbeat/certs
+  resources:
+    limits:
+      # Should avoid OOM (Error 137) when running goss tests into the pod
+      memory: "300Mi"


### PR DESCRIPTION
This commit increase the memory limit for Filebeat and Metricbeat goss
tests. This should help with the regular `Error 137` during goss tests.

Indeed `Error 137` seems to be related to OOM. As beats pods default
memory limit is really small (200Mb), it seems that injecting goss
inside the pods to run the test can reach the memory limit regularly.

Also remove the biggest test in the default config test examples to make
goss use less memory because we can't override default values for these
tests.
