### PR TITLE
feat(kibana): chart template add readiness probes fields

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -149,7 +149,26 @@ spec:
 {{ toYaml .Values.envFrom | indent 10 }}
 {{- end }}
         readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 10 }}
+{{- if .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+{{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.successThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+{{- end }}
+{{- if .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.httpGet }}
+          httpGet:
+{{ toYaml .Values.readinessProbe.httpGet | indent 12 }}
+{{- end }}
+{{- if and (empty .Values.readinessProbe.exec) (empty .Values.readinessProbe.httpGet) }}
           exec:
             command:
               - bash
@@ -179,6 +198,11 @@ spec:
                 }
 
                 http "{{ .Values.healthCheckPath }}"
+{{- end }}
+{{- if .Values.readinessProbe.exec }}
+          exec:
+{{ toYaml .Values.readinessProbe.exec | indent 12 }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.httpPort }}
 {{- if .Values.lifecycle }}

--- a/kibana/tests/kibana_test.py
+++ b/kibana/tests/kibana_test.py
@@ -850,3 +850,28 @@ def test_adding_annotations():
         r["deployment"][name]["metadata"]["annotations"]["iam.amazonaws.com/role"]
         == "es-role"
     )
+
+
+def test_httpget_readinessprobe():
+    config = """
+readinessProbe:
+   httpGet:
+     path: /app/kibana
+     port: 5601
+"""
+    r = helm_template(config)
+    httpGet = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]["readinessProbe"]
+    assert dict({'httpGet': {'path': '/app/kibana', 'port': 5601}}).items() <= httpGet.items()
+
+def test_exec_readinessprobe_custom():
+    config = """
+readinessProbe:
+   exec:
+     command:
+       - echo
+       - 'ok'
+"""
+    r = helm_template(config)
+    exec = r["deployment"][name]["spec"]["template"]["spec"]["containers"][0]["readinessProbe"]
+    assert dict({'exec': {'command': ['echo', 'ok']}}).items() <= exec.items()
+

--- a/kibana/values.yaml
+++ b/kibana/values.yaml
@@ -157,6 +157,10 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 3
   timeoutSeconds: 5
+# exec: {}
+# httpGet:
+#   path: /app/kibana
+#   port: 5601
 
 imagePullSecrets: []
 nodeSelector: {}


### PR DESCRIPTION
### Prerequisites
- [X] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [X] README.md updated with any new values or changes _(nothing to add)_
- [X] Updated template tests in `kibana/tests/*.py` 
- [ ] Updated integration tests in `kibana/examples/*/test/goss.yaml` _(nothing to add)_

### Tests added in `kibana/tests/*.py` 
````
tests/kibana_test.py::test_httpget_readinessprobe PASSED
tests/kibana_test.py::test_exec_readinessprobe_custom PASSED
```

### Description
