### PR TITLE
Disable xpack.security.enabled if  is not enabled

### DIFF
--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -361,6 +361,9 @@ spec:
             value: "/usr/share/elasticsearch/config/certs/tls.crt"
           - name: xpack.security.http.ssl.certificate_authorities
             value: "/usr/share/elasticsearch/config/certs/ca.crt"
+          {{- else }}
+          - name: xpack.security.enabled
+            value: "false"
           {{- end }}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
