### PR TITLE
[logstash] change labels template in service-headless

### DIFF
--- a/logstash/templates/service-headless.yaml
+++ b/logstash/templates/service-headless.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-{{- if .Values.labels }}
-{{ toYaml .Values.labels | indent 4 }}
-{{- end }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   clusterIP: None
   selector:


### PR DESCRIPTION
Changes to add labels as quotes. Same as https://github.com/elastic/helm-charts/blob/main/logstash/templates/statefulset.yaml#L11-L13

- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
