### PR TITLE
[kibana] create a secret with es token

### DIFF
--- a/kibana/examples/upgrade/Makefile
+++ b/kibana/examples/upgrade/Makefile
@@ -23,6 +23,7 @@ upgrade-es:
 	kubectl delete pod --selector=app=$(ES_CLUSTER)-master
 
 upgrade-kb:
+	sleep 120 # wait that ES pods are started
 	helm upgrade $(RELEASE) ../../ --wait --values values.yaml
 	kubectl rollout status deployment $(RELEASE)-kibana
 

--- a/kibana/examples/upgrade/Makefile
+++ b/kibana/examples/upgrade/Makefile
@@ -23,7 +23,6 @@ upgrade-es:
 	kubectl delete pod --selector=app=$(ES_CLUSTER)-master
 
 upgrade-kb:
-	sleep 120 # wait that ES pods are started
 	helm upgrade $(RELEASE) ../../ --wait --values values.yaml
 	kubectl rollout status deployment $(RELEASE)-kibana
 

--- a/kibana/templates/NOTES.txt
+++ b/kibana/templates/NOTES.txt
@@ -2,3 +2,5 @@
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l release={{ .Release.Name }} -w
 2. Retrieve the elastic user's password.
   $ kubectl get secrets --namespace={{ .Release.Namespace }} {{ .Values.elasticsearchCredentialSecret }} -ojsonpath='{.data.password}' | base64 -d
+3. Retrieve the kibana service account token.
+  $ kubectl get secrets --namespace={{ .Release.Namespace }} {{ template "kibana.fullname" . }}-es-token -ojsonpath='{.data.password}' | base64 -d

--- a/kibana/templates/NOTES.txt
+++ b/kibana/templates/NOTES.txt
@@ -3,4 +3,4 @@
 2. Retrieve the elastic user's password.
   $ kubectl get secrets --namespace={{ .Release.Namespace }} {{ .Values.elasticsearchCredentialSecret }} -ojsonpath='{.data.password}' | base64 -d
 3. Retrieve the kibana service account token.
-  $ kubectl get secrets --namespace={{ .Release.Namespace }} {{ template "kibana.fullname" . }}-es-token -ojsonpath='{.data.password}' | base64 -d
+  $ kubectl get secrets --namespace={{ .Release.Namespace }} {{ template "kibana.fullname" . }}-es-token -ojsonpath='{.data.token}' | base64 -d

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -171,4 +171,5 @@ data:
         break;
       default:
         console.log('Unknown command');
+        process.exit(1);
     }

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -17,10 +17,8 @@ data:
     const fs = require('fs');
 
     // Elasticsearch API
-    //TODO: remove hardcoded host
-    const esHostname = "elasticsearch-master";
-    const esPort = process.env.ELASTICSEARCH_MASTER_SERVICE_PORT;
     const esPath = '_security/service/elastic/kibana/credential/token/kb-kibana';
+    const esUrl = '{{ .Values.elasticsearchHosts }}' + '/' + esPath
     const esUsername = process.env.ELASTICSEARCH_USERNAME;
     const esPassword = process.env.ELASTICSEARCH_PASSWORD;
     const esAuth = esUsername + ':' + esPassword;
@@ -31,16 +29,17 @@ data:
     const k8sHostname = process.env.KUBERNETES_SERVICE_HOST;
     const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
     const k8sPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets';
+    const k8sUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sPath
     const k8sBearer = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/token');
     const k8sCa = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/ca.crt');
 
     // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
-    function requestPromise(options, payload) {
+    function requestPromise(url, options, payload) {
       return new Promise((resolve, reject) => {
-        const request = https.request(options, response => {
+        const request = https.request(url, options, response => {
 
           console.log('statusCode:', response.statusCode);
-          console.log('headers:', response.headers);
+          // console.log('headers:', response.headers);
 
           // TODO: remove 404 and handle it during esToken deletion
           const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
@@ -65,70 +64,147 @@ data:
       });
     }
 
-    // delete kb-kibana token
+    // Delete kb-kibana token
     const esTokenDeleteOptions = {
-      hostname: esHostname,
-      port: esPort,
-      path: esPath,
       method: 'DELETE',
       auth: esAuth,
       ca: esCa,
     };
 
-    // create new kb-kibana token
+    // Create new kb-kibana token
     const esTokenCreateOptions = {
-      hostname: esHostname,
-      port: esPort,
-      path: esPath,
       method: 'POST',
       auth: esAuth,
       ca: esCa,
     };
 
-    // create new k8s secret
+    // Create new k8s secret
     const secretCreateOptions = {
-      hostname: k8sHostname,
-      port: k8sPort,
-      path: k8sPath,
       method: 'POST',
       ca: k8sCa,
       headers: {
-        'Authorization': 'Bearer' + k8sBearer,
+        'Authorization': 'Bearer ' + k8sBearer,
         'Accept': 'application/json',
         'Content-Type': 'application/json',
       }
     };
 
     // Chaining requests
-    requestPromise(esTokenDeleteOptions).then(() =>
-      requestPromise(esTokenCreateOptions).then(response => {
+    console.log('Cleaning previous token');
+    requestPromise(esUrl, esTokenDeleteOptions).then(() => {
+      console.log('Creating new token');
+      requestPromise(esUrl, esTokenCreateOptions).then(response => {
         const body = JSON.parse(response);
         const token = body.token.value
-        console.log('Token:', token);
 
-        // encode the token in base 64
-        const base64Token = Buffer.from(token, 'utf8').toString('base64')
-        console.log('Base64 Token:', base64Token);
+        // Encode the token in base64
+        const base64Token = Buffer.from(token, 'utf8').toString('base64');
 
-        // prepare the k8s secret
-        secretData = {
-          "apiVersion":"v1",
-          "kind" :"Secret",
-          "metadata" :{
-            "namespace" :"{{ .Release.Namespace }}",
-            "name":"{{ template "kibana.fullname" . }}-token"
+        // Prepare the k8s secret
+        secretData = JSON.stringify({
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "namespace": "{{ .Release.Namespace }}",
+            "name": "{{ template "kibana.fullname" . }}-es-token",
           },
           "type": "Opaque",
           "data": {
             "token": base64Token,
           }
-        }
+        })
 
-        // create the k8s secret
-        requestPromise(secretCreateOptions, secretData.toString())
-
+        // Create the k8s secret
+        console.log('Creating K8S secret');
+        requestPromise(k8sUrl, secretCreateOptions, secretData).then().catch(err => {
+          console.error(err)
+        });
         return;
       })
-    ).catch(err => {
+    }).catch(err => {
+      console.error(err);
+    });
+
+  clean-token.js: |
+    const https = require('https');
+    const fs = require('fs');
+
+    // Elasticsearch API
+    const esPath = '_security/service/elastic/kibana/credential/token/kb-kibana';
+    const esUrl = '{{ .Values.elasticsearchHosts }}' + '/' + esPath
+    const esUsername = process.env.ELASTICSEARCH_USERNAME;
+    const esPassword = process.env.ELASTICSEARCH_PASSWORD;
+    const esAuth = esUsername + ':' + esPassword;
+    const esCaFile = process.env.ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES;
+    const esCa = fs.readFileSync(esCaFile);
+
+    // Kubernetes API
+    const k8sHostname = process.env.KUBERNETES_SERVICE_HOST;
+    const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
+    const k8sPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets/{{ template "kibana.fullname" . }}-es-token';
+    const k8sUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sPath
+    const k8sBearer = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/token');
+    const k8sCa = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/ca.crt');
+
+    // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
+    function requestPromise(url, options, payload) {
+      return new Promise((resolve, reject) => {
+        const request = https.request(url, options, response => {
+
+          console.log('statusCode:', response.statusCode);
+          // console.log('headers:', response.headers);
+
+          // TODO: remove 404 and handle it during esToken deletion
+          const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
+
+          let data = '';
+          response.on('data', chunk => data += chunk); // accumulate data
+          response.once('end', () => isSuccess ? resolve(data) : reject(data));  // resolve promise here
+        });
+
+        request.once('error', err => {
+          // This won't log anything for e.g. an HTTP 404 or 500 response,
+          // since from HTTP's point-of-view we successfully received a
+          // response.
+          console.log(`${options.method} ${options.path} failed: `, err.message || err);
+          reject(err);  // if promise is not already resolved, then we can reject it here
+        });
+
+        if (payload) {
+          request.write(payload);
+        }
+        request.end();
+      });
+    }
+
+    // Delete kb-kibana token
+    const esTokenDeleteOptions = {
+      method: 'DELETE',
+      auth: esAuth,
+      ca: esCa,
+    };
+
+    // Create new k8s secret
+    const secretDeleteOptions = {
+      method: 'DELETE',
+      ca: k8sCa,
+      headers: {
+        'Authorization': 'Bearer ' + k8sBearer,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      }
+    };
+
+    // Chaining requests
+    console.log('Cleaning token');
+    requestPromise(esUrl, esTokenDeleteOptions).then(() => {
+      // Create the k8s secret
+      console.log('Delete K8S secret');
+      requestPromise(k8sUrl, secretDeleteOptions).then().catch(err => {
+          console.error(err)
+        });
+        return;
+      })
+    }).catch(err => {
       console.error(err);
     });

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "kibana.fullname" . }}-helm-scripts
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,post-delete
+    "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -18,7 +18,7 @@ data:
     const fs = require('fs');
 
     // Elasticsearch API
-    const esPath = '_security/service/elastic/kibana/credential/token/kb-kibana';
+    const esPath = '_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}';
     const esUrl = '{{ .Values.elasticsearchHosts }}' + '/' + esPath
     const esUsername = process.env.ELASTICSEARCH_USERNAME;
     const esPassword = process.env.ELASTICSEARCH_PASSWORD;

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -31,8 +31,8 @@ data:
     const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
     const k8sPostSecretPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets';
     const k8sDeleteSecretPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets/{{ template "kibana.fullname" . }}-es-token';
-    const k8sPostSecretUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sPostSecretPath;
-    const k8sDeleteSecretUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sDeleteSecretPath;
+    const k8sPostSecretUrl = `https://${k8sHostname}:${k8sPort}/${k8sPostSecretPath}`;
+    const k8sDeleteSecretUrl = `https://${k8sHostname}:${k8sPort}/${k8sDeleteSecretPath}`;
     const k8sBearer = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/token');
     const k8sCa = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/ca.crt');
 

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -17,18 +17,27 @@ data:
     const https = require('https');
     const fs = require('fs');
 
+    // Read environment variables
+    function getEnvVar(name) {
+      if (name in process.env) {
+        return process.env[name]
+      } else {
+        throw new Error(name + ' environment variable is missing')
+      }
+    }
+
     // Elasticsearch API
     const esPath = '_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}';
     const esUrl = '{{ .Values.elasticsearchHosts }}' + '/' + esPath
-    const esUsername = process.env.ELASTICSEARCH_USERNAME;
-    const esPassword = process.env.ELASTICSEARCH_PASSWORD;
+    const esUsername = getEnvVar('ELASTICSEARCH_USERNAME');
+    const esPassword = getEnvVar('ELASTICSEARCH_PASSWORD');
     const esAuth = esUsername + ':' + esPassword;
-    const esCaFile = process.env.ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES;
+    const esCaFile = getEnvVar('ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES');
     const esCa = fs.readFileSync(esCaFile);
 
     // Kubernetes API
-    const k8sHostname = process.env.KUBERNETES_SERVICE_HOST;
-    const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
+    const k8sHostname = getEnvVar('KUBERNETES_SERVICE_HOST');
+    const k8sPort = getEnvVar('KUBERNETES_SERVICE_PORT_HTTPS');
     const k8sPostSecretPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets';
     const k8sDeleteSecretPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets/{{ template "kibana.fullname" . }}-es-token';
     const k8sPostSecretUrl = `https://${k8sHostname}:${k8sPort}/${k8sPostSecretPath}`;

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -5,14 +5,15 @@ metadata:
   name: {{ template "kibana.fullname" . }}-helm-scripts
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
 data:
-  get-token.js: |
+  manage-es-token.js: |
     const https = require('https');
     const fs = require('fs');
 
@@ -28,57 +29,24 @@ data:
     // Kubernetes API
     const k8sHostname = process.env.KUBERNETES_SERVICE_HOST;
     const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
-    const k8sPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets';
-    const k8sUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sPath
+    const k8sPostSecretPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets';
+    const k8sDeleteSecretPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets/{{ template "kibana.fullname" . }}-es-token';
+    const k8sPostSecretUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sPostSecretPath;
+    const k8sDeleteSecretUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sDeleteSecretPath;
     const k8sBearer = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/token');
     const k8sCa = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/ca.crt');
 
-    // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
-    function requestPromise(url, options, payload) {
-      return new Promise((resolve, reject) => {
-        const request = https.request(url, options, response => {
-
-          console.log('statusCode:', response.statusCode);
-          // console.log('headers:', response.headers);
-
-          // TODO: remove 404 and handle it during esToken deletion
-          const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
-
-          let data = '';
-          response.on('data', chunk => data += chunk); // accumulate data
-          response.once('end', () => isSuccess ? resolve(data) : reject(data));  // resolve promise here
-        });
-
-        request.once('error', err => {
-          // This won't log anything for e.g. an HTTP 404 or 500 response,
-          // since from HTTP's point-of-view we successfully received a
-          // response.
-          console.log(`${options.method} ${options.path} failed: `, err.message || err);
-          reject(err);  // if promise is not already resolved, then we can reject it here
-        });
-
-        if (payload) {
-          request.write(payload);
-        }
-        request.end();
-      });
-    }
-
-    // Delete kb-kibana token
+    // Post Data
     const esTokenDeleteOptions = {
       method: 'DELETE',
       auth: esAuth,
       ca: esCa,
     };
-
-    // Create new kb-kibana token
     const esTokenCreateOptions = {
       method: 'POST',
       auth: esAuth,
       ca: esCa,
     };
-
-    // Create new k8s secret
     const secretCreateOptions = {
       method: 'POST',
       ca: k8sCa,
@@ -88,103 +56,6 @@ data:
         'Content-Type': 'application/json',
       }
     };
-
-    // Chaining requests
-    console.log('Cleaning previous token');
-    requestPromise(esUrl, esTokenDeleteOptions).then(() => {
-      console.log('Creating new token');
-      requestPromise(esUrl, esTokenCreateOptions).then(response => {
-        const body = JSON.parse(response);
-        const token = body.token.value
-
-        // Encode the token in base64
-        const base64Token = Buffer.from(token, 'utf8').toString('base64');
-
-        // Prepare the k8s secret
-        secretData = JSON.stringify({
-          "apiVersion": "v1",
-          "kind": "Secret",
-          "metadata": {
-            "namespace": "{{ .Release.Namespace }}",
-            "name": "{{ template "kibana.fullname" . }}-es-token",
-          },
-          "type": "Opaque",
-          "data": {
-            "token": base64Token,
-          }
-        })
-
-        // Create the k8s secret
-        console.log('Creating K8S secret');
-        requestPromise(k8sUrl, secretCreateOptions, secretData).then().catch(err => {
-          console.error(err)
-        });
-        return;
-      })
-    }).catch(err => {
-      console.error(err);
-    });
-
-  clean-token.js: |
-    const https = require('https');
-    const fs = require('fs');
-
-    // Elasticsearch API
-    const esPath = '_security/service/elastic/kibana/credential/token/kb-kibana';
-    const esUrl = '{{ .Values.elasticsearchHosts }}' + '/' + esPath
-    const esUsername = process.env.ELASTICSEARCH_USERNAME;
-    const esPassword = process.env.ELASTICSEARCH_PASSWORD;
-    const esAuth = esUsername + ':' + esPassword;
-    const esCaFile = process.env.ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES;
-    const esCa = fs.readFileSync(esCaFile);
-
-    // Kubernetes API
-    const k8sHostname = process.env.KUBERNETES_SERVICE_HOST;
-    const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
-    const k8sPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets/{{ template "kibana.fullname" . }}-es-token';
-    const k8sUrl = 'https://' + k8sHostname + ':' + k8sPort + '/' + k8sPath
-    const k8sBearer = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/token');
-    const k8sCa = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/ca.crt');
-
-    // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
-    function requestPromise(url, options, payload) {
-      return new Promise((resolve, reject) => {
-        const request = https.request(url, options, response => {
-
-          console.log('statusCode:', response.statusCode);
-          // console.log('headers:', response.headers);
-
-          // TODO: remove 404 and handle it during esToken deletion
-          const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
-
-          let data = '';
-          response.on('data', chunk => data += chunk); // accumulate data
-          response.once('end', () => isSuccess ? resolve(data) : reject(data));  // resolve promise here
-        });
-
-        request.once('error', err => {
-          // This won't log anything for e.g. an HTTP 404 or 500 response,
-          // since from HTTP's point-of-view we successfully received a
-          // response.
-          console.log(`${options.method} ${options.path} failed: `, err.message || err);
-          reject(err);  // if promise is not already resolved, then we can reject it here
-        });
-
-        if (payload) {
-          request.write(payload);
-        }
-        request.end();
-      });
-    }
-
-    // Delete kb-kibana token
-    const esTokenDeleteOptions = {
-      method: 'DELETE',
-      auth: esAuth,
-      ca: esCa,
-    };
-
-    // Create new k8s secret
     const secretDeleteOptions = {
       method: 'DELETE',
       ca: k8sCa,
@@ -195,16 +66,99 @@ data:
       }
     };
 
-    // Chaining requests
-    console.log('Cleaning token');
-    requestPromise(esUrl, esTokenDeleteOptions).then(() => {
-      // Create the k8s secret
-      console.log('Delete K8S secret');
-      requestPromise(k8sUrl, secretDeleteOptions).then().catch(err => {
+    // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
+    function requestPromise(url, options, payload) {
+      return new Promise((resolve, reject) => {
+        const request = https.request(url, options, response => {
+
+          console.log('statusCode:', response.statusCode);
+
+          // TODO: remove 404 and handle it during esToken deletion
+          const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
+
+          let data = '';
+          response.on('data', chunk => data += chunk); // accumulate data
+          response.once('end', () => isSuccess ? resolve(data) : reject(data));  // resolve promise here
+        });
+
+        request.once('error', err => {
+          // This won't log anything for e.g. an HTTP 404 or 500 response,
+          // since from HTTP's point-of-view we successfully received a
+          // response.
+          console.log(`${options.method} ${options.path} failed: `, err.message || err);
+          reject(err);  // if promise is not already resolved, then we can reject it here
+        });
+
+        if (payload) {
+          request.write(payload);
+        }
+        request.end();
+      });
+    }
+
+    function createEsToken() {
+      // Chaining requests
+      console.log('Cleaning previous token');
+      requestPromise(esUrl, esTokenDeleteOptions).then(() => {
+        console.log('Creating new token');
+        requestPromise(esUrl, esTokenCreateOptions).then(response => {
+          const body = JSON.parse(response);
+          const token = body.token.value
+
+          // Encode the token in base64
+          const base64Token = Buffer.from(token, 'utf8').toString('base64');
+
+          // Prepare the k8s secret
+          secretData = JSON.stringify({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+              "namespace": "{{ .Release.Namespace }}",
+              "name": "{{ template "kibana.fullname" . }}-es-token",
+            },
+            "type": "Opaque",
+            "data": {
+              "token": base64Token,
+            }
+          })
+
+          // Create the k8s secret
+          console.log('Creating K8S secret');
+          requestPromise(k8sPostSecretUrl, secretCreateOptions, secretData).then().catch(err => {
+            console.error(err)
+          });
+          return;
+        })
+      }).catch(err => {
+        console.error(err);
+      });
+    }
+
+    function cleanEsToken() {
+      // Chaining requests
+      console.log('Cleaning token');
+      requestPromise(esUrl, esTokenDeleteOptions).then(() => {
+        // Create the k8s secret
+        console.log('Delete K8S secret');
+        requestPromise(k8sDeleteSecretUrl, secretDeleteOptions).then().catch(err => {
           console.error(err)
         });
         return;
-      })
-    }).catch(err => {
-      console.error(err);
-    });
+      }).catch(err => {
+        console.error(err);
+      });
+    }
+
+    const command = process.argv[2];
+    switch (command) {
+      case 'create':
+        console.log('Creating a new Elasticsearch token for Kibana')
+        createEsToken();
+        break;
+      case 'clean':
+        console.log('Cleaning the Kibana Elasticsearch token')
+        cleanEsToken();
+        break;
+      default:
+        console.log('Unknown command');
+    }

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -160,12 +160,14 @@ data:
         console.log('Creating a new Elasticsearch token for Kibana')
         createEsToken().catch(err => {
           console.error(err);
+          process.exit(1);
         });
         break;
       case 'clean':
         console.log('Cleaning the Kibana Elasticsearch token')
         cleanEsToken().catch(err => {
           console.error(err);
+          process.exit(1);
         });
         break;
       default:

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -4,18 +4,131 @@ kind: ConfigMap
 metadata:
   name: {{ template "kibana.fullname" . }}-helm-scripts
   labels: {{ include "kibana.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    {{- if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 data:
-  kibana-entrypoint.sh: |
-    #!/bin/bash
-    set -euo pipefail
+  get-token.js: |
+    const https = require('https');
+    const fs = require('fs');
 
-    echo "export ELASTICSEARCH_SERVICEACCOUNTTOKEN=$({{ template "kibana.home_dir" . }}/node/bin/node {{ template "kibana.home_dir" . }}/helm-scripts/parse-token.js {{ template "kibana.home_dir" . }}/config/tokens/{{ template "kibana.fullname" . }}.json)" > $HOME/.elasticsearch-serviceaccounttoken
-    source $HOME/.elasticsearch-serviceaccounttoken
+    // Elasticsearch API
+    //TODO: remove hardcoded host
+    const esHostname = "elasticsearch-master";
+    const esPort = process.env.ELASTICSEARCH_MASTER_SERVICE_PORT;
+    const esPath = '_security/service/elastic/kibana/credential/token/kb-kibana';
+    const esUsername = process.env.ELASTICSEARCH_USERNAME;
+    const esPassword = process.env.ELASTICSEARCH_PASSWORD;
+    const esAuth = esUsername + ':' + esPassword;
+    const esCaFile = process.env.ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES;
+    const esCa = fs.readFileSync(esCaFile);
 
-    # https://github.com/elastic/dockerfiles/blob/a405a4d692031b72cefcb8523bd464aa3221ec47/kibana/Dockerfile#L131
-    exec /bin/tini -- /usr/local/bin/kibana-docker "$@"
+    // Kubernetes API
+    const k8sHostname = process.env.KUBERNETES_SERVICE_HOST;
+    const k8sPort = process.env.KUBERNETES_SERVICE_PORT_HTTPS;
+    const k8sPath = 'api/v1/namespaces/{{ .Release.Namespace }}/secrets';
+    const k8sBearer = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/token');
+    const k8sCa = fs.readFileSync('/run/secrets/kubernetes.io/serviceaccount/ca.crt');
 
-  parse-token.js: |
-    let dataFile = process.argv[2];
-    let dataContent = require(dataFile.toString());
-    console.log(dataContent.token.value);
+    // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
+    function requestPromise(options, payload) {
+      return new Promise((resolve, reject) => {
+        const request = https.request(options, response => {
+
+          console.log('statusCode:', response.statusCode);
+          console.log('headers:', response.headers);
+
+          // TODO: remove 404 and handle it during esToken deletion
+          const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
+
+          let data = '';
+          response.on('data', chunk => data += chunk); // accumulate data
+          response.once('end', () => isSuccess ? resolve(data) : reject(data));  // resolve promise here
+        });
+
+        request.once('error', err => {
+          // This won't log anything for e.g. an HTTP 404 or 500 response,
+          // since from HTTP's point-of-view we successfully received a
+          // response.
+          console.log(`${options.method} ${options.path} failed: `, err.message || err);
+          reject(err);  // if promise is not already resolved, then we can reject it here
+        });
+
+        if (payload) {
+          request.write(payload);
+        }
+        request.end();
+      });
+    }
+
+    // delete kb-kibana token
+    const esTokenDeleteOptions = {
+      hostname: esHostname,
+      port: esPort,
+      path: esPath,
+      method: 'DELETE',
+      auth: esAuth,
+      ca: esCa,
+    };
+
+    // create new kb-kibana token
+    const esTokenCreateOptions = {
+      hostname: esHostname,
+      port: esPort,
+      path: esPath,
+      method: 'POST',
+      auth: esAuth,
+      ca: esCa,
+    };
+
+    // create new k8s secret
+    const secretCreateOptions = {
+      hostname: k8sHostname,
+      port: k8sPort,
+      path: k8sPath,
+      method: 'POST',
+      ca: k8sCa,
+      headers: {
+        'Authorization': 'Bearer' + k8sBearer,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      }
+    };
+
+    // Chaining requests
+    requestPromise(esTokenDeleteOptions).then(() =>
+      requestPromise(esTokenCreateOptions).then(response => {
+        const body = JSON.parse(response);
+        const token = body.token.value
+        console.log('Token:', token);
+
+        // encode the token in base 64
+        const base64Token = Buffer.from(token, 'utf8').toString('base64')
+        console.log('Base64 Token:', base64Token);
+
+        // prepare the k8s secret
+        secretData = {
+          "apiVersion":"v1",
+          "kind" :"Secret",
+          "metadata" :{
+            "namespace" :"{{ .Release.Namespace }}",
+            "name":"{{ template "kibana.fullname" . }}-token"
+          },
+          "type": "Opaque",
+          "data": {
+            "token": base64Token,
+          }
+        }
+
+        // create the k8s secret
+        requestPromise(secretCreateOptions, secretData.toString())
+
+        return;
+      })
+    ).catch(err => {
+      console.error(err);
+    });

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -19,11 +19,10 @@ data:
 
     // Read environment variables
     function getEnvVar(name) {
-      if (name in process.env) {
-        return process.env[name]
-      } else {
+      if (!process.env[name]) {
         throw new Error(name + ' environment variable is missing')
       }
+      return process.env[name]
     }
 
     // Elasticsearch API

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -139,28 +139,18 @@ data:
 
           // Create the k8s secret
           console.log('Creating K8S secret');
-          requestPromise(k8sPostSecretUrl, secretCreateOptions, {payload: secretData}).then().catch(err => {
-            console.error(err)
-          });
-          return;
-        })
-      }).catch(err => {
-        console.error(err);
+          requestPromise(k8sPostSecretUrl, secretCreateOptions, {payload: secretData})
+        });
       });
     }
 
     function cleanEsToken() {
       // Chaining requests
       console.log('Cleaning token');
-      requestPromise(esUrl, esTokenDeleteOptions).then(() => {
+      return requestPromise(esUrl, esTokenDeleteOptions).then(() => {
         // Create the k8s secret
         console.log('Delete K8S secret');
-        requestPromise(k8sDeleteSecretUrl, secretDeleteOptions).then().catch(err => {
-          console.error(err)
-        });
-        return;
-      }).catch(err => {
-        console.error(err);
+        requestPromise(k8sDeleteSecretUrl, secretDeleteOptions)
       });
     }
 
@@ -168,11 +158,15 @@ data:
     switch (command) {
       case 'create':
         console.log('Creating a new Elasticsearch token for Kibana')
-        createEsToken();
+        createEsToken().catch(err => {
+          console.error(err);
+        });
         break;
       case 'clean':
         console.log('Cleaning the Kibana Elasticsearch token')
-        cleanEsToken();
+        cleanEsToken().catch(err => {
+          console.error(err);
+        });
         break;
       default:
         console.log('Unknown command');

--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -76,14 +76,19 @@ data:
     };
 
     // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
-    function requestPromise(url, options, payload) {
+    function requestPromise(url, httpsOptions, extraOptions = {}) {
       return new Promise((resolve, reject) => {
-        const request = https.request(url, options, response => {
+        const request = https.request(url, httpsOptions, response => {
 
           console.log('statusCode:', response.statusCode);
 
-          // TODO: remove 404 and handle it during esToken deletion
-          const isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == 404;
+          let isSuccess = undefined;
+
+          if (typeof(extraOptions.extraStatusCode) != "undefined" && extraOptions.extraStatusCode != null) {
+            isSuccess = response.statusCode >= 200 && response.statusCode < 300 || response.statusCode == extraOptions.extraStatusCode;
+          } else {
+            isSuccess = response.statusCode >= 200 && response.statusCode < 300;
+          }
 
           let data = '';
           response.on('data', chunk => data += chunk); // accumulate data
@@ -94,12 +99,12 @@ data:
           // This won't log anything for e.g. an HTTP 404 or 500 response,
           // since from HTTP's point-of-view we successfully received a
           // response.
-          console.log(`${options.method} ${options.path} failed: `, err.message || err);
+          console.log(`${httpsOptions.method} ${httpsOptions.path} failed: `, err.message || err);
           reject(err);  // if promise is not already resolved, then we can reject it here
         });
 
-        if (payload) {
-          request.write(payload);
+        if (typeof(extraOptions.payload) != "undefined") {
+          request.write(extraOptions.payload);
         }
         request.end();
       });
@@ -108,7 +113,8 @@ data:
     function createEsToken() {
       // Chaining requests
       console.log('Cleaning previous token');
-      requestPromise(esUrl, esTokenDeleteOptions).then(() => {
+      // 404 status code is accepted if there is no previous token to clean
+      return requestPromise(esUrl, esTokenDeleteOptions, {extraStatusCode: 404}).then(() => {
         console.log('Creating new token');
         requestPromise(esUrl, esTokenCreateOptions).then(response => {
           const body = JSON.parse(response);
@@ -133,7 +139,7 @@ data:
 
           // Create the k8s secret
           console.log('Creating K8S secret');
-          requestPromise(k8sPostSecretUrl, secretCreateOptions, secretData).then().catch(err => {
+          requestPromise(k8sPostSecretUrl, secretCreateOptions, {payload: secretData}).then().catch(err => {
             console.error(err)
           });
           return;

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -49,10 +49,6 @@ spec:
       volumes:
         - name: kibana-tokens
           emptyDir: {}
-        - name: kibana-helm-scripts
-          configMap:
-            name: {{ template "kibana.fullname" . }}-helm-scripts
-            defaultMode: 0755
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
@@ -86,31 +82,6 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
       initContainers:
-      - name: configure-kibana-token
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-        # TODO add retries
-        command:
-          - sh
-          - -c
-          - curl --output {{ template "kibana.home_dir" . }}/config/tokens/{{ template "kibana.fullname" . }}.json --fail -XPOST --cacert {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }} -u "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)" "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}?pretty"
-        env:
-          - name: "ELASTICSEARCH_USERNAME"
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.elasticsearchCredentialSecret }}
-                key: username
-          - name: "ELASTICSEARCH_PASSWORD"
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.elasticsearchCredentialSecret }}
-                key: password
-        volumeMounts:
-          - name: elasticsearch-certs
-            mountPath: {{ template "kibana.home_dir" . }}/config/certs
-            readOnly: true
-          - name: kibana-tokens
-            mountPath: {{ template "kibana.home_dir" . }}/config/tokens
       {{- if .Values.extraInitContainers }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
@@ -127,8 +98,6 @@ spec:
 {{ toYaml .Values.securityContext | indent 10 }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-        command: ["/bin/bash"]
-        args: ["-c","{{ template "kibana.home_dir" . }}/helm-scripts/kibana-entrypoint.sh"]
         env:
           {{- if .Values.elasticsearchURL }}
           - name: ELASTICSEARCH_URL
@@ -141,6 +110,12 @@ spec:
             value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
           - name: SERVER_HOST
             value: "{{ .Values.serverHost }}"
+          - name: ELASTICSEARCH_SERVICEACCOUNTTOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "kibana.fullname" . }}-es-token
+                key: token
+                optional: false
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}
 {{- end }}
@@ -194,8 +169,6 @@ spec:
           - name: kibana-tokens
             mountPath: {{ template "kibana.home_dir" . }}/config/tokens
             readOnly: true
-          - name: kibana-helm-scripts
-            mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
           {{- range .Values.secretMounts }}
           - name: {{ .name }}
             mountPath: {{ .path }}

--- a/kibana/templates/post-delete-job.yaml
+++ b/kibana/templates/post-delete-job.yaml
@@ -5,7 +5,6 @@ metadata:
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -20,14 +19,9 @@ spec:
         - name: clean-kibana-token
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-          command: ["curl"]
+          command: ["{{ template "kibana.home_dir" . }}/node/bin/node"]
           args:
-            - -XDELETE
-            - --cacert
-            - {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}
-            - -u
-            - "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)"
-            - "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}"
+           - {{ template "kibana.home_dir" . }}/helm-scripts/clean-token.js
           env:
             - name: "ELASTICSEARCH_USERNAME"
               valueFrom:
@@ -39,11 +33,20 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.elasticsearchCredentialSecret }}
                   key: password
+            - name: ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES
+              value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
           volumeMounts:
             - name: elasticsearch-certs
               mountPath: {{ template "kibana.home_dir" . }}/config/certs
               readOnly: true
+            - name: kibana-helm-scripts
+              mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
+      serviceAccount: pre-install-{{ template "kibana.fullname" . }}
       volumes:
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        - name: kibana-helm-scripts
+          configMap:
+            name: {{ template "kibana.fullname" . }}-helm-scripts
+            defaultMode: 0755

--- a/kibana/templates/post-delete-job.yaml
+++ b/kibana/templates/post-delete-job.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-delete-{{ template "kibana.fullname" . }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: clean-kibana-token
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+          command: ["curl"]
+          args:
+            - -XDELETE
+            - --cacert
+            - {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}
+            - -u
+            - "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)"
+            - "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}"
+          env:
+            - name: "ELASTICSEARCH_USERNAME"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.elasticsearchCredentialSecret }}
+                  key: username
+            - name: "ELASTICSEARCH_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.elasticsearchCredentialSecret }}
+                  key: password
+          volumeMounts:
+            - name: elasticsearch-certs
+              mountPath: {{ template "kibana.home_dir" . }}/config/certs
+              readOnly: true
+      volumes:
+        - name: elasticsearch-certs
+          secret:
+            secretName: {{ .Values.elasticsearchCertificateSecret }}

--- a/kibana/templates/post-delete-job.yaml
+++ b/kibana/templates/post-delete-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -21,7 +22,8 @@ spec:
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           command: ["{{ template "kibana.home_dir" . }}/node/bin/node"]
           args:
-           - {{ template "kibana.home_dir" . }}/helm-scripts/clean-token.js
+           - {{ template "kibana.home_dir" . }}/helm-scripts/manage-es-token.js
+           - clean
           env:
             - name: "ELASTICSEARCH_USERNAME"
               valueFrom:
@@ -41,7 +43,7 @@ spec:
               readOnly: true
             - name: kibana-helm-scripts
               mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
-      serviceAccount: pre-install-{{ template "kibana.fullname" . }}
+      serviceAccount: post-delete-{{ template "kibana.fullname" . }}
       volumes:
         - name: elasticsearch-certs
           secret:

--- a/kibana/templates/post-delete-role.yaml
+++ b/kibana/templates/post-delete-role.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: pre-install-{{ template "kibana.fullname" . }}
+  name: post-delete-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
@@ -17,5 +17,4 @@ rules:
     resources:
       - secrets
     verbs:
-      - create
-      - update
+      - delete

--- a/kibana/templates/post-delete-rolebinding.yaml
+++ b/kibana/templates/post-delete-rolebinding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: pre-install-{{ template "kibana.fullname" . }}
+  name: post-delete-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
@@ -13,9 +13,9 @@ metadata:
     {{- end }}
 subjects:
   - kind: ServiceAccount
-    name: pre-install-{{ template "kibana.fullname" . }}
+    name: post-delete-{{ template "kibana.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: Role
-  name: pre-install-{{ template "kibana.fullname" . }}
+  name: post-delete-{{ template "kibana.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/kibana/templates/post-delete-serviceaccount.yaml
+++ b/kibana/templates/post-delete-serviceaccount.yaml
@@ -1,21 +1,13 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: pre-install-{{ template "kibana.fullname" . }}
+  name: post-delete-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - update

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -1,11 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "kibana.fullname" . }}-post-delete
+  name: pre-install-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": pre-install
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -17,17 +16,15 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: clean-kibana-token
+        - name: create-kibana-token
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-          command: ["curl"]
+          command: ["{{ template "kibana.home_dir" . }}/node/bin/node"]
           args:
-            - -XDELETE
-            - --cacert
-            - {{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}
-            - -u
-            - "$(ELASTICSEARCH_USERNAME):$(ELASTICSEARCH_PASSWORD)"
-            - "{{ .Values.elasticsearchHosts }}/_security/service/elastic/kibana/credential/token/{{ template "kibana.fullname" . }}"
+            - {{ template "kibana.home_dir" . }}/helm-scripts/get-token.js
+          #command: ["sleep"]
+          #args:
+          #  - "600"
           env:
             - name: "ELASTICSEARCH_USERNAME"
               valueFrom:
@@ -39,11 +36,19 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.elasticsearchCredentialSecret }}
                   key: password
+            - name: ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES
+              value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
           volumeMounts:
             - name: elasticsearch-certs
               mountPath: {{ template "kibana.home_dir" . }}/config/certs
               readOnly: true
+            - name: kibana-helm-scripts
+              mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
       volumes:
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        - name: kibana-helm-scripts
+          configMap:
+            name: {{ template "kibana.fullname" . }}-helm-scripts
+            defaultMode: 0755

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
-  backoffLimit: 3
+  backoffLimit: 20
   template:
     spec:
       restartPolicy: Never

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -21,10 +21,7 @@ spec:
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           command: ["{{ template "kibana.home_dir" . }}/node/bin/node"]
           args:
-            - {{ template "kibana.home_dir" . }}/helm-scripts/get-token.js
-          #command: ["sleep"]
-          #args:
-          #  - "600"
+           - {{ template "kibana.home_dir" . }}/helm-scripts/get-token.js
           env:
             - name: "ELASTICSEARCH_USERNAME"
               valueFrom:
@@ -44,6 +41,7 @@ spec:
               readOnly: true
             - name: kibana-helm-scripts
               mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
+      serviceAccount: pre-install-{{ template "kibana.fullname" . }}
       volumes:
         - name: elasticsearch-certs
           secret:

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -24,7 +24,6 @@ spec:
           args:
            - {{ template "kibana.home_dir" . }}/helm-scripts/manage-es-token.js
            - create
-           - {{ template "kibana.home_dir" . }}/helm-scripts/get-token.js
           env:
             - name: "ELASTICSEARCH_USERNAME"
               valueFrom:

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -21,6 +22,8 @@ spec:
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           command: ["{{ template "kibana.home_dir" . }}/node/bin/node"]
           args:
+           - {{ template "kibana.home_dir" . }}/helm-scripts/manage-es-token.js
+           - create
            - {{ template "kibana.home_dir" . }}/helm-scripts/get-token.js
           env:
             - name: "ELASTICSEARCH_USERNAME"

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pre-install-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}

--- a/kibana/templates/pre-install-role.yaml
+++ b/kibana/templates/pre-install-role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pre-install-{{ template "kibana.fullname" . }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    {{- if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update

--- a/kibana/templates/pre-install-role.yaml
+++ b/kibana/templates/pre-install-role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pre-install-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}

--- a/kibana/templates/pre-install-rolebinding.yaml
+++ b/kibana/templates/pre-install-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pre-install-{{ template "kibana.fullname" . }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    {{- if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: pre-install-{{ template "kibana.fullname" . }}
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: pre-install-{{ template "kibana.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/kibana/templates/pre-install-rolebinding.yaml
+++ b/kibana/templates/pre-install-rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pre-install-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}

--- a/kibana/templates/pre-install-serviceaccount.yaml
+++ b/kibana/templates/pre-install-serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/kibana/templates/pre-install-serviceaccount.yaml
+++ b/kibana/templates/pre-install-serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pre-install-{{ template "kibana.fullname" . }}
+  labels: {{ include "kibana.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    {{- if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}

--- a/kibana/templates/pre-install-serviceaccount.yaml
+++ b/kibana/templates/pre-install-serviceaccount.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pre-install-{{ template "kibana.fullname" . }}
   labels: {{ include "kibana.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- if .Values.annotations }}
     {{- range $key, $value := .Values.annotations }}


### PR DESCRIPTION
This PR moves the Elasticsearch token for Kibana creation into Helm pre-install hooks and adds it to a K8S secret so it can be used by every pod of the Kibana Deployment.

The K8S secret and all linked resources are cleaned in post-delete hooks.

The call to Elasticsearch and K8S API to create the ES token and convert it to a secret are done in a Node JS script because the only language runtime available in the Kibana Docker image are Node and Bash, but `jq` command isn't available which exclude Bash script.

The Node JS script is also available in plain JS format to facilitate the review: https://gist.github.com/jmlrt/482b3d984588c1d3e10a84ce5fcd7b3b

Many thanks @pugnascotia for the help on this script 🙏🏻 

Follow-up of https://github.com/elastic/helm-charts/pull/1679
Replace https://github.com/elastic/helm-charts/pull/1715
Fixes https://github.com/elastic/helm-charts/issues/1714