### PR TITLE
[APM-Server] Fix label deployment not match service pod selector

### DIFF
--- a/apm-server/templates/deployment.yaml
+++ b/apm-server/templates/deployment.yaml
@@ -14,12 +14,12 @@ spec:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   selector:
     matchLabels:
-      app: apm-server
+      app: {{ .Chart.Name }}
       release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        app: apm-server
+        app: {{ .Chart.Name }}
         release: {{ .Release.Name | quote }}
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
