### PR TITLE
[meta] update supported gke versions

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -37,7 +37,6 @@ APM_SERVER_SUITE:
   - security
   - upgrade
 KUBERNETES_VERSION:
-  - "1.20"
   - "1.21"
   - "1.22"
   - "1.23"


### PR DESCRIPTION
- Remove GKE 1.20 support

Relates to https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule_for_static_no_channel_versions
