### PR TITLE
Fix kibana's init container configure-kibana-token http request error 409

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -93,7 +93,9 @@ spec:
         command:
           - sh
           - -c
-          - curl --output {{ template "kibana.home_dir" . }}/config/tokens/{{ template "kibana.fullname" . }}.json --fail -XPOST --cacert {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }} -u "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)" "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}?pretty"
+          - |
+            curl --output /dev/null --fail -XDELETE --cacert {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }} -u "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)" "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}?pretty"
+            curl --output {{ template "kibana.home_dir" . }}/config/tokens/{{ template "kibana.fullname" . }}.json --fail -XPOST --cacert {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }} -u "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)" "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}?pretty"
         env:
           - name: "ELASTICSEARCH_USERNAME"
             valueFrom:


### PR DESCRIPTION
this is a fix proposal to this issue: https://github.com/elastic/helm-charts/issues/1714

kubernetes pods die regularly and new ones are created. kibana's init container does not work this way since it always tries to create a new token, which elasticsearch will deny if it already exists.

this PR makes kibana's init container attempt to delete the old token before attempting to create a new one. deleting a non-existing token returns a valid status code so this is not a breaking change. I chose this approach because I found no way of getting an existing token using elasticsearch API, the token is only returned on creation (please correct me if i'm wrong).

Also, i noticed that there is a helm cleanup job to cleanup the old token, but that one runs only when we delete the entire helm release, and will not trigger on pod termination/creation.

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
