### PR TITLE
[7.17] [meta] update supported gke versions (#1703)

### DIFF
--- a/helpers/matrix.yml
+++ b/helpers/matrix.yml
@@ -38,7 +38,6 @@ APM_SERVER_SUITE:
   - security
   - upgrade
 KUBERNETES_VERSION:
-  - "1.20"
   - "1.21"
   - "1.22"
   - "1.23"


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [meta] update supported gke versions (#1703)