### PR TITLE
Increase memory allocation in minikube example

### DIFF
--- a/elasticsearch/examples/minikube/values.yaml
+++ b/elasticsearch/examples/minikube/values.yaml
@@ -9,10 +9,10 @@ esJavaOpts: "-Xmx128m -Xms128m"
 resources:
   requests:
     cpu: "100m"
-    memory: "512M"
+    memory: "1028M"
   limits:
     cpu: "1000m"
-    memory: "512M"
+    memory: "1028M"
 
 # Request smaller persistent volumes.
 volumeClaimTemplate:


### PR DESCRIPTION
I noticed that deploying a simple playground ELK stack to minikube resulted in unexpected errors in Elasticsearch; see [this discussion](https://discuss.elastic.co/t/elasticsearch-pods-fail-unexpectedly-when-deploying-elastic-stack-through-helm-on-minikube/320194). Increasing the memory allocated to the Elasticsearch pods solved the issue. 
