### PR TITLE
[7.17] [meta] remove 6.8 branch from backport config (#1705)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,7 +5,6 @@
     "backported"
   ],
   "targetBranchChoices": [
-    "6.8",
     "7.17"
   ],
   "targetPRLabels": [


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [meta] remove 6.8 branch from backport config (#1705)