### PR TITLE
set protocol to http

### DIFF
--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -187,7 +187,7 @@ podManagementPolicy: "Parallel"
 # If you experience slow pod startups you probably want to set this to `false`.
 enableServiceLinks: true
 
-protocol: https
+protocol: http
 httpPort: 9200
 transportPort: 9300
 


### PR DESCRIPTION
As per https://github.com/elastic/helm-charts/tree/main/elasticsearch#configuration , default value of protocol as http
Also, it clearly mentions "Change this to https if you have xpack.security.http.ssl.enabled"

`protocol`	`The protocol that will be used for the readiness probe. Change this to https if you have xpack.security.http.ssl.enabled`