### PR TITLE
[7.17] [meta] overriding imageTag recommendation (#1723)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ work with the version of the product, you are installing.
 For example, if you want to deploy an Elasticsearch `7.7.1` cluster, use the
 corresponding `7.7.1` [tag][elasticsearch-771].
 
+However, we are not releasing new charts versions for each new patch version of
+the Elastic products, so if a chart for the latest patch version doesn't exist,
+you can use the latest chart with the same **MAJOR.MINOR** version and override
+the Docker image tag to the latest patch version with the `imageTag` value.
+
+For example, if you want to deploy an Elasticsearch `7.17.5` cluster, use the
+corresponding `7.17.3` [tag][elasticsearch-7173], with `imageTag=7.17.5` value.
+
 The `master` version of these charts is intended to support the latest
 pre-release versions of our products, and therefore may or may not work with
 current released versions.
@@ -65,10 +73,11 @@ Kubernetes. There is a dedicated Helm chart for ECK which can be found
 
 
 [currently tested]: https://devops-ci.elastic.co/job/elastic+helm-charts+7.17/
-[eck-chart]: https://github.com/elastic/cloud-on-k8s/tree/master/deploy
 [eck-chart-doc]: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html
+[eck-chart]: https://github.com/elastic/cloud-on-k8s/tree/master/deploy
 [elastic cloud on kubernetes]: https://github.com/elastic/cloud-on-k8s
 [elastic helm repo]: https://helm.elastic.co
+[elasticsearch-7173]: https://github.com/elastic/helm-charts/tree/7.17.3/elasticsearch/
 [elasticsearch-771]: https://github.com/elastic/helm-charts/tree/7.7.1/elasticsearch/
 [github releases]: https://github.com/elastic/helm-charts/releases
 [helm-tester Dockerfile]: https://github.com/elastic/helm-charts/blob/7.17/helpers/helm-tester/Dockerfile


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [meta] overriding imageTag recommendation (#1723)