### PR TITLE
[elasticsearch] feat: Add *.svc.cluster.local in certificate alts

### DIFF
--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -37,7 +37,7 @@ tls.crt: {{ index $certs.data "tls.crt" }}
 tls.key: {{ index $certs.data "tls.key" }}
 ca.crt: {{ index $certs.data "ca.crt" }}
 {{- else -}}
-{{- $altNames := list ( include "elasticsearch.masterService" . ) ( printf "%s.%s" (include "elasticsearch.masterService" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "elasticsearch.masterService" .) .Release.Namespace ) -}}
+{{- $altNames := list ( include "elasticsearch.masterService" . ) ( printf "%s.%s" (include "elasticsearch.masterService" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "elasticsearch.masterService" .) .Release.Namespace ) ( printf "%s.%s.svc.cluster.local" (include "elasticsearch.masterService" .) .Release.Namespace ) -}}
 {{- $ca := genCA "elasticsearch-ca" 365 -}}
 {{- $cert := genSignedCert ( include "elasticsearch.masterService" . ) nil $altNames 365 $ca -}}
 tls.crt: {{ $cert.Cert | toString | b64enc }}


### PR DESCRIPTION
- [x] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py` 
- [x] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`

This PR adds support for adding *.svc.cluster.local DNS when generating new SSL certificates. 
This is also in the example on the elasic cloud on kubernetes doc: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-custom-http-certificate.html#k8s_custom_self_signed_certificate_using_cert_manager